### PR TITLE
CDC #149 - Identifiers

### DIFF
--- a/client/src/components/ProjectItemMenu.js
+++ b/client/src/components/ProjectItemMenu.js
@@ -74,11 +74,11 @@ const ProjectItemMenu = () => {
 
         addSection(items, projectModelRelationship.id, name);
       });
-    }
 
-    // Add web identifiers
-    if (projectModel?.allow_identifiers) {
-      addSection(items, SECTION_ID_IDENTIFIERS, t('ProjectItemMenu.labels.identifiers'));
+      // Add web identifiers
+      if (projectModel?.allow_identifiers) {
+        addSection(items, SECTION_ID_IDENTIFIERS, t('ProjectItemMenu.labels.identifiers'));
+      }
     }
 
     return items;


### PR DESCRIPTION
This pull request fixes a bug adding web identifiers to records. I was able to reproduce the issue when attempting to add an identifier to an unsaved record.

The solution is to only display the identifiers list once the base record has been saved (much like we do with other relationships).