### PR TITLE
CDC #29 - Create related records

### DIFF
--- a/client/src/components/OrganizationForm.js
+++ b/client/src/components/OrganizationForm.js
@@ -1,0 +1,70 @@
+// @flow
+
+import { BooleanIcon, EmbeddedList } from '@performant-software/semantic-components';
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Form, Header } from 'semantic-ui-react';
+import type { Organization as OrganizationType } from '../types/Organization';
+import OrganizationNameModal from './OrganizationNameModal';
+
+type Props = EditContainerProps & {
+  item: OrganizationType
+};
+
+const OrganizationForm = (props: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Header
+        content={t('OrganizationForm.labels.names')}
+      />
+      <EmbeddedList
+        actions={[{
+          name: 'edit'
+        }, {
+          name: 'delete'
+        }]}
+        addButton={{
+          basic: false,
+          color: 'blue',
+          location: 'top'
+        }}
+        columns={[{
+          name: 'name',
+          label: t('OrganizationForm.organizationNames.columns.name')
+        }, {
+          name: 'primary',
+          label: t('OrganizationForm.organizationNames.columns.primary'),
+          render: (organizationName) => <BooleanIcon value={organizationName.primary} />
+        }]}
+        items={props.item.organization_names}
+        modal={{
+          component: OrganizationNameModal
+        }}
+        onSave={props.onSaveChildAssociation.bind(this, 'organization_names')}
+        onDelete={props.onDeleteChildAssociation.bind(this, 'organization_names')}
+      />
+      <Form.TextArea
+        error={props.isError('description')}
+        label={t('OrganizationForm.labels.description')}
+        onChange={props.onTextInputChange.bind(this, 'description')}
+        required={props.isRequired('description')}
+        value={props.item.description}
+      />
+      <UserDefinedFieldsForm
+        data={props.item.user_defined}
+        defineableId={props.item.project_model_id}
+        defineableType='CoreDataConnector::ProjectModel'
+        isError={props.isError}
+        onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
+        onClearValidationError={props.onClearValidationError}
+        tableName='CoreDataConnector::Organization'
+      />
+    </>
+  );
+};
+
+export default OrganizationForm;

--- a/client/src/components/OrganizationModal.js
+++ b/client/src/components/OrganizationModal.js
@@ -1,0 +1,45 @@
+// @flow
+
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import React from 'react';
+import { Form, Modal } from 'semantic-ui-react';
+import { initializeRelated } from '../hooks/Relationship';
+import type { Organization as OrganizationType } from '../types/Organization';
+import OrganizationForm from './OrganizationForm';
+import { useTranslation } from 'react-i18next';
+
+type Props = EditContainerProps & {
+  item: OrganizationType
+};
+
+const OrganizationModal = (props: Props) => {
+  const { t } = useTranslation();
+
+  /**
+   * Sets the required foreign keys on the state.
+   */
+  initializeRelated(props);
+
+  return (
+    <Modal
+      as={Form}
+      centered={false}
+      noValidate
+      open
+    >
+      <Modal.Header
+        content={t('OrganizationModal.title')}
+      />
+      <Modal.Content
+        scrolling
+      >
+        <OrganizationForm
+          {...props}
+        />
+      </Modal.Content>
+      { props.children }
+    </Modal>
+  );
+};
+
+export default OrganizationModal;

