### PR TITLE
Add point/polygon toggle to map search

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,10 +11,10 @@
     "flow": "flow"
   },
   "dependencies": {
-    "@performant-software/geospatial": "^2.2.16",
-    "@performant-software/semantic-components": "^2.2.16",
-    "@performant-software/shared-components": "^2.2.16",
-    "@performant-software/user-defined-fields": "^2.2.16",
+    "@performant-software/geospatial": "^2.2.21",
+    "@performant-software/semantic-components": "^2.2.21",
+    "@performant-software/shared-components": "^2.2.21",
+    "@performant-software/user-defined-fields": "^2.2.21",
     "@peripleo/maplibre": "^0.5.2",
     "@peripleo/peripleo": "^0.5.2",
     "@samvera/clover-iiif": "^2.7.3",

--- a/client/src/components/PlaceForm.js
+++ b/client/src/components/PlaceForm.js
@@ -227,10 +227,10 @@ const PlaceForm = (props: Props) => {
               styles.button
             )}
             onClick={(() => setGeocoding((oldVal) => (oldVal === 'point' ? 'polygon' : 'point')))}
-            title={geocoding === 'polygon' ? t('PlaceForm.labels.polygonMode') : t('PlaceForm.labels.pointMode')}
+            title={geocoding === 'point' ? t('PlaceForm.labels.pointMode') : t('PlaceForm.labels.polygonMode')}
             type='button'
           >
