### PR TITLE
CDC #300 - Import Duplicates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.62'
-gem 'core_data_connector', path: '../core-data-connector'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.64'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.62'
+#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.62'
+gem 'core_data_connector', path: '../core-data-connector'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 5b091181d7fa3329e8a79eb7687263b06a9e0977
-  tag: v0.1.62
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -65,6 +43,26 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -158,8 +156,6 @@ GEM
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,26 @@
 GIT
+  remote: https://github.com/performant-software/core-data-connector.git
+  revision: 5d0031397aceb7dcd9c0c2245b9ef27bc90f6e16
+  tag: v0.1.64
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
+
+GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -43,26 +65,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -156,6 +158,8 @@ GEM
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)
@@ -250,7 +254,7 @@ GEM
     rake (13.0.6)
     reline (0.3.8)
       io-console (~> 0.5)
-    rexml (3.3.7)
+    rexml (3.3.8)
     rgeo (3.0.1)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)

--- a/client/src/components/ImportCompareModal.js
+++ b/client/src/components/ImportCompareModal.js
@@ -38,7 +38,7 @@ const ImportCompareModal = (props: Props) => {
     if (props.item.duplicates) {
       _.each(props.item.duplicates, (duplicate, idx) => value.push({
         ...duplicate,
-        label: t('ImportCompareModal.labels.duplicate', { index: idx + 1 })
+        label: t('ImportCompareModal.labels.merged', { index: idx + 1 })
       }));
     }
 

--- a/client/src/components/ImportModal.js
+++ b/client/src/components/ImportModal.js
@@ -12,6 +12,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import {
   Button,
+  Checkbox,
   Confirm,
   Dimmer,
   Dropdown,
@@ -80,7 +81,6 @@ const ImportModal = (props: Props) => {
       )
     });
 
-    console.log('recalculating columns');
     return value;
   }, [data, fileName]);
 