--- a/client/src/components/OrganizationNameModal.js
+++ b/client/src/components/OrganizationNameModal.js
@@ -17,6 +17,7 @@ const OrganizationNameModal: AbstractComponent<any> = (props: Props) => {
     <Modal
       as={Form}
       centered={false}
+      noValidate
       open
     >
       <Modal.Header

--- a/client/src/components/PersonForm.js
+++ b/client/src/components/PersonForm.js
@@ -1,0 +1,74 @@
+// @flow
+
+import { BooleanIcon, EmbeddedList } from '@performant-software/semantic-components';
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Form, Header } from 'semantic-ui-react';
+import type { Person as PersonType } from '../types/Person';
+import PersonNameModal from './PersonNameModal';
+
+type Props = EditContainerProps & {
+  item: PersonType,
+  projectModelId: number
+};
+
+const PersonForm = (props: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Header
+        content={t('PersonForm.labels.names')}
+      />
+      <EmbeddedList
+        actions={[{
+          name: 'edit'
+        }, {
+          name: 'delete'
+        }]}
+        addButton={{
+          basic: false,
+          color: 'blue',
+          location: 'top'
+        }}
+        columns={[{
+          name: 'last_name',
+          label: t('PersonForm.personNames.columns.lastName')
+        }, {
+          name: 'first_name',
+          label: t('PersonForm.personNames.columns.firstName')
+        }, {
+          name: 'primary',
+          label: t('PersonForm.personNames.columns.primary'),
+          render: (personName) => <BooleanIcon value={personName.primary} />
+        }]}
+        items={props.item.person_names}
+        modal={{
+          component: PersonNameModal
+        }}
+        onSave={props.onSaveChildAssociation.bind(this, 'person_names')}
+        onDelete={props.onDeleteChildAssociation.bind(this, 'person_names')}
+      />
+      <Form.TextArea
+        error={props.isError('biography')}
+        label={t('PersonForm.labels.biography')}
+        onChange={props.onTextInputChange.bind(this, 'biography')}
+        required={props.isRequired('biography')}
+        value={props.item.biography}
+      />
+      <UserDefinedFieldsForm
+        data={props.item.user_defined}
+        defineableId={props.projectModelId}
+        defineableType='CoreDataConnector::ProjectModel'
+        isError={props.isError}
+        onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
+        onClearValidationError={props.onClearValidationError}
+        tableName='CoreDataConnector::Person'
+      />
+    </>
+  );
+};
+
+export default PersonForm;

--- a/client/src/components/PersonModal.js
+++ b/client/src/components/PersonModal.js
@@ -1,0 +1,45 @@
+// @flow
+
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Form, Modal } from 'semantic-ui-react';
+import { initializeRelated } from '../hooks/Relationship';
+import type { Person as PersonType } from '../types/Person';
+import PersonForm from './PersonForm';
+
+type Props = EditContainerProps & {
+  item: PersonType
+};
+
+const PersonModal = (props: Props) => {
+  const { t } = useTranslation();
+
+  /**
+   * Sets the required foreign keys on the state.
+   */
+  initializeRelated(props);
+
+  return (
+    <Modal
+      as={Form}
+      centered={false}
+      noValidate
+      open
+    >
+      <Modal.Header
+        content={t('PersonModal.title')}
+      />
+      <Modal.Content
+        scrolling
+      >
+        <PersonForm
+          {...props}
+        />
+      </Modal.Content>
+      { props.children }
+    </Modal>
+  );
+};
+
+export default PersonModal;

--- a/client/src/components/PersonNameModal.js
+++ b/client/src/components/PersonNameModal.js
@@ -17,6 +17,7 @@ const PersonNameModal: AbstractComponent<any> = (props: Props) => {
     <Modal
       as={Form}
       centered={false}
+      noValidate
       open
     >
       <Modal.Header

--- a/client/src/components/PlaceForm.js
+++ b/client/src/components/PlaceForm.js
@@ -1,0 +1,63 @@
+// @flow
+
+import { BooleanIcon, EmbeddedList } from '@performant-software/semantic-components';
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Header } from 'semantic-ui-react';
+import type { Place as PlaceType } from '../types/Place';
+import PlaceNameModal from './PlaceNameModal';
+
+type Props = EditContainerProps & {
+  item: PlaceType
+};
+
+const PlaceForm = (props: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Header
+        content={t('PlaceForm.labels.names')}
+      />
+      <EmbeddedList
+        actions={[{
+          name: 'edit'
+        }, {
+          name: 'delete'
+        }]}
+        addButton={{
+          basic: false,
+          color: 'blue',
+          location: 'top'
+        }}
+        columns={[{
+          name: 'name',
+          label: t('PlaceForm.placeNames.columns.name')
+        }, {
+          name: 'primary',
+          label: t('PlaceForm.placeNames.columns.primary'),
+          render: (placeName) => <BooleanIcon value={placeName.primary} />
+        }]}
+        items={props.item.place_names}
+        modal={{
+          component: PlaceNameModal
+        }}
+        onSave={props.onSaveChildAssociation.bind(this, 'place_names')}
+        onDelete={props.onDeleteChildAssociation.bind(this, 'place_names')}
+      />
+      <UserDefinedFieldsForm
+        data={props.item.user_defined}
+        defineableId={props.item.project_model_id}
+        defineableType='CoreDataConnector::ProjectModel'
+        isError={props.isError}
+        onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
+        onClearValidationError={props.onClearValidationError}
+        tableName='CoreDataConnector::Place'
+      />
+    </>
+  );
+};
+
+export default PlaceForm;