-            {geocoding === 'polygon' ? <PiPolygonBold /> : <FaMapPin />}
+            {geocoding === 'point' ? <FaMapPin /> : <PiPolygonBold />}
           </button>
           <FileInputButton
             className={cx(

--- a/client/src/components/PlaceForm.js
+++ b/client/src/components/PlaceForm.js
@@ -10,12 +10,16 @@ import {
 } from '@performant-software/geospatial';
 import { BooleanIcon, EmbeddedList, FileInputButton } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
+import { FaMapPin } from 'react-icons/fa';
 import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
 import cx from 'classnames';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Form, Header, Icon } from 'semantic-ui-react';
+import {
+  Form, Header, Icon
+} from 'semantic-ui-react';
 import _ from 'underscore';
+import { PiPolygonBold } from 'react-icons/pi';
 import type { Place as PlaceType } from '../types/Place';
 import PlaceLayerModal from './PlaceLayerModal';
 import PlaceLayerUtils from '../utils/PlaceLayers';
@@ -30,6 +34,7 @@ const { LayerTypes } = PlaceLayerUtils;
 
 const PlaceForm = (props: Props) => {
   const { t } = useTranslation();
+  const [showPolygons, setShowPolygons] = useState(false);
 
   /**
    * Memo-izes the names of the passed place layers.
@@ -187,7 +192,7 @@ const PlaceForm = (props: Props) => {
       <MapDraw
         apiKey={process.env.REACT_APP_MAP_TILER_KEY}
         data={props.item.place_geometry?.geometry_json}
-        geocoding='point'
+        geocoding={showPolygons ? 'polygon' : 'point'}
         mapStyle='https://api.maptiler.com/maps/dataviz/style.json'
         maxPitch={0}
         onChange={onMapChange}
@@ -200,6 +205,19 @@ const PlaceForm = (props: Props) => {
         <MapControl
           position='bottom-left'
         >
+          <button
+            className={cx(
+              'mapbox-gl-draw_ctrl-draw-btn',
+              'layer-button',
+              styles.ui,
+              styles.button
+            )}
+            onClick={(() => setShowPolygons(!showPolygons))}
+            title={showPolygons ? t('PlaceForm.labels.polygonMode') : t('PlaceForm.labels.pointMode')}
+            type='button'
+          >
+            {showPolygons ? <PiPolygonBold /> : <FaMapPin />}
+          </button>
           <FileInputButton
             className={cx(
               'mapbox-gl-draw_ctrl-draw-btn',

--- a/client/src/components/PlaceForm.js
+++ b/client/src/components/PlaceForm.js
@@ -35,6 +35,11 @@ type Props = EditContainerProps & {
 
 const { LayerTypes } = PlaceLayerUtils;
 
+const GeocodingTypes = {
+  point: 'point',
+  polygon: 'polygon'
+};
+
 const PlaceForm = (props: Props) => {
   const { t } = useTranslation();
 
@@ -226,11 +231,15 @@ const PlaceForm = (props: Props) => {
               styles.ui,
               styles.button
             )}
-            onClick={(() => setGeocoding((oldVal) => (oldVal === 'point' ? 'polygon' : 'point')))}
-            title={geocoding === 'point' ? t('PlaceForm.labels.pointMode') : t('PlaceForm.labels.polygonMode')}
+            onClick={(() => setGeocoding(
+              (oldVal) => (oldVal === GeocodingTypes.point ? GeocodingTypes.polygon : GeocodingTypes.point)
+            ))}
+            title={geocoding === GeocodingTypes.point
+              ? t('PlaceForm.labels.pointMode')
+              : t('PlaceForm.labels.polygonMode')}
             type='button'
           >
-            {geocoding === 'point' ? <FaMapPin /> : <PiPolygonBold />}
+            {geocoding === GeocodingTypes.point ? <FaMapPin /> : <PiPolygonBold />}
           </button>
           <FileInputButton
             className={cx(

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -444,7 +444,9 @@
     "labels": {
       "layers": "Layers",
       "location": "Location",
-      "names": "Names"
+      "names": "Names",
+      "polygonMode": "Polygon mode",
+      "pointMode": "Point mode"
     },
     "placeLayers": {
       "columns": {

--- a/client/src/utils/MapSession.js
+++ b/client/src/utils/MapSession.js
@@ -1,0 +1,41 @@
+// @flow
+
+const SESSION_DEFAULT = '{ "geocoding": "point" }';
+
+/**
+ * Restores the map session from the passed storage object.
+ *
+ * @param key
+ * @param storage
+ *
+ * @returns {{}|any}
+ */
+const restoreSession = (key, storage) => {
+  if (!(key && storage)) {
+    return {};
+  }
+
+  const session = storage.getItem(key) || SESSION_DEFAULT;
+  return JSON.parse(session);
+};
+
+/**
+ * Sets the passed map session on the passed storage object.
+ *
+ * @param key
+ * @param storage
+ * @param session
+ */
+const setSession = (key, storage, session) => {
+  if (!(key && storage)) {
+    return;
+  }
+
+  const currentSession = restoreSession(key, storage);
+  storage.setItem(key, JSON.stringify({ ...currentSession, ...session }));
+};
+
+export default {
+  restoreSession,
+  setSession
+};

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2137,12 +2137,17 @@
     sort-object "^3.0.3"
     tinyqueue "^2.0.3"
 
-"@maptiler/geocoding-control@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@maptiler/geocoding-control/-/geocoding-control-1.2.2.tgz#319b1b2abaa2b4de6cc91e1a2990e58b18557960"
-  integrity sha512-w0JH0MOWN/z4l5t89LPinn9P9CGUg+L9R0WslXSVFP8gX9SYUMaqmGB28txXlSJsckA5/oyYfOe5UOBgXK7sbw==
+"@maptiler/geocoding-control@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@maptiler/geocoding-control/-/geocoding-control-1.4.1.tgz#4cba09f5e6cb0a4c792b00ec48e9bd2991ee68b7"
+  integrity sha512-/NMM8oaKKAdF36KbJuucJc18RaY+VpwkJ2V098yoG7H+9K7Rkyen+XKuLDA8gmvrgTeX1m48Pb9RP+e5zCrRvA==
   dependencies:
-    geo-coordinates-parser "^1.6.4"
+    "@turf/bbox" "^7.1.0"
+    "@turf/clone" "^7.1.0"
+    "@turf/difference" "^7.1.0"
+    "@turf/flatten" "^7.1.0"
+    "@turf/union" "^7.1.0"
+    geo-coordinates-parser "^1.7.3"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -2177,14 +2182,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@performant-software/geospatial@^2.2.16":
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/@performant-software/geospatial/-/geospatial-2.2.16.tgz#346154fa43b1e7f89d9a8f5868fae1cf2c49a467"
-  integrity sha512-pAnnChGy6F3CY4SI/QvA+XIJjTZRNc/zEHLe38d1IgfJvPi9x/HmjcBl73pHaekeRhxUa5Q1NeEneRsrSwS3RQ==
+"@performant-software/geospatial@^2.2.21":
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/@performant-software/geospatial/-/geospatial-2.2.21.tgz#d99e22a989c22ae82ca00fe72ee5a8785a9e3da6"
+  integrity sha512-JqjZzfIhNcNCwf4C5jGU35G1sTIxgAwMlSAsPf8jpGAad1rWn5YL4XvzoehLbzpYBs1+EHc3kyurC8tEn0l/hg==
   dependencies:
     "@allmaps/maplibre" "^1.0.0-beta.25"
     "@mapbox/mapbox-gl-draw" "^1.4.3"
-    "@maptiler/geocoding-control" "^1.2.2"
+    "@maptiler/geocoding-control" "^1.4.1"
     "@turf/turf" "^6.5.0"
     mapbox-gl "npm:empty-npm-package@1.0.0"
     maplibre-gl "^3.6.2"
@@ -2192,10 +2197,10 @@
     react-map-gl "^7.1.6"
     underscore "^1.13.6"
 
-"@performant-software/semantic-components@^2.2.16":
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-2.2.16.tgz#6f4aff56ab60367661678a61cfdad669d067cfe1"
-  integrity sha512-PN3FfIcq7hj4y6GEyU3QK5S44Ll1Ws/lXdXDaTyhLUR4RXe1+fRxrP0RBZMpIlOAUFCtjFtgQX8b7kRPXgFbwQ==
+"@performant-software/semantic-components@^2.2.21":
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-2.2.21.tgz#5b923298e1f811bf1cc29c9bc6ed98f145bb4ea9"
+  integrity sha512-QqozrzG8I6DeETAp3QhPoC31oIHcMBFYdlIr1xK1gB7MHZ35iErarLDGpt+aDQl/ZkPt4JMOWscq6kAzWN1MQQ==
   dependencies:
     "@react-google-maps/api" "^2.8.1"
     axios "^0.26.1"
@@ -2213,10 +2218,10 @@
     zotero-api-client "^0.40.0"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/shared-components@^2.2.16":
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-2.2.16.tgz#8978772d781120b9c565ada1d6be5e9bcdb6c1f2"
-  integrity sha512-ji+sc/ViVq7vx4Wx9TNMm2+tqC/IyK7R2gz7vBu/ppgMUI0vIeoYphzmUEetshSasrA3MyIz6mx0NF5vRy8vbg==
+"@performant-software/shared-components@^2.2.21":
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-2.2.21.tgz#71d5ab5a018fa436cbd2f77436358c399a556adf"
+  integrity sha512-UtiK7JiluGxNwQBPXKF1lp7xk33eroaM/t72W338quY/zw7QWwbjLQcM53nJ6vACcKDx6vLbwdIiktFVfVhuIQ==
   dependencies:
     "@react-google-maps/api" "^2.8.1"
     axios "^0.26.1"
@@ -2232,10 +2237,10 @@
     underscore "^1.13.2"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/user-defined-fields@^2.2.16":
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-2.2.16.tgz#b746bbd3bd804bdb9868e10375c2ff298a486e97"
-  integrity sha512-oiuynu/G6oAsUG8r758wMca5899hxQejXoVhw09ChacrVHpKtbE3fR9zk8VBgCqPYWjwMMlGJ325OlSjIQYFSQ==
+"@performant-software/user-defined-fields@^2.2.21":
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-2.2.21.tgz#c2faeffb7436c56b3472a3ccb5e03b983399f66f"
+  integrity sha512-LBhownAycnuNYGRFiUZOCPin0XrL1MCKPjMCx9G0aDXFwtJnQI7W/PyOGZLveWicp7d0w4kOO1Y8Eu24fSFw9g==
   dependencies:
     i18next "^21.9.1"
     semantic-ui-react "^2.1.2"
@@ -3004,6 +3009,16 @@
     "@turf/helpers" "^6.5.0"
     "@turf/meta" "^6.5.0"
 
+"@turf/bbox@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-7.2.0.tgz#9db338d6407380f66a72050657f1998c5c5ccc4a"
+  integrity sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
 "@turf/bearing@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.5.0.tgz#462a053c6c644434bdb636b39f8f43fb0cd857b0"
@@ -3212,6 +3227,15 @@
   dependencies:
     "@turf/helpers" "^6.5.0"
 
+"@turf/clone@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-7.2.0.tgz#1dbf6e2f82ba2f9da45285fb870aa40662ccc55f"
+  integrity sha512-JlGUT+/5qoU5jqZmf6NMFIoLDY3O7jKd53Up+zbpJ2vzUp6QdwdNzwrsCeONhynWM13F0MVtPXH4AtdkrgFk4g==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
 "@turf/clusters-dbscan@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/clusters-dbscan/-/clusters-dbscan-6.5.0.tgz#e01f854d24fac4899009fc6811854424ea8f0985"
@@ -3300,6 +3324,17 @@
     "@turf/invariant" "^6.5.0"
     polygon-clipping "^0.15.3"
 
+"@turf/difference@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-7.2.0.tgz#f404b256fde3ddfd5fc75f336797d4cad938fbff"
+  integrity sha512-NHKD1v3s8RX+9lOpvHJg6xRuJOKiY3qxHhz5/FmE0VgGqnCkE7OObqWZ5SsXG+Ckh0aafs5qKhmDdDV/gGi6JA==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    polyclip-ts "^0.16.8"
+    tslib "^2.8.1"
+
 "@turf/dissolve@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/dissolve/-/dissolve-6.5.0.tgz#65debed7ef185087d842b450ebd01e81cc2e80f6"
@@ -3363,6 +3398,16 @@
     "@turf/helpers" "^6.5.0"
     "@turf/meta" "^6.5.0"
 
+"@turf/flatten@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/flatten/-/flatten-7.2.0.tgz#b3cca9dcf7b7ec4532c966a919065744b2c0de9f"
+  integrity sha512-q38Qsqr4l7mxp780zSdn0gp/WLBX+sa+gV6qIbDQ1HKCrrPK8QQJmNx7gk1xxEXVot6tq/WyAPysCQdX+kLmMA==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
 "@turf/flip@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/flip/-/flip-6.5.0.tgz#04b38eae8a78f2cf9240140b25401b16b37d20e2"
@@ -3384,6 +3429,14 @@
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
   integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/helpers@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.2.0.tgz#5771308108c98d608eb8e7f16dcd0eb3fb8a3417"
+  integrity sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==
+  dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
 
 "@turf/hex-grid@^6.5.0":
   version "6.5.0"
@@ -3590,6 +3643,14 @@
   integrity sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==
   dependencies:
     "@turf/helpers" "^6.5.0"
+
+"@turf/meta@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.2.0.tgz#6a6b1918890b4d9d2b5ff10b3ad47e2fd7470912"
+  integrity sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
 
 "@turf/midpoint@^6.3.0", "@turf/midpoint@^6.5.0":
   version "6.5.0"
@@ -4069,6 +4130,17 @@
     "@turf/invariant" "^6.5.0"
     polygon-clipping "^0.15.3"
 
+"@turf/union@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-7.2.0.tgz#f396ca5c8a66c424a0e2d0664280ef3d16974dac"
+  integrity sha512-Xex/cfKSmH0RZRWSJl4RLlhSmEALVewywiEXcu0aIxNbuZGTcpNoI0h4oLFrE/fUd0iBGFg/EGLXRL3zTfpg6g==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    polyclip-ts "^0.16.8"
+    tslib "^2.8.1"
+
 "@turf/unkink-polygon@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/unkink-polygon/-/unkink-polygon-6.5.0.tgz#9e54186dcce08d7e62f608c8fa2d3f0342ebe826"
@@ -4221,6 +4293,11 @@
   version "7946.0.8"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
   integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
+
+"@types/geojson@^7946.0.10":
+  version "7946.0.15"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.15.tgz#f9d55fd5a0aa2de9dc80b1b04e437538b7298868"
+  integrity sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==
 
 "@types/geojson@^7946.0.13", "@types/geojson@^7946.0.14", "@types/geojson@^7946.0.7", "@types/geojson@^7946.0.8":
   version "7946.0.14"
@@ -5197,6 +5274,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@^9.1.0:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -7257,10 +7339,10 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-geo-coordinates-parser@^1.6.4:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/geo-coordinates-parser/-/geo-coordinates-parser-1.6.6.tgz#856ea86639b5fb4ea20208418b7cfcf465d55fc2"
-  integrity sha512-+zmVBzbTrC/LyFUMcYrvUqi+XUYkJ6bWqPHywfCsMYLa9BEGHEzLsBgltwXS9Ul5oJcFbrdt2y/CjjxNtTTQ+w==
+geo-coordinates-parser@^1.7.3:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/geo-coordinates-parser/-/geo-coordinates-parser-1.7.4.tgz#b9c45ee188cc5bdd7b29f82601e6e6d7b566ac9c"
+  integrity sha512-gVGxBW+s1csexXVMf5bIwz3TH9n4sCEglOOOqmrPk8YazUI5f79jCowKjTw05m/0h1//3+Z2m/nv8IIozgZyUw==
 
 geojson-equality@0.1.6:
   version "0.1.6"
@@ -9881,6 +9963,14 @@ poly2tri@^1.5.0:
   resolved "https://registry.yarnpkg.com/poly2tri/-/poly2tri-1.5.0.tgz#db8dfb8cf36ddc6066bcc02ab448aa05617cf22c"
   integrity sha512-5yACqznqRrlFA9RhdWyD2blNPVhlB3qK+iRYJCfHtJGINb+XNBgKTw+pJOsJZ+oaGxFsIyFmOVapuREHnRhXPg==
 
+polyclip-ts@^0.16.8:
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/polyclip-ts/-/polyclip-ts-0.16.8.tgz#503160d05e9d56380533aab0bc2dae835d6da5f9"
+  integrity sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==
+  dependencies:
+    bignumber.js "^9.1.0"
+    splaytree-ts "^1.0.2"
+
 polygon-clipping@^0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/polygon-clipping/-/polygon-clipping-0.15.3.tgz#0215840438470ba2e9e6593625e4ea5c1087b4b7"
@@ -11766,6 +11856,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+splaytree-ts@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/splaytree-ts/-/splaytree-ts-1.0.2.tgz#34963704587aff45eaa09c24713f552bbf56e8f0"
+  integrity sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==
+
 splaytree@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.2.tgz#d1db2691665a3c69d630de98d55145a6546dc166"
@@ -12294,6 +12389,11 @@ tslib@^2.0.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -179,11 +179,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_30_173046) do
   create_table "core_data_connector_project_model_relationships", force: :cascade do |t|
     t.bigint "primary_model_id", null: false
     t.bigint "related_model_id", null: false
+    t.string "name"
+    t.boolean "multiple"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
-    t.boolean "multiple"
-    t.string "name"
     t.boolean "allow_inverse", default: false, null: false
     t.string "inverse_name"
     t.boolean "inverse_multiple", default: false


### PR DESCRIPTION
# Summary

This PR adds a new toggle button to the map search component that allows the user to toggle between point entry and polygon entry. Prior to this PR, only points could be entered, so the toggle has points enabled by default.

The setting is persisted in `localStorage` the same way we persist other setting such as list sorting. I added a new `MapSessionUtils` with helper functions based on https://github.com/performant-software/react-components/blob/fb305898f92134e73777539c5e9bb0c1b20e4ae7/packages/semantic-ui/src/utils/ListSession.js, because it seems like Core Data's other session storage is done inside the components from `react-components` and not directly in the CD codebase.

## Screen recording

https://github.com/user-attachments/assets/3209bf93-6932-409f-9212-3caef63608d0

