### PR TITLE
CDC #31 - Models Menu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.54'
-gem 'core_data_connector', path: '../core-data-connector'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.55'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.54'
+#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.54'
+gem 'core_data_connector', path: '../core-data-connector'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,26 @@
 GIT
+  remote: https://github.com/performant-software/core-data-connector.git
+  revision: 5ea99c7ac00bbdb8f8b41c1429d0eb496cdfa25b
+  tag: v0.1.55
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
+
+GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -43,26 +65,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -153,9 +155,11 @@ GEM
     erubi (1.12.0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    faker (3.4.1)
+    faker (3.4.2)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 029f55b1cfbe53fb599b41d33ef1eebfb6f8e122
-  tag: v0.1.54
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -65,6 +43,26 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -158,8 +156,6 @@ GEM
     faker (3.4.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)

--- a/client/src/components/ProjectContextProvider.js
+++ b/client/src/components/ProjectContextProvider.js
@@ -32,7 +32,11 @@ const ProjectContextProvider = (props: Props) => {
    */
   const onLoadProjectModels = useCallback(() => (
     ProjectModelsService
-      .fetchAll({ project_id: projectId, sort_by: 'name', per_page: 0 })
+      .fetchAll({
+        project_id: projectId,
+        sort_by: ['order', 'name'],
+        per_page: 0
+      })
       .then(({ data }) => setProjectModels(data.project_models))
   ), [projectId]);
 

--- a/client/src/components/ProjectModelRelationshipModal.js
+++ b/client/src/components/ProjectModelRelationshipModal.js
@@ -42,6 +42,14 @@ const RelationshipForm = (props: Props) => {
         onChange={props.onTextInputChange.bind(this, 'name')}
         value={props.item.name}
       />
+      <Form.Input
+        error={props.isError('order')}
+        label={t('ProjectModelRelationshipModal.labels.order')}
+        required={props.isRequired('order')}
+        onChange={props.onTextInputChange.bind(this, 'order')}
+        type='number'
+        value={props.item.order}
+      />
       <Form.Checkbox
         checked={props.item.multiple}
         error={props.isError('multiple')}
@@ -101,6 +109,14 @@ const InverseForm = (props: Props) => {
         required={props.isRequired('inverse_name')}
         onChange={props.onTextInputChange.bind(this, 'inverse_name')}
         value={props.item.inverse_name}
+      />
+      <Form.Input
+        error={props.isError('order')}
+        label={t('ProjectModelRelationshipModal.labels.order')}
+        required={props.isRequired('order')}
+        onChange={props.onTextInputChange.bind(this, 'order')}
+        type='number'
+        value={props.item.order}
       />
       <Form.Checkbox
         checked={props.item.inverse_multiple}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -612,13 +612,15 @@
       "all": "All Models",
       "allowIdentifiers": "Allow identifiers",
       "name": "Name",
+      "order": "Order",
       "type": "Type"
     },
     "relationships": {
       "columns": {
-        "related": "Related type",
         "multiple": "Multiple",
-        "name": "Name"
+        "name": "Name",
+        "order": "Order",
+        "related": "Related type"
       }
     },
     "shares": {
@@ -644,6 +646,7 @@
       "inverseName": "Inverse name",
       "multiple": "Multiple",
       "name": "Name",
+      "order": "Order",
       "related": "Related type"
     },
     "title": {
@@ -654,6 +657,7 @@
   "ProjectModels": {
     "columns": {
       "name": "Name",
+      "order": "Order",
       "type": "Type"
     }
   },

--- a/client/src/pages/ProjectModel.js
+++ b/client/src/pages/ProjectModel.js
@@ -144,6 +144,14 @@ const ProjectModelForm = (props: Props) => {
               onChange={props.onTextInputChange.bind(this, 'name')}
               value={props.item.name}
             />
+            <Form.Input
+              error={props.isError('order')}
+              label={t('ProjectModel.labels.order')}
+              required={props.isRequired('order')}
+              onChange={props.onTextInputChange.bind(this, 'order')}
+              type='number'
+              value={props.item.order}
+            />
             <Form.Checkbox
               checked={props.item.allow_identifiers}
               error={props.isError('allow_identifiers')}
@@ -209,6 +217,9 @@ const ProjectModelForm = (props: Props) => {
                 name: 'multiple',
                 label: t('ProjectModel.relationships.columns.multiple'),
                 render: (relationship) => <BooleanIcon value={resolveMultiple(relationship)} />
+              }, {
+                name: 'order',
+                label: t('ProjectModel.relationships.columns.order')
               }, {
                 name: 'uuid',
                 label: t('Common.columns.uuid'),

--- a/client/src/pages/ProjectModels.js
+++ b/client/src/pages/ProjectModels.js
@@ -42,6 +42,10 @@ const ProjectModels = () => {
           resolve: (projectModel) => projectModel.model_class_view,
           sortable: true
         }, {
+          name: 'order',
+          label: t('ProjectModels.columns.order'),
+          sortable: true
+        }, {
           name: 'uuid',
           label: t('Common.columns.uuid'),
           hidden: true

--- a/client/src/transforms/ProjectModel.js
+++ b/client/src/transforms/ProjectModel.js
@@ -31,6 +31,7 @@ class ProjectModel extends BaseTransform {
       'name',
       'model_class',
       'allow_identifiers',
+      'order'
     ];
   }
 
@@ -70,12 +71,13 @@ class ProjectModel extends BaseTransform {
       })
     );
 
-    // Sort all relationships by name
-    const sortProjectModelRelationships = (relationship) => (
+    // Sort all relationships by order, name
+    const sortProjectModelRelationships = (relationship) => ([
+      relationship.order,
       relationship.inverse
         ? relationship.inverse_name
         : relationship.name
-    );
+    ]);
 
     // Add a collection containing all of the relationships
     const allRelationships = _.sortBy([

--- a/client/src/transforms/ProjectModelRelationships.js
+++ b/client/src/transforms/ProjectModelRelationships.js
@@ -24,6 +24,7 @@ class ProjectModelRelationships extends NestedAttributesTransform {
       'allow_inverse',
       'inverse_name',
       'inverse_multiple',
+      'order',
       '_destroy'
     ];
   }
@@ -38,10 +39,9 @@ class ProjectModelRelationships extends NestedAttributesTransform {
    */
   toPayload(projectModel: ProjectModelType, collection: string = 'project_model_relationships') {
     return {
-      [collection]: _.map(projectModel[collection], (item, index) => ({
+      [collection]: _.map(projectModel[collection], (item) => ({
         ..._.pick(item, this.getPayloadKeys()),
-        ...UserDefinedFieldsTransform.toPayload(item),
-        order: index
+        ...UserDefinedFieldsTransform.toPayload(item)
       }))
     };
   }

--- a/db/migrate/20240717155711_add_order_to_project_models.core_data_connector.rb
+++ b/db/migrate/20240717155711_add_order_to_project_models.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240717155011)
+class AddOrderToProjectModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_models, :order, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20240717155712_add_order_to_project_model_relationships.core_data_connector.rb
+++ b/db/migrate/20240717155712_add_order_to_project_model_relationships.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20240717155610)
+class AddOrderToProjectModelRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_project_model_relationships, :order, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_31_180143) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_17_155712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -190,6 +190,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_31_180143) do
     t.string "inverse_name"
     t.boolean "inverse_multiple", default: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "order", default: 0, null: false
     t.index ["primary_model_id"], name: "index_cdc_project_model_relationships_on_primary_model_id"
     t.index ["related_model_id"], name: "index_cdc_project_model_relationships_on_related_model_id"
   end
@@ -212,6 +213,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_31_180143) do
     t.string "slug"
     t.boolean "allow_identifiers", default: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "order", default: 0, null: false
     t.index ["project_id"], name: "index_core_data_connector_project_models_on_project_id"
   end
 


### PR DESCRIPTION
This pull request adds the `order` attribute to the Project Model edit page and Project Model Relationship edit modal. It also updates the project models menu and relationships menu to order the items based on the `order` attribute.

**Note:** This pull request is dependent on a [PR](https://github.com/performant-software/core-data-connector/pull/94) in the `core-data-connector` repo.

## Project Models List
The `order` attribute has been added to the project models list.

![Screenshot 2024-07-17 at 1 52 50 PM](https://github.com/user-attachments/assets/909b2d62-9643-4fac-a1b4-9031a4af3df3)

## Project Models Edit Page
An input element for `order` has been added to the project models edit page.

![Screenshot 2024-07-17 at 1 52 56 PM](https://github.com/user-attachments/assets/ee76ece5-2309-483d-bfd2-8cb36d9a00eb)

## Project Model Relationships List
The `order` attribute has been added to the project model relationships list.

![Screenshot 2024-07-17 at 1 53 02 PM](https://github.com/user-attachments/assets/60fea5c7-8d98-4701-95e2-c294875cc1d8)

## Project Model Relationships Edit Modal
An input element for `order` has been added to the project model relationships edit modal.

![Screenshot 2024-07-17 at 1 53 07 PM](https://github.com/user-attachments/assets/33b2ea0c-33ef-4205-9d12-761fa24f2285)

## Project Models Menu
The project models menu has been updated to sort the available models based on the `order` attribute.

![Screenshot 2024-07-17 at 1 53 13 PM](https://github.com/user-attachments/assets/e45b1271-23db-4db1-8a81-a922ead25d30)

## Project Model Relationships Menu
The project model relationships menu has been updated to sort the available relationships based on the `order` attribute. Note: The "Identifiers" relationship will still always be listed last.

![Screenshot 2024-07-17 at 1 53 19 PM](https://github.com/user-attachments/assets/958be084-4315-4b1e-934f-89e52203be8f)
