### PR TITLE
Source imports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.19'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.20'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: e3dc3b7d5eaadd49012b675195c3d53ac5b83f3e
-  tag: v0.1.19
+  revision: 00657a0bbfc8fc600bdf099d5d2c5e41bf52fe33
+  tag: v0.1.20
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/db/migrate/20240108144116_add_z_instance_id_to_core_data_connector_instances.core_data_connector.rb
+++ b/db/migrate/20240108144116_add_z_instance_id_to_core_data_connector_instances.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240108143923)
+class AddZInstanceIdToCoreDataConnectorInstances < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_instances, :z_instance_id, :integer
+  end
+end

--- a/db/migrate/20240108144117_add_z_item_id_to_core_data_connector_items.core_data_connector.rb
+++ b/db/migrate/20240108144117_add_z_item_id_to_core_data_connector_items.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240108143938)
+class AddZItemIdToCoreDataConnectorItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_items, :z_item_id, :integer
+  end
+end

--- a/db/migrate/20240108144118_add_z_work_id_to_core_data_connector_works.core_data_connector.rb
+++ b/db/migrate/20240108144118_add_z_work_id_to_core_data_connector_works.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240108143947)
+class AddZWorkIdToCoreDataConnectorWorks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_works, :z_work_id, :integer
+  end
+end

--- a/db/migrate/20240108195038_add_z_source_fields_to_names.core_data_connector.rb
+++ b/db/migrate/20240108195038_add_z_source_fields_to_names.core_data_connector.rb
@@ -1,0 +1,7 @@
+# This migration comes from core_data_connector (originally 20240108194908)
+class AddZSourceFieldsToNames < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_names, :z_source_id, :integer
+    add_column :core_data_connector_names, :z_source_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_12_111940) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_08_195038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_111940) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
+    t.integer "z_instance_id"
     t.index ["project_model_id"], name: "index_core_data_connector_instances_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_instances_on_user_defined", using: :gin
   end
@@ -32,6 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_111940) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
+    t.integer "z_item_id"
     t.index ["project_model_id"], name: "index_core_data_connector_items_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_items_on_user_defined", using: :gin
   end
@@ -51,6 +53,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_111940) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "z_source_id"
+    t.string "z_source_type"
   end
 
   create_table "core_data_connector_organization_names", force: :cascade do |t|
@@ -237,6 +241,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_111940) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
+    t.integer "z_work_id"
     t.index ["project_model_id"], name: "index_core_data_connector_works_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_works_on_user_defined", using: :gin
   end


### PR DESCRIPTION
# Summary

- adds the new database migrations from https://github.com/performant-software/core-data-connector/pull/37
- updates the Gemfile to point to the new Core Data Connector release