### PR TITLE
CDC #141 - List Refresh

### DIFF
--- a/client/src/components/ProjectModelsFactory.js
+++ b/client/src/components/ProjectModelsFactory.js
@@ -25,39 +25,39 @@ const ProjectModelsFactory = () => {
 
   switch (className) {
     case Types.Event:
-      component = <Events />;
+      component = <Events key={projectModel?.id} />;
       break;
 
     case Types.Instance:
-      component = <Instances />;
+      component = <Instances key={projectModel?.id} />;
       break;
 
     case Types.Item:
-      component = <Items />;
+      component = <Items key={projectModel?.id} />;
       break;
 
     case Types.MediaContent:
-      component = <MediaContents />;
+      component = <MediaContents key={projectModel?.id} />;
       break;
 
     case Types.Organization:
-      component = <Organizations />;
+      component = <Organizations key={projectModel?.id} />;
       break;
 
     case Types.Person:
-      component = <People />;
+      component = <People key={projectModel?.id} />;
       break;
 
     case Types.Place:
-      component = <Places />;
+      component = <Places key={projectModel?.id} />;
       break;
 
     case Types.Taxonomy:
-      component = <TaxonomyItems />;
+      component = <TaxonomyItems key={projectModel?.id} />;
       break;
 
     case Types.Work:
-      component = <Works />;
+      component = <Works key={projectModel?.id} />;
       break;
 
     default:

--- a/client/src/pages/Events.js
+++ b/client/src/pages/Events.js
@@ -13,6 +13,7 @@ import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
 import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
+import WindowUtils from '../utils/Window';
 
 const Events: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -77,13 +78,17 @@ const Events: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(event) => EventsService.delete(event)}
-        onLoad={(params) => EventsService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          defineable_id: projectModelId,
-          defineable_type: 'CoreDataConnector::ProjectModel',
-          view
-        })}
+        onLoad={(params) => (
+          EventsService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/Instances.js
+++ b/client/src/pages/Instances.js
@@ -18,6 +18,7 @@ import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import WindowUtils from '../utils/Window';
 
 const Instances: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -74,11 +75,17 @@ const Instances: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(instance) => InstancesService.delete(instance)}
-        onLoad={(params) => InstancesService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          view
-        })}
+        onLoad={(params) => (
+          InstancesService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/Items.js
+++ b/client/src/pages/Items.js
@@ -18,6 +18,7 @@ import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import WindowUtils from '../utils/Window';
 
 const Items: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -74,11 +75,11 @@ const Items: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(item) => ItemsService.delete(item)}
-        onLoad={(params) => ItemsService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          view
-        })}
+        onLoad={(params) => (
+          ItemsService
+            .fetchAll({ ...params, project_model_id: projectModelId, view })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/MediaContents.js
+++ b/client/src/pages/MediaContents.js
@@ -11,6 +11,7 @@ import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
 import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
+import WindowUtils from '../utils/Window';
 
 const MediaContents = () => {
   const [view, setView] = useState(Views.all);
@@ -55,7 +56,17 @@ const MediaContents = () => {
         }}
         collectionName='media_contents'
         key={view}
-        onLoad={(params) => MediaContentsService.fetchAll({ ...params, project_model_id: projectModelId, view })}
+        onLoad={(params) => (
+          MediaContentsService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         onDelete={(mediaContent) => MediaContentsService.delete(mediaContent)}
         renderEmptyList={() => null}
         renderHeader={(mediaContent) => mediaContent.name}

--- a/client/src/pages/Organizations.js
+++ b/client/src/pages/Organizations.js
@@ -12,6 +12,7 @@ import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
 import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
+import WindowUtils from '../utils/Window';
 
 const Organizations: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -66,13 +67,17 @@ const Organizations: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(organization) => OrganizationsService.delete(organization)}
-        onLoad={(params) => OrganizationsService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          defineable_id: projectModelId,
-          defineable_type: 'CoreDataConnector::ProjectModel',
-          view
-        })}
+        onLoad={(params) => (
+          OrganizationsService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/People.js
+++ b/client/src/pages/People.js
@@ -12,6 +12,7 @@ import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
 import Views from '../constants/ListViews';
 import useParams from '../hooks/ParsedParams';
+import WindowUtils from '../utils/Window';
 
 const People: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -70,13 +71,17 @@ const People: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(place) => PeopleService.delete(place)}
-        onLoad={(params) => PeopleService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          defineable_id: projectModelId,
-          defineable_type: 'CoreDataConnector::ProjectModel',
-          view
-        })}
+        onLoad={(params) => (
+          PeopleService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/Places.js
+++ b/client/src/pages/Places.js
@@ -13,6 +13,7 @@ import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
 import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
+import WindowUtils from '../utils/Window';
 
 const Places: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -67,13 +68,17 @@ const Places: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(place) => PlacesService.delete(place)}
-        onLoad={(params) => PlacesService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          defineable_id: projectModelId,
-          defineable_type: 'CoreDataConnector::ProjectModel',
-          view
-        })}
+        onLoad={(params) => (
+          PlacesService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/TaxonomyItems.js
+++ b/client/src/pages/TaxonomyItems.js
@@ -1,16 +1,17 @@
 // @flow
 
+import { ListTable } from '@performant-software/semantic-components';
 import React, { useContext, useState } from 'react';
+import { FaTag, FaTags } from 'react-icons/fa6';
 import { useNavigate, useParams } from 'react-router-dom';
+import { Icon } from 'semantic-ui-react';
+import ListViewMenu from '../components/ListViewMenu';
 import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
-import { ListTable } from '@performant-software/semantic-components';
-import { useTranslation } from 'react-i18next';
 import TaxonomiesService from '../services/Taxonomies';
+import { useTranslation } from 'react-i18next';
 import Views from '../constants/ListViews';
-import ListViewMenu from '../components/ListViewMenu';
-import { FaTag, FaTags } from 'react-icons/fa6';
-import { Icon } from 'semantic-ui-react';
+import WindowUtils from '../utils/Window';
 
 const TaxonomyItems = () => {
   const [view, setView] = useState(Views.all);
@@ -61,11 +62,11 @@ const TaxonomyItems = () => {
         }]}
         key={view}
         onDelete={(taxonomy) => TaxonomiesService.delete(taxonomy)}
-        onLoad={(params) => TaxonomiesService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          view
-        })}
+        onLoad={(params) => (
+          TaxonomiesService
+            .fetchAll({ ...params, project_model_id: projectModelId, view })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/pages/Works.js
+++ b/client/src/pages/Works.js
@@ -6,26 +6,26 @@ import React, {
   useContext
 } from 'react';
 
-import { Icon } from 'semantic-ui-react';
-import { IoBulb, IoBulbOutline } from 'react-icons/io5';
-import WorksService from '../services/Works';
 import { ListTable } from '@performant-software/semantic-components';
+import { Icon } from 'semantic-ui-react';
+import { useTranslation } from 'react-i18next';
+import { IoBulb, IoBulbOutline } from 'react-icons/io5';
+import { useNavigate } from 'react-router-dom';
 import ListViewMenu from '../components/ListViewMenu';
 import PermissionsService from '../services/Permissions';
 import ProjectContext from '../context/Project';
 import useParams from '../hooks/ParsedParams';
 import Views from '../constants/ListViews';
-import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import WindowUtils from '../utils/Window';
+import WorksService from '../services/Works';
 
 const Works: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
 
-  const { t } = useTranslation();
-
   const { projectModel } = useContext(ProjectContext);
   const navigate = useNavigate();
   const { projectModelId } = useParams();
+  const { t } = useTranslation();
 
   return (
     <>
@@ -73,11 +73,17 @@ const Works: AbstractComponent<any> = () => {
         }]}
         key={view}
         onDelete={(work) => WorksService.delete(work)}
-        onLoad={(params) => WorksService.fetchAll({
-          ...params,
-          project_model_id: projectModelId,
-          view
-        })}
+        onLoad={(params) => (
+          WorksService
+            .fetchAll({
+              ...params,
+              project_model_id: projectModelId,
+              defineable_id: projectModelId,
+              defineable_type: 'CoreDataConnector::ProjectModel',
+              view
+            })
+            .finally(() => WindowUtils.scrollToTop())
+        )}
         searchable
       />
     </>

--- a/client/src/utils/Window.js
+++ b/client/src/utils/Window.js
@@ -1,0 +1,10 @@
+// @flow
+
+/**
+ * Scrolls to the top of the current window.
+ */
+const scrollToTop = () => window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+
+export default {
+  scrollToTop
+};


### PR DESCRIPTION
This pull request fixes a bug that occurred when switch between models on the same type in "Edit" mode. Since the same component was being used, it was not re-rendered. The solution was to add the `key` prop to the component to force it to re-render when the project model is changed.

This pull request also adds functionality to all of the list pages to scroll to the top of the page after fetching a new page of data.