### PR TITLE
CDC #330 - Remove duplicates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.66'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.67'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 1ed3845ac19318dfd2fcce717fc561064e8d3c48
-  tag: v0.1.66
+  revision: bbec41fd84a07789cfa0208d34d329bb8ac506cb
+  tag: v0.1.67
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)


### PR DESCRIPTION
This pull request updates the `core_data_connector` gem to the latest version to fix an issue with importing from FairCopy.cloud using the "Remove duplicates" toggle.