### PR TITLE
Upgrade gem for taxonomy imports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.23'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.24'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 9c26444e0887fcab18f3d961d44d4742e22149a4
-  tag: v0.1.23
+  revision: 5cb3a712ccd7258649e6e31295a4400d46fac2bf
+  tag: v0.1.24
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/db/migrate/20240118173700_add_z_taxonomy_id_to_taxonomies.core_data_connector.rb
+++ b/db/migrate/20240118173700_add_z_taxonomy_id_to_taxonomies.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240117215342)
+class AddZTaxonomyIdToTaxonomies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_taxonomies, :z_taxonomy_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_08_195038) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_18_173700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -141,11 +141,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_195038) do
   create_table "core_data_connector_project_model_relationships", force: :cascade do |t|
     t.bigint "primary_model_id", null: false
     t.bigint "related_model_id", null: false
+    t.string "name"
+    t.boolean "multiple"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
-    t.boolean "multiple"
-    t.string "name"
     t.boolean "allow_inverse", default: false, null: false
     t.string "inverse_name"
     t.boolean "inverse_multiple", default: false
@@ -213,6 +213,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_195038) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "z_taxonomy_id"
     t.index ["project_model_id"], name: "index_core_data_connector_taxonomies_on_project_model_id"
   end
 


### PR DESCRIPTION
# Summary

- upgrades to version 0.1.24 of `core-data-connector`
- installs the new migration to add the `z_taxonomy_id` column for taxonomy imports