### PR TITLE
CDC #39 - Typesense

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.8'
-gem 'core_data_connector', path: '../core-data-connector'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.9'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,19 @@
 GIT
+  remote: https://github.com/performant-software/core-data-connector.git
+  revision: b463034867fd7b1bb2a601c8ffd7f8f5f642c954
+  tag: v0.1.9
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rgeo-geojson (~> 2.1)
+      triple_eye_effable
+      typesense (~> 0.14)
+      user_defined_fields
+
+GIT
   remote: https://github.com/performant-software/jwt-auth.git
   revision: fa54af0cdcad6122fad10d9ad745b814c2918853
   tag: v0.1.2
@@ -34,19 +49,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rgeo-geojson (~> 2.1)
-      triple_eye_effable
-      typesense (~> 0.14)
-      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -239,7 +241,7 @@ GEM
     typesense (0.15.0)
       oj (~> 3.11)
       typhoeus (~> 1.4)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
This pull request updates the `core_data_connector` gem to the latest version to support indexing data into Typesense.

**Note:** This pull request has a dependent [PR](https://github.com/performant-software/core-data-connector/pull/16) in the `core-data-connector` repo.