### PR TITLE
CDC #204 - Related Records

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,10 +11,10 @@
     "flow": "flow"
   },
   "dependencies": {
-    "@performant-software/geospatial": "^2.2.1-beta.1",
-    "@performant-software/semantic-components": "^2.2.1-beta.1",
-    "@performant-software/shared-components": "^2.2.1-beta.1",
-    "@performant-software/user-defined-fields": "^2.2.1-beta.1",
+    "@performant-software/geospatial": "^2.2.1",
+    "@performant-software/semantic-components": "^2.2.1",
+    "@performant-software/shared-components": "^2.2.1",
+    "@performant-software/user-defined-fields": "^2.2.1",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "@samvera/clover-iiif": "^2.7.3",

--- a/client/package.json
+++ b/client/package.json
@@ -11,10 +11,10 @@
     "flow": "flow"
   },
   "dependencies": {
-    "@performant-software/geospatial": "^2.1.3",
-    "@performant-software/semantic-components": "^2.1.3",
-    "@performant-software/shared-components": "^2.1.3",
-    "@performant-software/user-defined-fields": "^2.1.3",
+    "@performant-software/geospatial": "^2.2.1-beta.1",
+    "@performant-software/semantic-components": "^2.2.1-beta.1",
+    "@performant-software/shared-components": "^2.2.1-beta.1",
+    "@performant-software/user-defined-fields": "^2.2.1-beta.1",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "@samvera/clover-iiif": "^2.7.3",

--- a/client/src/components/InstanceForm.js
+++ b/client/src/components/InstanceForm.js
@@ -26,9 +26,11 @@ const InstanceForm = (props: Props) => {
       />
       <EmbeddedList
         actions={[{
-          name: 'edit'
+          name: 'edit',
+          icon: 'pencil'
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/components/ItemForm.js
+++ b/client/src/components/ItemForm.js
@@ -29,9 +29,11 @@ const ItemForm = (props: Props) => {
       />
       <EmbeddedList
         actions={[{
-          name: 'edit'
+          name: 'edit',
+          icon: 'pencil'
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/components/OrganizationForm.js
+++ b/client/src/components/OrganizationForm.js
@@ -24,9 +24,11 @@ const OrganizationForm = (props: Props) => {
       />
       <EmbeddedList
         actions={[{
-          name: 'edit'
+          name: 'edit',
+          icon: 'pencil'
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/components/PersonForm.js
+++ b/client/src/components/PersonForm.js
@@ -24,9 +24,11 @@ const PersonForm = (props: Props) => {
       />
       <EmbeddedList
         actions={[{
-          name: 'edit'
+          name: 'edit',
+          icon: 'pencil'
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/components/PlaceForm.js
+++ b/client/src/components/PlaceForm.js
@@ -137,9 +137,11 @@ const PlaceForm = (props: Props) => {
       />
       <EmbeddedList
         actions={[{
-          name: 'edit'
+          name: 'edit',
+          icon: 'pencil'
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/components/ProjectModelRelationshipModal.js
+++ b/client/src/components/ProjectModelRelationshipModal.js
@@ -159,6 +159,13 @@ const ProjectModelRelationshipModal = (props: Props) => {
         name={t('Common.tabs.fields')}
       >
         <UserDefinedFieldsEmbeddedList
+          actions={[{
+            name: 'edit',
+            icon: 'pencil'
+          }, {
+            name: 'delete',
+            icon: 'times'
+          }]}
           defaults={{
             table_name: 'CoreDataConnector::Relationship'
           }}

--- a/client/src/components/RelatedEvents.js
+++ b/client/src/components/RelatedEvents.js
@@ -9,6 +9,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedEvents = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -31,11 +32,7 @@ const RelatedEvents = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit'
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedIdentifiers.js
+++ b/client/src/components/RelatedIdentifiers.js
@@ -61,9 +61,11 @@ const RelatedIdentifiers = () => {
   return (
     <ListTable
       actions={[{
-        name: 'edit'
+        name: 'edit',
+        icon: 'pencil'
       }, {
-        name: 'delete'
+        name: 'delete',
+        icon: 'times'
       }, {
         accept: (identifier) => !!WebIdentifierUtils.getURL(identifier),
         icon: 'share square',

--- a/client/src/components/RelatedInstance.js
+++ b/client/src/components/RelatedInstance.js
@@ -23,6 +23,7 @@ const RelatedInstanceForm = (props: Props) => {
   const { foreignProjectModelId } = useProjectModelRelationship();
 
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -50,21 +51,7 @@ const RelatedInstanceForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='instances'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedInstances.js
+++ b/client/src/components/RelatedInstances.js
@@ -8,6 +8,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedInstances = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -20,11 +21,7 @@ const RelatedInstances = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit'
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedItem.js
+++ b/client/src/components/RelatedItem.js
@@ -23,6 +23,7 @@ const RelatedItemForm = (props: Props) => {
   const { foreignProjectModelId } = useProjectModelRelationship();
 
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -50,21 +51,7 @@ const RelatedItemForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='items'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedItems.js
+++ b/client/src/components/RelatedItems.js
@@ -8,6 +8,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedItems = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -20,11 +21,7 @@ const RelatedItems = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit',
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedMediaContent.js
+++ b/client/src/components/RelatedMediaContent.js
@@ -23,8 +23,14 @@ const RelatedMediaContentForm = (props: Props) => {
   const [editModal, setEditModal] = useState(false);
 
   const { foreignProjectModelId } = useProjectModelRelationship();
-  const { error, foreignObject, onSelection } = useRelationship(props);
   const { t } = useTranslation();
+
+  const {
+    error,
+    foreignObject,
+    onNavigate,
+    onSelection
+  } = useRelationship(props);
 
   /**
    * Sets the manifest URL.
@@ -102,12 +108,20 @@ const RelatedMediaContentForm = (props: Props) => {
             </>
           )}
           { props.item.id && (
-            <Button
-              color='red'
-              content={t('Common.buttons.delete')}
-              icon='trash'
-              onClick={onDelete}
-            />
+            <>
+              <Button
+                color='teal'
+                content={t('Common.buttons.edit')}
+                icon='pencil'
+                onClick={onNavigate}
+              />
+              <Button
+                color='red'
+                content={t('Common.buttons.delete')}
+                icon='trash'
+                onClick={onDelete}
+              />
+            </>
           )}
         </LazyIIIF>
       </Form.Input>

--- a/client/src/components/RelatedMediaContents.js
+++ b/client/src/components/RelatedMediaContents.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { DropdownButton, ItemList, ItemViews } from '@performant-software/semantic-components';
+import cx from 'classnames';
 import React, { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Image } from 'semantic-ui-react';
@@ -36,6 +37,7 @@ const RelatedMediaContents = () => {
   const { foreignProjectModelId, projectModelRelationship } = useProjectModelRelationship();
 
   const {
+    actions,
     onDelete,
     onInitialize,
     onLoad: onRelationshipLoad,
@@ -130,15 +132,7 @@ const RelatedMediaContents = () => {
         count={count}
       />
       <ItemList
-        actions={[{
-          basic: false,
-          name: 'edit',
-          size: 'tiny'
-        }, {
-          basic: false,
-          name: 'delete',
-          size: 'tiny'
-        }]}
+        actions={_.map(actions, (action) => ({ ...action, size: 'tiny' }))}
         addButton={{}}
         buttons={[{
           render: () => (
@@ -169,7 +163,7 @@ const RelatedMediaContents = () => {
             />
           )
         }]}
-        className={styles.relatedMediaContents}
+        className={cx('compact', styles.relatedMediaContents)}
         collectionName='relationships'
         defaultView={ItemViews.grid}
         hideToggle

--- a/client/src/components/RelatedOrganization.js
+++ b/client/src/components/RelatedOrganization.js
@@ -23,6 +23,7 @@ const RelatedOrganizationForm = (props: Props) => {
   const { foreignProjectModelId } = useProjectModelRelationship();
 
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -50,21 +51,7 @@ const RelatedOrganizationForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='organizations'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedOrganizations.js
+++ b/client/src/components/RelatedOrganizations.js
@@ -8,6 +8,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedOrganizations = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -20,11 +21,7 @@ const RelatedOrganizations = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit'
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedPeople.js
+++ b/client/src/components/RelatedPeople.js
@@ -8,6 +8,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedPeople = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -20,11 +21,7 @@ const RelatedPeople = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit'
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedPerson.js
+++ b/client/src/components/RelatedPerson.js
@@ -24,6 +24,7 @@ const RelatedPersonForm = (props: Props) => {
   const { foreignProjectModelId } = useProjectModelRelationship();
 
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -51,21 +52,7 @@ const RelatedPersonForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='people'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedPlace.js
+++ b/client/src/components/RelatedPlace.js
@@ -23,6 +23,7 @@ const RelatedPlaceForm = (props: Props) => {
 
   const { foreignProjectModelId } = useProjectModelRelationship();
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -50,21 +51,7 @@ const RelatedPlaceForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='places'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedPlaces.js
+++ b/client/src/components/RelatedPlaces.js
@@ -8,6 +8,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedPlaces = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -19,11 +20,7 @@ const RelatedPlaces = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit'
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedTaxonomyItem.js
+++ b/client/src/components/RelatedTaxonomyItem.js
@@ -23,6 +23,7 @@ const RelatedTaxonomyItemForm = (props: Props) => {
   const { foreignProjectModelId } = useProjectModelRelationship();
 
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -50,21 +51,7 @@ const RelatedTaxonomyItemForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='taxonomies'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedTaxonomyItems.js
+++ b/client/src/components/RelatedTaxonomyItems.js
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 const RelatedTaxonomyItems = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -20,11 +21,7 @@ const RelatedTaxonomyItems = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit',
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/RelatedWork.js
+++ b/client/src/components/RelatedWork.js
@@ -23,6 +23,7 @@ const RelatedWorkForm = (props: Props) => {
   const { foreignProjectModelId } = useProjectModelRelationship();
 
   const {
+    buttons,
     error,
     foreignKey,
     foreignObject,
@@ -50,21 +51,7 @@ const RelatedWorkForm = (props: Props) => {
         error={error}
       >
         <AssociatedDropdown
-          buttons={[{
-            accept: () => !!props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'edit'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            icon: 'pencil',
-            name: 'add'
-          }, {
-            accept: () => !props.item[foreignKey],
-            content: null,
-            name: 'clear'
-          }]}
+          buttons={buttons}
           collectionName='works'
           header={(
             <RelatedViewMenu

--- a/client/src/components/RelatedWorks.js
+++ b/client/src/components/RelatedWorks.js
@@ -8,6 +8,7 @@ import useRelationships from '../hooks/Relationships';
 
 const RelatedWorks = () => {
   const {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
@@ -20,11 +21,7 @@ const RelatedWorks = () => {
 
   return (
     <ListTable
-      actions={[{
-        name: 'edit',
-      }, {
-        name: 'delete'
-      }]}
+      actions={actions}
       addButton={{
         basic: false,
         color: 'dark gray',

--- a/client/src/components/WorkForm.js
+++ b/client/src/components/WorkForm.js
@@ -26,9 +26,11 @@ const WorkForm = (props: Props) => {
       />
       <EmbeddedList
         actions={[{
-          name: 'edit'
+          name: 'edit',
+          icon: 'pencil'
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/hooks/Relationship.js
+++ b/client/src/hooks/Relationship.js
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState
 } from 'react';
+import { useNavigate } from 'react-router-dom';
 import _ from 'underscore';
 import ItemLayoutContext from '../context/ItemLayout';
 import ProjectContext from '../context/Project';
@@ -56,7 +57,8 @@ const useRelationship = (props) => {
   const { projectModel } = useContext(ProjectContext);
   const { setSaved } = useContext(ItemLayoutContext);
 
-  const { itemId } = useParams();
+  const navigate = useNavigate();
+  const { itemId, projectId } = useParams();
   const { projectModelRelationship } = useProjectModelRelationship();
 
   const {
@@ -161,6 +163,18 @@ const useRelationship = (props) => {
   ), [item]);
 
   /**
+   * Navigates to the record on the other side of the current relationship.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onNavigate = useCallback(() => {
+    const projectModelId = foreignObject.project_model_id;
+    const recordId = foreignObject.id;
+
+    navigate(`/projects/${projectId}/${projectModelId}/${recordId}`);
+  }, [foreignObject]);
+
+  /**
    * Calls the onChange or onDelete function based on the passed value.
    *
    * @type {function(*): void|*}
@@ -168,6 +182,30 @@ const useRelationship = (props) => {
   const onSelection = useCallback((value) => (
     value ? onChange(value) : onDelete()
   ), [onChange, onDelete]);
+
+  /**
+   * Sets the available dropdown buttons for the current relationship.
+   */
+  const buttons = useMemo(() => [{
+    accept: () => !!props.item[foreignKey],
+    content: null,
+    icon: 'pencil',
+    name: 'edit'
+  }, {
+    accept: () => !props.item[foreignKey],
+    content: null,
+    icon: 'pencil',
+    name: 'add'
+  }, {
+    accept: () => !!props.item[foreignKey],
+    content: null,
+    name: 'clear'
+  }, {
+    basic: true,
+    icon: 'arrow right',
+    name: 'navigate',
+    onClick: onNavigate
+  }], [foreignKey, onNavigate, props.item]);
 
   /**
    * Saves the record after a related record has been changed. We only want to do this when the user makes a
@@ -204,11 +242,13 @@ const useRelationship = (props) => {
   }, [item.id, itemId, projectModel, projectModelRelationship]);
 
   return {
+    buttons,
     error,
     foreignKey,
     foreignObject,
     foreignObjectName,
     label,
+    onNavigate,
     onSave,
     onSelection
   };

--- a/client/src/hooks/Relationships.js
+++ b/client/src/hooks/Relationships.js
@@ -1,11 +1,18 @@
 // @flow
 
 import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import _ from 'underscore';
 import RelationshipsService from '../services/Relationships';
+import useParams from './ParsedParams';
 import useProjectModelRelationship from './ProjectModelRelationship';
 
 const useRelationships = () => {
+  const navigate = useNavigate();
+  const { projectId } = useParams();
+  const { t } = useTranslation();
+
   const { parameters, projectModelRelationship } = useProjectModelRelationship();
 
   /**
@@ -78,11 +85,44 @@ const useRelationships = () => {
     return value;
   }, [projectModelRelationship.inverse]);
 
+  /**
+   * Navigates to the record on the other side of the passed relationship.
+   *
+   * @type {(function(*): void)|*}
+   */
+  const onNavigate = useCallback((relationship) => {
+    const projectModelId = resolveAttributeValue('project_model_id', relationship);
+    const recordId = resolveAttributeValue('id', relationship);
+
+    navigate(`/projects/${projectId}/${projectModelId}/${recordId}`);
+  }, [resolveAttributeValue]);
+
+  /**
+   * Sets the list of default actions for the related list.
+   */
+  const actions = useMemo(() => [{
+    name: 'edit',
+    icon: 'pencil'
+  }, {
+    name: 'delete',
+    icon: 'times'
+  }, {
+    name: 'navigate',
+    icon: 'arrow right',
+    onClick: onNavigate,
+    popup: {
+      content: t('Common.actions.navigate.content'),
+      title: t('Common.actions.navigate.title')
+    }
+  }], [onNavigate]);
+
   return {
+    actions,
     foreignKey,
     onDelete,
     onInitialize,
     onLoad,
+    onNavigate,
     onSave,
     resolveAttributeValue
   };

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -28,6 +28,12 @@
     }
   },
   "Common": {
+    "actions": {
+      "navigate": {
+        "content": "Navigates to the edit page for this record",
+        "title": "Navigate"
+      }
+    },
     "buttons": {
       "add": "Add",
       "addName": "Add Name",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -69,6 +69,11 @@ textarea {
   margin-bottom: 1.5em;
 }
 
+.list.data-table-column-selector > table.ui.sortable > tbody > tr > td.actions-cell > .ui.button {
+  border: none;
+  box-shadow: none;
+}
+
 .list.compact.data-table-column-selector > table.ui.sortable > thead > tr > th {
   color: #616161;
   font-size: 12px;
@@ -83,11 +88,11 @@ textarea {
   padding: 0.4em;
 }
 
-.list.compact.data-table-column-selector > table.ui.sortable > tbody > tr > td.actions-cell > .ui.button {
-  border: none;
-  box-shadow: none;
-}
-
 .ui.form .maplibregl-control-container form .input-group > input {
   border: none;
+}
+
+.list.compact > .item-list > .ui.cards > .ui.card > .extra > .ui.button {
+  border: none;
+  box-shadow: none !important;
 }

--- a/client/src/pages/Events.js
+++ b/client/src/pages/Events.js
@@ -44,9 +44,11 @@ const Events: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (event) => navigate(`${event.id}`)
         }, {
           accept: (event) => PermissionsService.canDeleteRecord(projectModel, event),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/Instances.js
+++ b/client/src/pages/Instances.js
@@ -50,9 +50,11 @@ const Instances: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (instance) => navigate(`${instance.id}`)
         }, {
           accept: (instance) => PermissionsService.canDeleteRecord(projectModel, instance),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/Items.js
+++ b/client/src/pages/Items.js
@@ -50,9 +50,11 @@ const Items: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (item) => navigate(`${item.id}`)
         }, {
           accept: (item) => PermissionsService.canDeleteRecord(projectModel, item),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/Organizations.js
+++ b/client/src/pages/Organizations.js
@@ -43,9 +43,11 @@ const Organizations: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (organization) => navigate(`${organization.id}`)
         }, {
           accept: (organization) => PermissionsService.canDeleteRecord(projectModel, organization),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/People.js
+++ b/client/src/pages/People.js
@@ -43,9 +43,11 @@ const People: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (person) => navigate(`${person.id}`)
         }, {
           accept: (person) => PermissionsService.canDeleteRecord(projectModel, person),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/Places.js
+++ b/client/src/pages/Places.js
@@ -44,9 +44,11 @@ const Places: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (place) => navigate(`${place.id}`)
         }, {
           accept: (place) => PermissionsService.canDeleteRecord(projectModel, place),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/ProjectModel.js
+++ b/client/src/pages/ProjectModel.js
@@ -158,6 +158,13 @@ const ProjectModelForm = (props: Props) => {
               name={t('ProjectModel.tabs.fields')}
             >
               <UserDefinedFieldsEmbeddedList
+                actions={[{
+                  name: 'edit',
+                  icon: 'pencil'
+                }, {
+                  name: 'delete',
+                  icon: 'times'
+                }]}
                 addButton={{
                   basic: false,
                   color: 'blue',
@@ -179,9 +186,11 @@ const ProjectModelForm = (props: Props) => {
           >
             <EmbeddedList
               actions={[{
-                name: 'edit'
+                name: 'edit',
+                icon: 'pencil'
               }, {
-                name: 'delete'
+                name: 'delete',
+                icon: 'times'
               }]}
               addButton={{
                 basic: false,
@@ -233,7 +242,8 @@ const ProjectModelForm = (props: Props) => {
             </Message>
             <EmbeddedList
               actions={[{
-                name: 'delete'
+                name: 'delete',
+                icon: 'times'
               }]}
               addButton={{
                 basic: false,
@@ -298,7 +308,8 @@ const ProjectModelForm = (props: Props) => {
             </Message>
             <EmbeddedList
               actions={[{
-                name: 'delete'
+                name: 'delete',
+                icon: 'times'
               }]}
               addButton={{
                 basic: false,

--- a/client/src/pages/ProjectModels.js
+++ b/client/src/pages/ProjectModels.js
@@ -19,9 +19,11 @@ const ProjectModels = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (projectModel) => navigate(`${projectModel.id}`)
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/pages/TaxonomyItems.js
+++ b/client/src/pages/TaxonomyItems.js
@@ -43,9 +43,11 @@ const TaxonomyItems = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (taxonomy) => navigate(`${taxonomy.id}`)
         }, {
           accept: (taxonomy) => PermissionsService.canDeleteRecord(projectModel, taxonomy),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -60,9 +60,11 @@ const UserProjects: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (item) => navigate(`${item.id}`)
         }, {
           accept: () => editable,
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={editable ? {

--- a/client/src/pages/WebAuthorities.js
+++ b/client/src/pages/WebAuthorities.js
@@ -20,9 +20,11 @@ const WebAuthorities = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (authority) => navigate(`${authority.id}`)
         }, {
-          name: 'delete'
+          name: 'delete',
+          icon: 'times'
         }]}
         addButton={{
           basic: false,

--- a/client/src/pages/Works.js
+++ b/client/src/pages/Works.js
@@ -48,9 +48,11 @@ const Works: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
+          icon: 'pencil',
           onClick: (work) => navigate(`${work.id}`)
         }, {
           accept: (work) => PermissionsService.canDeleteRecord(projectModel, work),
+          icon: 'times',
           name: 'delete'
         }]}
         addButton={{

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2078,10 +2078,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@performant-software/geospatial@^2.2.1-beta.1":
-  version "2.2.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@performant-software/geospatial/-/geospatial-2.2.1-beta.1.tgz#9d2961c8f1c99fd818006fad565a6a933cba0b2e"
-  integrity sha512-XBwtRiJROdmfzdqWHjOYL18d2JZnnDFGdEbiAe6wRBif/4P0fCeDlNtBAb4lSI2I1nuUfxQNMXahCEWNl0To4Q==
+"@performant-software/geospatial@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/geospatial/-/geospatial-2.2.1.tgz#e43473786507efe05e92a46e27964b94a01e0ea5"
+  integrity sha512-2wzroZpFvQcPHpDCMl7OOf4eA0P7G2dbDYoKTGTbGVpHilhqTwH+z1PycC5EiWAWome9czA8fiCFRIEE5ToyNg==
   dependencies:
     "@mapbox/mapbox-gl-draw" "^1.4.3"
     "@maptiler/geocoding-control" "^1.2.2"
@@ -2092,10 +2092,10 @@
     react-map-gl "^7.1.6"
     underscore "^1.13.6"
 
-"@performant-software/semantic-components@^2.2.1-beta.1":
-  version "2.2.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-2.2.1-beta.1.tgz#d62868720e0176c0a0d97f29aef54e4b34cdfc17"
-  integrity sha512-bi7PwU66UMIuZQzIswfHUznG0XEMR4A83V4TxWs+2PYkE5rMRZc2Ef6jYkfrNyfRVhOCIpYLeFcaiwvMwi5rHA==
+"@performant-software/semantic-components@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-2.2.1.tgz#1875025a310b859bbdb24b87c5239168f642f9fc"
+  integrity sha512-bbT+p0qPaqA96SX/kJGXdRwiTCijP+lsQydw7/1iDSi1BRRbQG0MMA0DPczRvQVPAZOutkvLeJNmwfeePFoY6w==
   dependencies:
     "@react-google-maps/api" "^2.8.1"
     axios "^0.26.1"
@@ -2113,10 +2113,10 @@
     zotero-api-client "^0.40.0"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/shared-components@^2.2.1-beta.1":
-  version "2.2.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-2.2.1-beta.1.tgz#2ab36519ab7161eebca14652f590c8840c2d865b"
-  integrity sha512-hxLNIJsld8XEgef4i+Y28VwGcd9Nkno7NKhdxloJHsqzocdNg35ClDms1G+3Emls8sWiUwvrtZo8s71Cpr/+pw==
+"@performant-software/shared-components@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-2.2.1.tgz#d69c85e427d61ddf0cc5eb5b12776e31e7c800f7"
+  integrity sha512-3SF9VpCvSQDQDZQuru3HDBqZAA1yAlp7MT+snJsofaq1Ba/l5N/M/nbxI/p8hovCswUI6pm6PIQJ/9DLOAeVEg==
   dependencies:
     "@react-google-maps/api" "^2.8.1"
     axios "^0.26.1"
@@ -2132,10 +2132,10 @@
     underscore "^1.13.2"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/user-defined-fields@^2.2.1-beta.1":
-  version "2.2.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-2.2.1-beta.1.tgz#00e777a929fbcf9d65b1e2861ea971bcfb4a63cc"
-  integrity sha512-7Yg/uucr8IXERg+Lq7Zo7nAzDoHNzZwBq7K/y36ttoBMlz4S3FCkznW4u0DUOfwFndSwOK2CKDPhs9P76vgUOA==
+"@performant-software/user-defined-fields@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-2.2.1.tgz#8fd95e27db703881f050c6f361137fefd24a7ee9"
+  integrity sha512-YSiXFaad+qIaqmCV/1cxbrwEGCRyzgZf/VYKVhOztVoyHzUVXRmQqs29U6mD+dMP6JcZQwa7QCX+X0Hqb+SCuw==
   dependencies:
     i18next "^21.9.1"
     semantic-ui-react "^2.1.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2078,10 +2078,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@performant-software/geospatial@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@performant-software/geospatial/-/geospatial-2.1.3.tgz#4fdb865c7c8db265b430d313625e677463720d31"
-  integrity sha512-5URdeIfiGNQw7fdSm50XFqLM+vkXlRwmvzqaUtbXcP+xVzGBfjI9V9EXt9MB1UNBmkqIQykpl27vTIy2Nzcl0Q==
+"@performant-software/geospatial@^2.2.1-beta.1":
+  version "2.2.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/geospatial/-/geospatial-2.2.1-beta.1.tgz#9d2961c8f1c99fd818006fad565a6a933cba0b2e"
+  integrity sha512-XBwtRiJROdmfzdqWHjOYL18d2JZnnDFGdEbiAe6wRBif/4P0fCeDlNtBAb4lSI2I1nuUfxQNMXahCEWNl0To4Q==
   dependencies:
     "@mapbox/mapbox-gl-draw" "^1.4.3"
     "@maptiler/geocoding-control" "^1.2.2"
@@ -2092,10 +2092,10 @@
     react-map-gl "^7.1.6"
     underscore "^1.13.6"
 
-"@performant-software/semantic-components@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-2.1.3.tgz#44e0cb1511c3f32ef4c2279a582537fb1f3ff292"
-  integrity sha512-bQH9TXhDOtnnqNHqlPCHuFu58IW1sultx5nZ61okgL5NyKP068lf9Wfu7G8sNtIP0j/ykl+TPrSm7ignmtTu9Q==
+"@performant-software/semantic-components@^2.2.1-beta.1":
+  version "2.2.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-2.2.1-beta.1.tgz#d62868720e0176c0a0d97f29aef54e4b34cdfc17"
+  integrity sha512-bi7PwU66UMIuZQzIswfHUznG0XEMR4A83V4TxWs+2PYkE5rMRZc2Ef6jYkfrNyfRVhOCIpYLeFcaiwvMwi5rHA==
   dependencies:
     "@react-google-maps/api" "^2.8.1"
     axios "^0.26.1"
@@ -2113,10 +2113,10 @@
     zotero-api-client "^0.40.0"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/shared-components@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-2.1.3.tgz#00928758e021ba0d52740e55b58859df47545929"
-  integrity sha512-YXBZS5j8XZhWW/zG9B2il68dxlHtzqLVdbXBX4h1Viv1xuV/juEx/FuAwAJak5JPG5RS0SgODVCzcF/2jCNbZg==
+"@performant-software/shared-components@^2.2.1-beta.1":
+  version "2.2.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-2.2.1-beta.1.tgz#2ab36519ab7161eebca14652f590c8840c2d865b"
+  integrity sha512-hxLNIJsld8XEgef4i+Y28VwGcd9Nkno7NKhdxloJHsqzocdNg35ClDms1G+3Emls8sWiUwvrtZo8s71Cpr/+pw==
   dependencies:
     "@react-google-maps/api" "^2.8.1"
     axios "^0.26.1"
@@ -2132,10 +2132,10 @@
     underscore "^1.13.2"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/user-defined-fields@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-2.1.3.tgz#ce27c338b1507bfb6d8cb56c03abd2cc2969674e"
-  integrity sha512-ke8/fdzuH1wbLGl2HBvFUHe581whT0LylgT538+ufh6Q7ZX9kTLarAokDgHwKmEtZhSENFrOlQ1ZD8jnmMwxeQ==
+"@performant-software/user-defined-fields@^2.2.1-beta.1":
+  version "2.2.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-2.2.1-beta.1.tgz#00e777a929fbcf9d65b1e2861ea971bcfb4a63cc"
+  integrity sha512-7Yg/uucr8IXERg+Lq7Zo7nAzDoHNzZwBq7K/y36ttoBMlz4S3FCkznW4u0DUOfwFndSwOK2CKDPhs9P76vgUOA==
   dependencies:
     i18next "^21.9.1"
     semantic-ui-react "^2.1.2"


### PR DESCRIPTION
This pull request adds the ability to navigate to a related record from the edit page of another record. It also makes the edit and delete icons on list components consistent across components.

**Note:** This pull request is dependent on a [PR](https://github.com/performant-software/react-components/pull/277) in the `react-components` repo.

## Action Icons
All list components will now use the same icons for edit and delete actions.

![Screenshot 2024-05-09 at 1 02 19 PM](https://github.com/performant-software/core-data-cloud/assets/20641961/ecfd0480-e297-4fb0-b8d0-7675340c9c88)

## Related Records Linking
A "right arrow" icon has been added to the lists and dropdown components for related records. Clicking the icon will navigate the user to the edit page for the related record.

![Screenshot 2024-05-09 at 12 57 06 PM](https://github.com/performant-software/core-data-cloud/assets/20641961/0c55f8c1-9aab-45f8-acda-18b3aa6292aa)
