### PR TITLE
CDC #222 - Model Menu Limit

### DIFF
--- a/client/src/components/ProjectContextProvider.js
+++ b/client/src/components/ProjectContextProvider.js
@@ -55,7 +55,7 @@ const ProjectContextProvider = (props: Props) => {
   useEffect(() => {
     if (projectId) {
       ProjectModelsService
-        .fetchAll({ project_id: projectId, sort_by: 'name' })
+        .fetchAll({ project_id: projectId, sort_by: 'name', per_page: 0 })
         .then(({ data }) => setProjectModels(data.project_models))
         .finally(() => setLoadedProjectModels(true));
     } else {

--- a/client/src/components/ProjectModelsMenu.js
+++ b/client/src/components/ProjectModelsMenu.js
@@ -50,6 +50,7 @@ const ProjectModelsMenu = () => {
   return (
     <Dropdown
       className={cx(styles.projectModelsMenu, styles.ui, styles.dropdown)}
+      scrolling
       text={currentModel.name}
     >
       <Dropdown.Menu>


### PR DESCRIPTION
This pull request updates the client side API call to `/core_data/projects/:id/project_models` to include a `per_page` parameter of "0" to disable pagination.

It also updates the dropdown component to scroll when the menu gets to a longer length.

![Screenshot 2024-06-10 at 11 49 14 AM](https://github.com/performant-software/core-data-cloud/assets/20641961/2b1b98e0-4fff-492e-9fb5-ba966ee9fbde)