--- a/client/src/components/PlaceModal.js
+++ b/client/src/components/PlaceModal.js
@@ -1,0 +1,45 @@
+// @flow
+
+import type { EditContainerProps } from '@performant-software/shared-components/types';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Form, Modal } from 'semantic-ui-react';
+import { initializeRelated } from '../hooks/Relationship';
+import type { Place as PlaceType } from '../types/Place';
+import PlaceForm from './PlaceForm';
+
+type Props = EditContainerProps & {
+  item: PlaceType
+};
+
+const PlaceModal = (props: Props) => {
+  const { t } = useTranslation();
+
+  /**
+   * Sets the required foreign keys on the state.
+   */
+  initializeRelated(props);
+
+  return (
+    <Modal
+      as={Form}
+      centered={false}
+      noValidate
+      open
+    >
+      <Modal.Header
+        content={t('PlaceModal.title')}
+      />
+      <Modal.Content
+        scrolling
+      >
+        <PlaceForm
+          {...props}
+        />
+      </Modal.Content>
+      { props.children }
+    </Modal>
+  );
+};
+
+export default PlaceModal;

--- a/client/src/hooks/Item.js
+++ b/client/src/hooks/Item.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { useContext, useEffect } from 'react';
+import CurrentRecordContext from '../context/CurrentRecord';
+import useParams from './ParsedParams';
+
+const initialize = ({ item, onSetState }) => {
+  const { setCurrentRecord } = useContext(CurrentRecordContext);
+  const { projectModelId } = useParams();
+
+  /**
+   * Sets the project model ID on the state from the route parameters.
+   */
+  useEffect(() => {
+    if (onSetState && !item.id) {
+      onSetState({ project_model_id: projectModelId });
+    }
+  }, [projectModelId, item.id]);
+
+  /**
+   * Sets the current record on the context.
+   */
+  useEffect(() => setCurrentRecord(item), [item]);
+};
+
+export default initialize;

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -74,7 +74,7 @@
   "MediaContentsSelectize": {
     "title": "Select Media"
   },
-  "Organization": {
+  "OrganizationForm": {
     "labels": {
       "description": "Description",
       "names": "Names"
@@ -86,10 +86,17 @@
       }
     }
   },
+  "OrganizationModal": {
+    "title": "Add Organization"
+  },
   "OrganizationNameModal": {
     "labels": {
       "name": "Name",
       "primary": "Primary"
+    },
+    "title": {
+      "add": "Add Organization Name",
+      "edit": "Edit Organization Name"
     }
   },
   "Organizations": {
@@ -104,7 +111,7 @@
       "project": "Project"
     }
   },
-  "Person": {
+  "PersonForm": {
     "labels": {
       "biography": "Biography",
       "names": "Names"
@@ -116,6 +123,9 @@
         "primary": "Primary"
       }
     }
+  },
+  "PersonModal": {
+    "title": "Add Person"
   },
   "PersonNameModal": {
     "labels": {
@@ -132,7 +142,9 @@
   "Place": {
     "buttons": {
       "upload": "Upload"
-    },
+    }
+  },
+  "PlaceForm": {
     "labels": {
       "names": "Names"
     },
@@ -143,10 +155,17 @@
       }
     }
   },
