### PR TITLE
Add Bibliothèque nationale de France to the Authorities options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.27'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.28'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: bb352394f305e719592c7d925a9b2c8f5030c245
-  tag: v0.1.27
+  revision: 94e693a718f4dd07bf034c3e926aaafb20d8fbe8
+  tag: v0.1.28
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)
@@ -11,6 +11,7 @@ GIT
       rack-cors (~> 2.0.1)
       rails (>= 6.0.3.2, < 8)
       resource_api
+      rexml (~> 3.2)
       rgeo-geojson (~> 2.1)
       rubyzip (~> 2.3.2)
       triple_eye_effable
@@ -237,6 +238,7 @@ GEM
     rake (13.0.6)
     reline (0.3.8)
       io-console (~> 0.5)
+    rexml (3.2.6)
     rgeo (3.0.1)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)

--- a/client/src/components/BnfIdentifierForm.js
+++ b/client/src/components/BnfIdentifierForm.js
@@ -1,0 +1,45 @@
+// @flow
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Form, Header } from 'semantic-ui-react';
+import WebIdentifierDropdown from './WebIdentifierDropdown';
+
+type Props = {
+  authorityId: number,
+  error?: boolean,
+  onSelection: (identifier: ?string | ?number) => void,
+  value: string | number
+};
+
+const BnfIdentifierForm = (props: Props) => {
+  const [selectedItem, setSelectedItem] = useState();
+  const { t } = useTranslation();
+
+  return (
+    <Form.Input
+      error={props.error}
+      label={t('Common.labels.identifier')}
+    >
+      <WebIdentifierDropdown
+        authorityId={props.authorityId}
+        id='recordIdentifier'
+        onLoad={({ data }) => setSelectedItem(data?.searchRetrieveResponse?.records?.record)}
+        onSelection={(identifier) => props.onSelection(identifier)}
+        onSearch={(data) => data?.searchRetrieveResponse?.records?.record}
+        renderOption={(item) => (
+          <Header
+            content={item?.recordData?.dc?.title}
+            key={item.id}
+            size='small'
+            subheader={item?.recordData?.dc?.contributor}
+          />
+        )}
+        text={selectedItem?.recordData?.dc?.title}
+        value={props.value}
+      />
+    </Form.Input>
+  );
+};
+
+export default BnfIdentifierForm;

--- a/client/src/components/RelatedIdentifierModal.js
+++ b/client/src/components/RelatedIdentifierModal.js
@@ -6,6 +6,7 @@ import React, { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Modal } from 'semantic-ui-react';
 import AtomIdentifierForm from './AtomIdentifierForm';
+import BnfIdentifierForm from './BnfIdentifierForm';
 import ProjectContext from '../context/Project';
 import useParams from '../hooks/ParsedParams';
 import WebAuthoritiesService from '../services/WebAuthorities';
@@ -84,6 +85,14 @@ const RelatedIdentifierModal = (props: Props) => {
               }
             })}
             onSelection={(identifier) => props.onSetState({ identifier, extra: {} })}
+            value={props.item.identifier}
+          />
+        )}
+        { props.item.web_authority?.source_type === WebAuthorityUtils.SourceTypes.bnf && (
+          <BnfIdentifierForm
+            authorityId={props.item.web_authority_id}
+            error={props.isError('identifier')}
+            onSelection={(identifier) => props.onSetState({ identifier })}
             value={props.item.identifier}
           />
         )}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -619,6 +619,7 @@
     },
     "labels": {
       "atom": "AtoM",
+      "bnf": "BnF",
       "wikidata": "Wikidata"
     }
   },

--- a/client/src/utils/WebAuthorities.js
+++ b/client/src/utils/WebAuthorities.js
@@ -9,11 +9,13 @@ const ERROR_KEY_URL = 'access.url';
 
 const SourceTypes = {
   atom: 'atom',
+  bnf: 'bnf',
   wikidata: 'wikidata'
 };
 
 const SourceTypeLabels = {
   [SourceTypes.atom]: i18n.t('WebAuthorities.labels.atom'),
+  [SourceTypes.bnf]: i18n.t('WebAuthorities.labels.bnf'),
   [SourceTypes.wikidata]: i18n.t('WebAuthorities.labels.wikidata')
 };
 

--- a/client/src/utils/WebIdentifiers.js
+++ b/client/src/utils/WebIdentifiers.js
@@ -3,6 +3,7 @@
 import WebAuthorityUtils from './WebAuthorities';
 
 const WIKIDATA_BASE_URL = 'https://www.wikidata.org/wiki';
+const BNF_BASE_URL = 'https://catalogue.bnf.fr';
 
 /**
  * Returns the webpage URL for the passed web identifier.
@@ -18,6 +19,8 @@ const getURL = (identifier) => {
 
   if (authority.source_type === WebAuthorityUtils.SourceTypes.atom) {
     url = `${authority.access.url}/${identifier.identifier}`;
+  } else if (authority.source_type === WebAuthorityUtils.SourceTypes.bnf) {
+    url = `${BNF_BASE_URL}/${identifier.identifier}`;
   } else if (authority.source_type === WebAuthorityUtils.SourceTypes.wikidata) {
     url = `${WIKIDATA_BASE_URL}/${identifier.identifier}`;
   }


### PR DESCRIPTION
# Summary

- adds the required frontend logic for BnF to appear in the authorities list, including the `BnfIdentifierForm` component and localization

# Screenshots

<img width="927" alt="Screenshot 2024-01-24 at 12 42 10 PM" src="https://github.com/performant-software/core-data-cloud/assets/64725469/e0888b45-3357-459a-8c62-f1805dc541c8">
<img width="466" alt="Screenshot 2024-01-24 at 12 42 16 PM" src="https://github.com/performant-software/core-data-cloud/assets/64725469/b23f8980-6269-4f94-9eca-8c7b9e31d76a">

# Notes

The form is really wonky. I'm not sure if I misunderstood what some of the `WebIdentifierDropdown` props do, or if it's just because of BnF's slow response times. Results sometimes don't show up, or I have to click the dropdown after typing to get them to show up.