### PR TITLE
CDC #353 - Import duplicates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.68'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.69'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 6b233b7fa06c137b467b52696e3e8d04f2356770
-  tag: v0.1.68
+  revision: 873ee55f98c11b71fea2c0d990125102a1a2979f
+  tag: v0.1.69
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/client/src/components/ItemForm.js
+++ b/client/src/components/ItemForm.js
@@ -3,7 +3,7 @@
 import { BooleanIcon, EmbeddedList } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
-import React, { useContext, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -14,8 +14,9 @@ import {
 import ImportModal from './ImportModal';
 import type { Item as ItemType } from '../types/Item';
 import ItemLayoutContext from '../context/ItemLayout';
-import SourceNameModal from './SourceNameModal';
+import ItemsService from '../services/Items';
 import ProjectContext from '../context/Project';
+import SourceNameModal from './SourceNameModal';
 
 type Props = EditContainerProps & {
   item: ItemType
@@ -27,6 +28,27 @@ const ItemForm = (props: Props) => {
   const { setSaved } = useContext(ItemLayoutContext);
   const { project, projectModel } = useContext(ProjectContext);
   const { t } = useTranslation();
+
+  /**
+   * Calls the `/core_data/items/:id/import` API endpoint.
+   *
+   * @type {function(*): *}
+   */
+  const onImport = useCallback((data) => (
+    ItemsService
+      .import(props.item.id, data)
+      .then(() => setSaved(true))
+  ), [props.item]);
+
+  /**
+   * Calls the `/core_data/items/:id/analyze_import` API endpoint.
+   *
+   * @type {function(): *}
+   */
+  const onLoad = useCallback(() => (
+    ItemsService
+      .analyzeImport(props.item.id)
+  ), [props.item]);
 
   return (
     <Form>
@@ -102,14 +124,11 @@ const ItemForm = (props: Props) => {
           tableName='CoreDataConnector::Item'
         />
       )}
-      { modal && (
+      { modal && props.item?.id && (
         <ImportModal
-          id={props.item.id}
           onClose={() => setModal(false)}
-          onSave={() => {
-            setModal(false);
-            setSaved(true);
-          }}
+          onImport={onImport}
+          onLoad={onLoad}
           title={props.item.faircopy_cloud_id}
         />
       )}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -578,6 +578,10 @@
         }
       },
       "data": {
+        "analyze": {
+          "content": "View and modify your data before importing",
+          "header": "Analyze"
+        },
         "export": {
           "content": "Export a ZIP archive of CSV files containing your project's data",
           "header": "Export"
@@ -609,7 +613,8 @@
     "labels": {
       "configuration": "Configuration",
       "data": "Data",
-      "developer": "Developer"
+      "developer": "Developer",
+      "importProject": "Import {{name}}"
     },
     "messages": {
       "import": {

--- a/client/src/services/Items.js
+++ b/client/src/services/Items.js
@@ -1,5 +1,6 @@
 // @flow
 
+import Importable from '../transforms/Importable';
 import ItemTransform from '../transforms/Item';
 import MergeableService from './Mergeable';
 
@@ -40,15 +41,15 @@ class Items extends MergeableService {
    * Calls the `/items/:id/import` API endpoint for the passed payload.
    *
    * @param id
-   * @param payload
+   * @param files
    *
    * @returns {*}
    */
-  import(id: number, payload: any) {
-    const transform = this.getTransform();
+  import(id: number, files: any) {
     const config = this.getConfig();
+    const payload = Importable.toImport(files);
 
-    return this.getAxios().post(`${this.getBaseUrl()}/${id}/import`, transform.toImport(payload), config);
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/import`, payload, config);
   }
 }
 

--- a/client/src/services/Projects.js
+++ b/client/src/services/Projects.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { BaseService } from '@performant-software/shared-components';
+import Importable from '../transforms/Importable';
 import ProjectTransform from '../transforms/Project';
 import type { Project as ProjectType } from '../types/Project';
 import SessionService from './Session';
@@ -9,6 +10,21 @@ import SessionService from './Session';
  * Class responsible for handling all project API requests.
  */
 class Projects extends BaseService {
+  /**
+   * Calls the `/projects/:id/analyze_import` API endpoint.
+   *
+   * @param id
+   *
+   * @returns {*}
+   */
+  analyzeImport(id: number, file: File) {
+    const config = this.getConfig();
+    const transform = this.getTransform();
+    const payload = transform.toFileImport(file);
+
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/analyze_import`, payload, config);
+  }
+
   /**
    * Calls the <code>/projects/:id/clear</code> API endpoint to clear all data from the passed project.
    *
@@ -85,6 +101,21 @@ class Projects extends BaseService {
   }
 
   /**
+   * Calls the `/projects/:id/import_analyze` API endpoint.
+   *
+   * @param id
+   * @param files
+   *
+   * @returns {*}
+   */
+  importAnalyze(id: number, files: any) {
+    const config = this.getConfig();
+    const payload = Importable.toImport(files);
+
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/import_analyze`, payload, config);
+  }
+
+  /**
    * Calls the /projects/:id/import_configuration API endpoint with the passed file.
    *
    * @param id
@@ -93,7 +124,11 @@ class Projects extends BaseService {
    * @returns {*}
    */
   importConfiguration(id: number, file: File): Promise<any> {
-    return this.import(id, file, 'import_configuration');
+    const config = this.getConfig();
+    const transform = this.getTransform();
+    const payload = transform.toFileImport(file);
+
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/import_configuration`, payload, config);
   }
 
   /**
@@ -105,26 +140,11 @@ class Projects extends BaseService {
    * @returns {*}
    */
   importData(id: number, file: File) {
-    return this.import(id, file, 'import_data');
-  }
-
-  // private
-
-  /**
-   * Helper function to call the import API endpoints with the passed file.
-   *
-   * @param id
-   * @param file
-   * @param route
-   *
-   * @returns {*}
-   */
-  import(id: number, file: File, route) {
     const config = this.getConfig();
     const transform = this.getTransform();
-    const payload = transform.toImport(file);
+    const payload = transform.toFileImport(file);
 
-    return this.getAxios().post(`${this.getBaseUrl()}/${id}/${route}`, payload, config);
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/import_data`, payload, config);
   }
 }
 

--- a/client/src/transforms/Importable.js
+++ b/client/src/transforms/Importable.js
@@ -1,0 +1,65 @@
+// @flow
+
+import _ from 'underscore';
+import { DataTypes } from '@performant-software/user-defined-fields';
+
+class Importable {
+  /**
+   * Transforms the passed payload into an importable payload.
+   *
+   * @param payload
+   *
+   * @returns {{files: {}}}
+   */
+  toImport(payload) {
+    const files = {};
+
+    _.each(_.keys(payload), (filename) => {
+      const file = payload[filename];
+      const { attributes, data, remove_duplicates: removeDuplicates } = file;
+
+      files[filename] = {
+        data: _.map(data, (item) => this.toImportItem(item.import, attributes)),
+        remove_duplicates: removeDuplicates
+      };
+    });
+
+    return {
+      files
+    };
+  }
+
+  /**
+   * Converts the JSON user-defined fields for the passed item to strings.
+   *
+   * @param item
+   * @param attributes
+   *
+   * @returns {*}
+   */
+  toImportItem(item, attributes) {
+    const importItem = { ...item };
+
+    _.each(attributes, (attribute) => {
+      const { field } = attribute;
+
+      const isJson = (field?.data_type === DataTypes.select
+          && field?.allow_multiple)
+        || field?.data_type === DataTypes.fuzzyDate;
+
+      if (isJson) {
+        let value = importItem[attribute.name];
+
+        if (value) {
+          value = JSON.stringify(value);
+        }
+
+        importItem[attribute.name] = value;
+      }
+    });
+
+    return importItem;
+  }
+}
+
+export default new Importable();

--- a/client/src/transforms/Project.js
+++ b/client/src/transforms/Project.js
@@ -54,7 +54,7 @@ class Project extends BaseTransform {
    *
    * @returns {FormData}
    */
-  toImport(file: File) {
+  toFileImport(file: File) {
     const formData = new FormData();
     formData.append('file', file);
 


### PR DESCRIPTION
This pull request adds the abililty to use the Analyze Import functionality at the project level (previously only available at the Item level). This functionality is only available to admin users and will assist in testing by allowing users to bypass the need for a FairCopy.cloud project in order to test the import functionality.

Clicking the "Analyze" option will bring up a file selection and allow the user to select a local `zip` file to import. After selection, the file will the analyzed and the results displayed to the user.

**Note:** This pull request has a dependent [PR](https://github.com/performant-software/core-data-connector/pull/118) in the `core-data-connector` repo.

![Screenshot 2025-01-16 at 12 21 54 PM](https://github.com/user-attachments/assets/2d3f0f81-eb37-40e7-aa9e-90f9d9e374b8)
![Screenshot 2025-01-16 at 12 22 12 PM](https://github.com/user-attachments/assets/ec9d32da-e528-4b53-acfa-6902ed27b1c5)
 