### PR TITLE
Web identifier imports

### DIFF
--- a/db/migrate/20240129182235_add_web_identifier_z_id_to_web_identifiers.core_data_connector.rb
+++ b/db/migrate/20240129182235_add_web_identifier_z_id_to_web_identifiers.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240122201553)
+class AddWebIdentifierZIdToWebIdentifiers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_web_identifiers, :z_web_identifier_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_18_173700) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_29_182235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -254,6 +254,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_173700) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "extra"
+    t.integer "z_web_identifier_id"
     t.index ["identifiable_type", "identifiable_id"], name: "index_core_data_connector_web_identifiers_on_identifiable"
     t.index ["web_authority_id"], name: "index_core_data_connector_web_identifiers_on_web_authority_id"
   end


### PR DESCRIPTION
# Summary

- adds the migration for a `z_web_identifier_id` column to allow for imports

This PR will also upgrade the connector gem, where most of the import changes reside, when it's ready.