+  "PlaceModal": {
+    "title": "Add Place"
+  },
   "PlaceNameModal": {
     "labels": {
       "name": "Name",
       "primary": "Primary"
+    },
+    "title": {
+      "add": "Add Place Name",
+      "edit": "Edit Place Name"
     }
   },
   "Places": {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -44,7 +44,22 @@ textarea {
   border-bottom: 1px solid rgba(34, 36, 38, 0.1);
 }
 
-.dropdown-button.ui.buttons>.ui.dropdown:last-child .menu.right {
+.dropdown-button.ui.buttons > .ui.dropdown:last-child .menu.right {
   left: 0;
   right: auto;
+}
+
+.association-dropdown > .ui.buttons > .ui.basic.button:hover {
+  background: unset !important;
+}
+
+.ui.modals > .ui.modal > .actions,
+.ui.modals > .ui.modal > .content,
+.ui.modals > .ui.modal > .header {
+  background-color: #f6f6f6;
+  box-shadow: rgba(0, 0, 0, 0.05) 0px 6px 24px 0px, rgba(0, 0, 0, 0.08) 0px 0px 0px 1px;
+}
+
+.embedded-list {
+  margin-bottom: 1em;
 }

--- a/client/src/pages/MediaContent.js
+++ b/client/src/pages/MediaContent.js
@@ -4,38 +4,28 @@ import { LazyIIIF, SimpleEditPage } from '@performant-software/semantic-componen
 import { IIIF as IIIFUtils } from '@performant-software/shared-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
-import React, { useContext, useEffect, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useMemo } from 'react';
 import { Form } from 'semantic-ui-react';
-import CurrentRecord from '../context/CurrentRecord';
+import initialize from '../hooks/Item';
 import type { MediaContent as MediaContentType } from '../types/MediaContent';
 import MediaContentsService from '../services/MediaContents';
 import Validation from '../utils/Validation';
-import useParams from '../hooks/ParsedParams';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
+import useParams from '../hooks/ParsedParams';
+import { useTranslation } from 'react-i18next';
 
 type Props = EditContainerProps & {
   item: MediaContentType
 };
 
-const MediaContentForm = (props: Props) => {
-  const { setCurrentRecord } = useContext(CurrentRecord);
+const MediaContentPage = (props: Props) => {
   const { projectModelId } = useParams();
   const { t } = useTranslation();
 
   /**
-   * Sets the project model ID on the state from the route parameters.
+   * Sets the required foreign keys on the state.
    */
-  useEffect(() => {
-    if (!props.item.id) {
-      props.onSetState({ project_model_id: projectModelId });
-    }
-  }, [projectModelId, props.item.id]);
-
-  /**
-   * Sets the current record on the context.
-   */
-  useEffect(() => setCurrentRecord(props.item), [props.item]);
+  initialize(props);
 
   /**
    * Sets the manifest URL.
@@ -49,8 +39,7 @@ const MediaContentForm = (props: Props) => {
       {...props}
     >
       <SimpleEditPage.Tab
-        key='details'
-        name={t('Common.tabs.details')}
+        key='default'
       >
         <Form.Input
           label={t('MediaContent.labels.content')}
@@ -89,7 +78,7 @@ const MediaContentForm = (props: Props) => {
   );
 };
 
-const MediaContent = withReactRouterEditPage(MediaContentForm, {
+const MediaContent = withReactRouterEditPage(MediaContentPage, {
   id: 'itemId',
   onInitialize: (id) => (
     MediaContentsService

--- a/client/src/pages/Organization.js
+++ b/client/src/pages/Organization.js
@@ -1,21 +1,12 @@
 // @flow
 
-import {
-  BooleanIcon,
-  EmbeddedList,
-  SimpleEditPage
-} from '@performant-software/semantic-components';
+import { SimpleEditPage } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
-import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
-import React, { type AbstractComponent, useContext, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Form, Header } from 'semantic-ui-react';
-import CurrentRecordContext from '../context/CurrentRecord';
+import React, { type AbstractComponent } from 'react';
+import initialize from '../hooks/Item';
 import type { Organization as OrganizationType } from '../types/Organization';
-import OrganizationNameModal from '../components/OrganizationNameModal';
+import OrganizationForm from '../components/OrganizationForm';
 import OrganizationService from '../services/Organizations';
-import styles from './Organization.module.css';
-import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
@@ -23,85 +14,28 @@ type Props = EditContainerProps & {
   item: OrganizationType
 };
 
-const OrganizationForm = (props: Props) => {
-  const { setCurrentRecord } = useContext(CurrentRecordContext);
-  const { projectModelId } = useParams();
-  const { t } = useTranslation();
-
+const OrganizationPage = (props: Props) => {
   /**
-   * Sets the project model ID on the state from the route parameters.
+   * Sets the required foreign keys on the state.
    */
-  useEffect(() => {
-    if (!props.item.id) {
-      props.onSetState({ project_model_id: projectModelId });
-    }
-  }, [projectModelId, props.item.id]);
-
-  /**
-   * Sets the current record on the context.
-   */
-  useEffect(() => setCurrentRecord(props.item), [props.item]);
+  initialize(props);
 
   return (
     <SimpleEditPage
       {...props}
-      className={styles.organization}
     >
       <SimpleEditPage.Tab
         key='default'
       >
-        <Header
-          content={t('Organization.labels.names')}
-        />
-        <EmbeddedList
-          actions={[{
-            name: 'edit'
-          }, {
-            name: 'delete'
-          }]}
-          addButton={{
-            basic: false,
-            color: 'blue',
-            location: 'top'
-          }}
-          className={styles.organizationNames}
-          columns={[{
-            name: 'name',
-            label: t('Organization.organizationNames.columns.name')
-          }, {
-            name: 'primary',
-            label: t('Organization.organizationNames.columns.primary'),
-            render: (organizationName) => <BooleanIcon value={organizationName.primary} />
-          }]}
-          items={props.item.organization_names}
-          modal={{
-            component: OrganizationNameModal
-          }}
-          onSave={props.onSaveChildAssociation.bind(this, 'organization_names')}
-          onDelete={props.onDeleteChildAssociation.bind(this, 'organization_names')}
-        />
-        <Form.TextArea
-          error={props.isError('description')}
-          label={t('Organization.labels.description')}
-          onChange={props.onTextInputChange.bind(this, 'description')}
-          required={props.isRequired('description')}
-          value={props.item.description}
-        />
-        <UserDefinedFieldsForm
-          data={props.item.user_defined}
-          defineableId={projectModelId}
-          defineableType='CoreDataConnector::ProjectModel'
-          isError={props.isError}
-          onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
-          onClearValidationError={props.onClearValidationError}
-          tableName='CoreDataConnector::Organization'
+        <OrganizationForm
+          {...props}
         />
       </SimpleEditPage.Tab>
     </SimpleEditPage>
   );
 };
 
-const Organization: AbstractComponent<any> = withReactRouterEditPage(OrganizationForm, {
+const Organization: AbstractComponent<any> = withReactRouterEditPage(OrganizationPage, {
   id: 'itemId',
   onInitialize: (id) => (
     OrganizationService

--- a/client/src/pages/Organization.module.css
+++ b/client/src/pages/Organization.module.css
@@ -1,3 +1,0 @@
-.organization .organizationNames {
-  margin-bottom: 1em;
-}

--- a/client/src/pages/Person.js
+++ b/client/src/pages/Person.js
@@ -1,21 +1,12 @@
 // @flow
 
-import {
-  BooleanIcon,
-  EmbeddedList,
-  SimpleEditPage
-} from '@performant-software/semantic-components';
+import { SimpleEditPage } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
-import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
-import React, { type AbstractComponent, useContext, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Form, Header } from 'semantic-ui-react';
-import CurrentRecordContext from '../context/CurrentRecord';
+import React, { type AbstractComponent } from 'react';
+import initialize from '../hooks/Item';
 import PeopleService from '../services/People';
 import type { Person as PersonType } from '../types/Place';
-import PersonNameModal from '../components/PersonNameModal';
-import styles from './Person.module.css';
-import useParams from '../hooks/ParsedParams';
+import PersonForm from '../components/PersonForm';
 import Validation from '../utils/Validation';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
@@ -23,88 +14,28 @@ type Props = EditContainerProps & {
   item: PersonType
 };
 
-const PlaceForm = (props: Props) => {
-  const { setCurrentRecord } = useContext(CurrentRecordContext);
-  const { projectModelId } = useParams();
-  const { t } = useTranslation();
-
+const PersonPage = (props: Props) => {
   /**
-   * Sets the project model ID on the state from the route parameters.
+   * Sets the required foreign keys on the state.
    */
-  useEffect(() => {
-    if (!props.item.id) {
-      props.onSetState({ project_model_id: projectModelId });
-    }
-  }, [projectModelId, props.item.id]);
-
-  /**
-   * Sets the current record on the context.
-   */
-  useEffect(() => setCurrentRecord(props.item), [props.item]);
+  initialize(props);
 
   return (
     <SimpleEditPage
       {...props}
-      className={styles.person}
     >
       <SimpleEditPage.Tab
         key='default'
       >
-        <Header
-          content={t('Person.labels.names')}
-        />
-        <EmbeddedList
-          actions={[{
-            name: 'edit'
-          }, {
-            name: 'delete'
-          }]}
-          addButton={{
-            basic: false,
-            color: 'blue',
-            location: 'top'
-          }}
-          className={styles.names}
-          columns={[{
-            name: 'last_name',
-            label: t('Person.personNames.columns.lastName')
-          }, {
-            name: 'first_name',
-            label: t('Person.personNames.columns.firstName')
-          }, {
-            name: 'primary',
-            label: t('Person.personNames.columns.primary'),
-            render: (personName) => <BooleanIcon value={personName.primary} />
-          }]}
-          items={props.item.person_names}
-          modal={{
-            component: PersonNameModal
-          }}
-          onSave={props.onSaveChildAssociation.bind(this, 'person_names')}
-          onDelete={props.onDeleteChildAssociation.bind(this, 'person_names')}
-        />
-        <Form.TextArea
-          error={props.isError('biography')}
-          label={t('Person.labels.biography')}
-          onChange={props.onTextInputChange.bind(this, 'biography')}
-          required={props.isRequired('biography')}
-          value={props.item.biography}
-        />
-        <UserDefinedFieldsForm
-          data={props.item.user_defined}
-          defineableId={projectModelId}
-          defineableType='CoreDataConnector::ProjectModel'
-          isError={props.isError}
-          onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
-          onClearValidationError={props.onClearValidationError}
-          tableName='CoreDataConnector::Person'
+        <PersonForm
+          {...props}
         />
       </SimpleEditPage.Tab>
     </SimpleEditPage>
   );
 };
 
-const Person: AbstractComponent<any> = withReactRouterEditPage(PlaceForm, {
+const Person: AbstractComponent<any> = withReactRouterEditPage(PersonPage, {
   id: 'itemId',
   onInitialize: (id) => (
     PeopleService

--- a/client/src/pages/Person.module.css
+++ b/client/src/pages/Person.module.css
@@ -1,3 +1,0 @@
-.person .names {
-  margin-bottom: 1em;
-}

--- a/client/src/pages/Place.js
+++ b/client/src/pages/Place.js
@@ -1,29 +1,16 @@
 // @flow
 
 import { MapDraw } from '@performant-software/geospatial';
-import {
-  BooleanIcon,
-  EmbeddedList,
-  FileInputButton,
-  SimpleEditPage
-} from '@performant-software/semantic-components';
+import { FileInputButton, SimpleEditPage } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
-import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
 import cx from 'classnames';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  type AbstractComponent
-} from 'react';
+import React, { useCallback, type AbstractComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Header } from 'semantic-ui-react';
-import CurrentRecordContext from '../context/CurrentRecord';
+import initialize from '../hooks/Item';
 import type { Place as PlaceType } from '../types/Place';
-import PlaceNameModal from '../components/PlaceNameModal';
+import PlaceForm from '../components/PlaceForm';
 import PlacesService from '../services/Places';
 import styles from './Place.module.css';
-import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
@@ -31,24 +18,13 @@ type Props = EditContainerProps & {
   item: PlaceType
 };
 
-const PlaceForm = (props: Props) => {
-  const { setCurrentRecord } = useContext(CurrentRecordContext);
-  const { projectModelId } = useParams();
+const PlacePage = (props: Props) => {
   const { t } = useTranslation();
 
   /**
-   * Sets the project model ID on the state from the route parameters.
+   * Set the required foreign keys on the state.
    */
-  useEffect(() => {
-    if (!props.item.id) {
-      props.onSetState({ project_model_id: projectModelId });
-    }
-  }, [projectModelId, props.item.id]);
-
-  /**
-   * Sets the current record on the context.
-   */
-  useEffect(() => setCurrentRecord(props.item), [props.item]);
+  initialize(props);
 
   /**
    * Sets the uploaded file as the GeoJSON object.
@@ -84,50 +60,15 @@ const PlaceForm = (props: Props) => {
             marginBottom: '4em'
           }}
         />
-        <Header
-          content={t('Place.labels.names')}
-        />
-        <EmbeddedList
-          actions={[{
-            name: 'edit'
-          }, {
-            name: 'delete'
-          }]}
-          addButton={{
-            basic: false,
-            color: 'blue',
-            location: 'top'
-          }}
-          columns={[{
-            name: 'name',
-            label: t('Place.placeNames.columns.name')
-          }, {
-            name: 'primary',
-            label: t('Place.placeNames.columns.primary'),
-            render: (placeName) => <BooleanIcon value={placeName.primary} />
-          }]}
-          items={props.item.place_names}
-          modal={{
-            component: PlaceNameModal
-          }}
-          onSave={props.onSaveChildAssociation.bind(this, 'place_names')}
-          onDelete={props.onDeleteChildAssociation.bind(this, 'place_names')}
-        />
-        <UserDefinedFieldsForm
-          data={props.item.user_defined}
-          defineableId={projectModelId}
-          defineableType='CoreDataConnector::ProjectModel'
-          isError={props.isError}
-          onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
-          onClearValidationError={props.onClearValidationError}
-          tableName='CoreDataConnector::Place'
+        <PlaceForm
+          {...props}
         />
       </SimpleEditPage.Tab>
     </SimpleEditPage>
   );
 };
 
-const Place: AbstractComponent<any> = withReactRouterEditPage(PlaceForm, {
+const Place: AbstractComponent<any> = withReactRouterEditPage(PlacePage, {
   id: 'itemId',
   onInitialize: (id) => (
     PlacesService

--- a/client/src/pages/RelatedMediaContent.js
+++ b/client/src/pages/RelatedMediaContent.js
@@ -4,14 +4,14 @@ import { LazyIIIF, SimpleEditPage } from '@performant-software/semantic-componen
 import { IIIF as IIIFUtils } from '@performant-software/shared-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Button, Header } from 'semantic-ui-react';
+import { initialize, useRelationship, withRelationshipEditPage } from '../hooks/Relationship';
 import type { Relationship as RelationshipType } from '../types/Relationship';
 import styles from './RelatedMediaContent.module.css';
 import useParams from '../hooks/ParsedParams';
-import { useRelationship, withRelationshipEditPage } from '../hooks/Relationship';
 import useProjectModelRelationship from '../hooks/ProjectModelRelationship';
 
 type Props = EditContainerProps & {
@@ -21,7 +21,7 @@ type Props = EditContainerProps & {
 const RelatedMediaContentForm = (props: Props) => {
   const { projectModelRelationshipId } = useParams();
   const { projectModelRelationship } = useProjectModelRelationship();
-  const { foreignObject, onNewRecord } = useRelationship(props);
+  const { foreignObject } = useRelationship(props);
   const { t } = useTranslation();
 
   /**
@@ -32,9 +32,9 @@ const RelatedMediaContentForm = (props: Props) => {
   const manifest = useMemo(() => (IIIFUtils.createManifestURL(foreignObject?.manifest)), [foreignObject?.manifest]);
 
   /**
-   * For a new record, set the foreign keys.
+   * Sets the required foreign keys on the state.
    */
-  useEffect(() => onNewRecord(), []);
+  initialize(props);
 
   return (
     <SimpleEditPage

--- a/client/src/transforms/PlaceGeometry.js
+++ b/client/src/transforms/PlaceGeometry.js
@@ -42,7 +42,7 @@ class PlaceGeometry extends BaseTransform {
     return {
       [this.getParameterName()]: {
         ..._.pick(placeGeometry, this.getPayloadKeys()),
-        geometry_json: JSON.stringify(placeGeometry.geometry_json)
+        geometry_json: JSON.stringify(placeGeometry?.geometry_json)
       }
     };
   }


### PR DESCRIPTION
This pull request implements the ability to related records without leaving the edit page of a primary record. For example, if I'm adding a `person` record for "Paul Revere", I can create a `place` record for "Boston, MA" from within the edit page for "Paul Revere". This will be the case for all primary model types: Organizations, Places, People.

Note: This list purposely does not include Media, as those records are handled a little differently.

## Dropdown
The related record dropdown component will now contain an "Add" button to facilitate creating new records.

![Screenshot 2023-11-20 at 6 59 02 AM](https://github.com/performant-software/core-data-cloud/assets/20641961/4abc091f-13b8-4413-a0df-30ad2a4aaca4)

## Modal
The related record information will be entered in a modal.

![Screenshot 2023-11-20 at 6 59 28 AM](https://github.com/performant-software/core-data-cloud/assets/20641961/558f5666-c72a-4d31-8527-6dd81a2f5e07)

## Save
Upon saving the modal, the new record is persisted.

![Screenshot 2023-11-20 at 6 59 40 AM](https://github.com/performant-software/core-data-cloud/assets/20641961/566a7198-5707-4d72-9c24-0fcbcd2750d5)
![Screenshot 2023-11-20 at 6 59 49 AM](https://github.com/performant-software/core-data-cloud/assets/20641961/45d964cb-bd13-4056-a372-8cf508ff632c)
