### PR TITLE
CDC #252 - Duplicate related images

### DIFF
--- a/client/src/components/MediaContentsUploadModal.js
+++ b/client/src/components/MediaContentsUploadModal.js
@@ -62,7 +62,7 @@ const MediaContentsUploadModal = (props: Props) => {
       user_defined: mediaContentUserDefined
     };
 
-    MediaContentsService
+    return MediaContentsService
       .save(payload)
       .then(({ data }) => afterSave(data.media_content, relationshipUserDefined));
   }, [projectModelRelationshipFields]);


### PR DESCRIPTION
This pull request fixes a bug that occurs when using the media upload modal to upload multiple media records to a base record. The issue was that the `onSave` function was missing a `return` statement, which in turn did not wait for the upload `Promise` to resolve, which resulted in the relationships being uploaded multiple times.