### PR TITLE
Upgrade connector gem to v0.1.74

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.73'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.74'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 77ca61fc0e575796158bc95c85a4f023c216ed99
-  tag: v0.1.73
+  revision: 7a2568f3acf77700a2bcb07c67d9315cf3a01f56
+  tag: v0.1.74
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)


### PR DESCRIPTION
# Summary

This PR upgrades `core-data-connector` to v0.1.74 to get this fix: https://github.com/performant-software/core-data-connector/pull/128