@@ -268,6 +268,19 @@ const ImportModal = (props: Props) => {
   }, [data, fileName, selectedIndex]);
 
   /**
+   * Toggles the "remove duplicates" value for the current file.
+   *
+   * @type {(function(*, {checked: *}): void)|*}
+   */
+  const onToggleRemoveDuplicates = useCallback((e, { checked }) => {
+    const newData = { ...data };
+
+    _.extend(newData[fileName], { remove_duplicates: checked });
+
+    setData(newData);
+  }, [data, fileName]);
+
+  /**
    * Sets the calculated import status on each row of the data set.
    *
    * @type {function(*): void}
@@ -379,6 +392,16 @@ const ImportModal = (props: Props) => {
                   onChange={(e, { value }) => setFileName(value)}
                   options={options}
                   value={fileName}
+                />
+              )
+            }, {
+              render: () => (
+                <Checkbox
+                  className={styles.duplicatesCheckbox}
+                  checked={data[fileName]?.remove_duplicates}
+                  label={t('ImportModal.labels.removeDuplicates')}
+                  onChange={onToggleRemoveDuplicates}
+                  toggle
                 />
               )
             }]}

--- a/client/src/components/ImportModal.module.css
+++ b/client/src/components/ImportModal.module.css
@@ -6,6 +6,10 @@
   min-height: 50vh;
 }
 
+.importModal > .content .duplicatesCheckbox {
+  margin-left: 1em;
+}
+
 .importModal > .content > table > thead > tr > th {
   text-wrap: nowrap;
 }

--- a/client/src/components/ItemLayout.js
+++ b/client/src/components/ItemLayout.js
@@ -90,6 +90,17 @@ const ItemLayout = (props: Props) => {
   const setSectionRef = useCallback((e: HTMLElement | null) => e && sections.current.push(e), [sections]);
 
   /**
+   * Sets the content style attribute.
+   *
+   * @type {{height: string}}
+   */
+  const sidebarStyle = useMemo(() => ({
+    height: `calc(100vh - ${contentPadding + menuBarHeight + headerHeight}px)`,
+    minWidth: 'min-content',
+    overflow: 'auto'
+  }), [contentPadding, menuBarHeight, headerHeight]);
+
+  /**
    * Memo-izes the value to set on the context.
    *
    * @type {{
@@ -165,6 +176,7 @@ const ItemLayout = (props: Props) => {
           { sidebar && (
             <div
               className={styles.sidebar}
+              style={sidebarStyle}
             >
               { sidebar.props.children }
             </div>

--- a/client/src/components/ItemPage.js
+++ b/client/src/components/ItemPage.js
@@ -26,6 +26,7 @@ import initialize from '../hooks/Item';
 import ProjectContext from '../context/Project';
 import ProjectItemMenu from './ProjectItemMenu';
 import RelatedIdentifiers from './RelatedIdentifiers';
+import RelatedRecordMerges from './RelatedRecordMerges';
 import Relationships from './Relationships';
 import SaveButton from './SaveButton';
 import Section from './Section';
@@ -162,6 +163,17 @@ const ItemPage = ({ form: Form, onInitialize, onSave }: Props) => {
                   <RelatedIdentifiers />
                 </Section>
               )}
+              <Section
+                id='merges'
+              >
+                <Divider
+                  section
+                />
+                <Header
+                  content={t('ItemPage.labels.merges')}
+                />
+                <RelatedRecordMerges />
+              </Section>
             </ItemLayout.Content>
           </ItemLayout>
         </ItemContext.Provider>

--- a/client/src/components/MergeModal.js
+++ b/client/src/components/MergeModal.js
@@ -67,7 +67,7 @@ const MergeModal = (props: Props) => {
    * @type {function(*, *, *): *}
    */
   const getAttributeValue = useCallback((current, item, attribute) => {
-    let value = item[attribute.name];
+    let value = item[attribute.name] || {};
 
     if (attribute.names) {
       value = _.map(value, (entry) => ({

--- a/client/src/components/ProjectItemMenu.js
+++ b/client/src/components/ProjectItemMenu.js
@@ -18,6 +18,7 @@ import useParams from '../hooks/ParsedParams';
 
 const SECTION_ID_DETAILS = 'details';
 const SECTION_ID_IDENTIFIERS = 'identifiers';
+const SECTION_ID_MERGES = 'merges';
 
 const ProjectItemMenu = () => {
   const [activeSection, setActiveSection] = useState();
@@ -79,6 +80,8 @@ const ProjectItemMenu = () => {
       if (projectModel?.allow_identifiers) {
         addSection(items, SECTION_ID_IDENTIFIERS, t('ProjectItemMenu.labels.identifiers'));
       }
+
+      addSection(items, SECTION_ID_MERGES, t('ProjectItemMenu.labels.merges'));
     }
 
     return items;

--- a/client/src/components/ProjectItemMenu.module.css
+++ b/client/src/components/ProjectItemMenu.module.css
@@ -1,7 +1,7 @@
 .projectItemMenu.ui.menu.pointing.secondary.vertical {
   margin-left: 1em;
   margin-right: 1em;
-  height: 100%;
+  min-height: 100%;
 }
 
 .projectItemMenu.ui.menu.pointing.secondary.vertical > .item:first-child {

--- a/client/src/components/RelatedRecordMerges.js
+++ b/client/src/components/RelatedRecordMerges.js
@@ -1,0 +1,61 @@
+// @flow
+
+import { ListTable } from '@performant-software/semantic-components';
+import React, { useCallback, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import ProjectContext from '../context/Project';
+import RecordMergesService from '../services/RecordMerges';
+import useParams from '../hooks/ParsedParams';
+
+const RelatedRecordMerges = () => {
+  const { projectModel } = useContext(ProjectContext);
+  const { itemId } = useParams();
+  const { t } = useTranslation();
+
+  /**
+   * Deletes the passed record merge.
+   *
+   * @type {function(*): Promise<AxiosResponse<T>>}
+   */
+  const onDelete = useCallback((recordMerge) => RecordMergesService.delete(recordMerge), []);
+
+  /**
+   * Loads the list of related record merges.
+   *
+   * @type {function(*): Promise<AxiosResponse<T>>}
+   */
+  const onLoad = useCallback((params) => (
+    RecordMergesService
+      .fetchAll({
+        ...params,
+        mergeable_id: itemId,
+        mergeable_type: projectModel?.model_class
+      })
+  ), [itemId, projectModel]);
+
+  return (
+    <ListTable
+      actions={[{
+        name: 'delete',
+        icon: 'times'
+      }]}
+      className='compact'
+      collectionName='record_merges'
+      columns={[{
+        name: 'merged_uuid',
+        label: t('Common.columns.uuid'),
+        sortable: true
+      }, {
+        name: 'created_at',
+        label: t('RelatedRecordMerges.columns.created'),
+        resolve: (recordMerge) => new Date(recordMerge.created_at).toLocaleDateString(),
+        sortable: true
+      }]}
+      configurable={false}
+      onDelete={onDelete}
+      onLoad={onLoad}
+    />
+  );
+};
+
+export default RelatedRecordMerges;

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -205,7 +205,8 @@
   "ItemPage": {
     "labels": {
       "details": "Details",
-      "identifiers": "Identifiers"
+      "identifiers": "Identifiers",
+      "merges": "Merges"
     }
   },
   "Items": {
@@ -621,7 +622,8 @@
   "ProjectItemMenu": {
     "labels": {
       "details": "Details",
-      "identifiers": "Identifiers"
+      "identifiers": "Identifiers",
+      "merges": "Merges"
     }
   },
   "ProjectModeLink": {
@@ -781,6 +783,11 @@
   "RelatedPlaces": {
     "columns": {
       "name": "Name"
+    }
+  },
+  "RelatedRecordMerges": {
+    "columns": {
+      "created": "Created"
     }
   },
   "RelatedTaxonomyItems": {

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -119,7 +119,7 @@
   },
   "ImportCompareModal": {
     "labels": {
-      "duplicate": "Duplicate {{index}}",
+      "merged": "Merged {{index}}",
       "existing": "Existing",
       "incoming": "Incoming"
     },

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -137,6 +137,7 @@
       "header": "There was an error importing for the current record"
     },
     "labels": {
+      "removeDuplicates": "Remove duplicates",
       "status": "Status",
       "total": "Total"
     },

--- a/client/src/services/RecordMerges.js
+++ b/client/src/services/RecordMerges.js
@@ -1,0 +1,29 @@
+// @flow
+
+import { BaseService } from '@performant-software/shared-components';
+
+/**
+ * Class responsible for handling all record merge API requests.
+ */
+class RecordMerges extends BaseService {
+  /**
+   * Returns the record merge base URL.
+   *
+   * @returns {string}
+   */
+  getBaseUrl() {
+    return '/core_data/record_merges';
+  }
+
+  /**
+   * Returns an empty transform object.
+   *
+   * @returns {{}}
+   */
+  getTransform() {
+    return {};
+  }
+}
+
+const RecordMergesService: RecordMerges = new RecordMerges();
+export default RecordMergesService;

--- a/client/src/transforms/Item.js
+++ b/client/src/transforms/Item.js
@@ -57,7 +57,10 @@ class Item extends MergeableTransform {
     const files = {};
 
     _.each(_.keys(payload), (filename) => {
-      files[filename] = _.map(payload[filename].data, (item) => item.import);
+      files[filename] = {
+        data: _.map(payload[filename].data, (item) => item.import),
+        remove_duplicates: payload[filename].remove_duplicates
+      };
     });
 
     return {

--- a/client/src/types/RecodMerge.js
+++ b/client/src/types/RecodMerge.js
@@ -1,0 +1,7 @@
+// @flow
+
+export type RecordMerge = {
+  id: number,
+  merged_uuid: string,
+  created_at: number
+};

--- a/db/migrate/20240930173046_add_import_id_to_models.core_data_connector.rb
+++ b/db/migrate/20240930173046_add_import_id_to_models.core_data_connector.rb
@@ -1,0 +1,14 @@
+# This migration comes from core_data_connector (originally 20240927191700)
+class AddImportIdToModels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_events, :import_id, :uuid, index: true
+    add_column :core_data_connector_instances, :import_id, :uuid, index: true
+    add_column :core_data_connector_items, :import_id, :uuid, index: true
+    add_column :core_data_connector_organizations, :import_id, :uuid, index: true
+    add_column :core_data_connector_people, :import_id, :uuid, index: true
+    add_column :core_data_connector_places, :import_id, :uuid, index: true
+    add_column :core_data_connector_relationships, :import_id, :uuid, index: true
+    add_column :core_data_connector_taxonomies, :import_id, :uuid, index: true
+    add_column :core_data_connector_works, :import_id, :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_30_173046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_events_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_events_on_user_defined", using: :gin
   end
@@ -36,6 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.integer "z_instance_id"
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_instances_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_instances_on_user_defined", using: :gin
   end
@@ -48,6 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.jsonb "user_defined", default: {}
     t.integer "z_item_id"
     t.string "faircopy_cloud_id"
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_items_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_items_on_user_defined", using: :gin
   end
@@ -95,6 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.jsonb "user_defined", default: {}
     t.integer "z_organization_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_organizations_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_organizations_on_user_defined", using: :gin
   end
@@ -107,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.jsonb "user_defined", default: {}
     t.integer "z_person_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_people_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_people_on_user_defined", using: :gin
   end
@@ -157,6 +162,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.jsonb "user_defined", default: {}
     t.integer "z_place_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_places_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_places_on_user_defined", using: :gin
   end
@@ -173,11 +179,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
   create_table "core_data_connector_project_model_relationships", force: :cascade do |t|
     t.bigint "primary_model_id", null: false
     t.bigint "related_model_id", null: false
-    t.string "name"
-    t.boolean "multiple"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
+    t.boolean "multiple"
+    t.string "name"
     t.boolean "allow_inverse", default: false, null: false
     t.string "inverse_name"
     t.boolean "inverse_multiple", default: false
@@ -239,6 +245,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.jsonb "user_defined", default: {}
     t.integer "z_relationship_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "import_id"
     t.index ["primary_record_type", "primary_record_id"], name: "index_core_data_connector_relationships_on_primary_record"
     t.index ["project_model_relationship_id"], name: "index_cdc_relationships_on_project_model_relationship_id"
     t.index ["related_record_type", "related_record_id"], name: "index_core_data_connector_relationships_on_related_record"
@@ -262,6 +269,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.datetime "updated_at", null: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.integer "z_taxonomy_id"
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_taxonomies_on_project_model_id"
   end
 
@@ -313,6 +321,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_10_171712) do
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.integer "z_work_id"
+    t.uuid "import_id"
     t.index ["project_model_id"], name: "index_core_data_connector_works_on_project_model_id"
     t.index ["user_defined"], name: "index_core_data_connector_works_on_user_defined", using: :gin
   end


### PR DESCRIPTION
This pull request adds the "Remove duplicates" option to the `ImportModal`, which will automatically merge records with the same name value. The option will need to be select on a per-file basis, as the behavior may only be desirable for some types of records.

This pull request also adds the ability to remove `record_merges` records. A list of related `record_merges` will be added to the bottom of each mergeable record.

**Note:** This PR is dependent on a [PR](https://github.com/performant-software/core-data-connector/pull/105) in the `core-data-connector` repo.

## Remove Duplicates
When select, records with the same name value will be merged after importing.

![Screenshot 2024-10-02 at 12 18 51 PM](https://github.com/user-attachments/assets/0b4c5f60-e6e0-4153-a95f-caf70472da00)

## Per File
The option must be selected per-file for better control over which records are merged.

![Screenshot 2024-10-02 at 12 19 03 PM](https://github.com/user-attachments/assets/54b2df1e-1903-46e5-8885-f6bf920152d0)

## No duplicates
After import, the duplicates have been removed.

![Screenshot 2024-10-02 at 12 19 19 PM](https://github.com/user-attachments/assets/62433dca-0449-4d9c-91c8-0b430edcaddc)

## Relationships
Duplicate relationships have also been removed.

![Screenshot 2024-10-02 at 12 19 30 PM](https://github.com/user-attachments/assets/60af64ea-90f5-4a3b-9445-1f9f77ed6d5b)

## Record Merges
Record merges are now available to view/delete at the bottom of the edit page.

![Screenshot 2024-10-02 at 12 19 52 PM](https://github.com/user-attachments/assets/635f22c7-4952-40cc-a9cd-0f5ac70b2832)
![Screenshot 2024-10-02 at 12 20 00 PM](https://github.com/user-attachments/assets/06d4fdbe-2458-495a-ab9b-0344dc90c569)
