### PR TITLE
Allow adding place map layers from map library (#380)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.75'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.76'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.74'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.75'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 7a2568f3acf77700a2bcb07c67d9315cf3a01f56
-  tag: v0.1.74
+  revision: 0a956096762d461b5acde264c2750789af16b8f5
+  tag: v0.1.75
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)
@@ -281,6 +281,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 0a956096762d461b5acde264c2750789af16b8f5
-  tag: v0.1.75
+  revision: 407a44862e0d08d2e18ccb4d656bfaa785b498f0
+  tag: v0.1.76
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/client/src/components/PlaceForm.js
+++ b/client/src/components/PlaceForm.js
@@ -86,7 +86,7 @@ const PlaceForm = (props: Props) => {
     if (layer.layer_type === LayerTypes.georeference) {
       return (
         <WarpedImageLayer
-          id={layer.id}
+          id={layer.id || layer.uid}
           manifest={layer.content}
           url={layer.url}
         />

--- a/client/src/components/PlaceLayerModal.js
+++ b/client/src/components/PlaceLayerModal.js
@@ -5,7 +5,6 @@ import { FileInputButton } from '@performant-software/semantic-components';
 import cx from 'classnames';
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -13,10 +12,10 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Menu, Modal } from 'semantic-ui-react';
-import PlacesService from '../services/Places';
+import useParams from '../hooks/ParsedParams';
+import ProjectsService from '../services/Projects';
 import type { PlaceLayer as PlaceLayerType } from '../types/Place';
 import PlaceLayerUtils from '../utils/PlaceLayers';
-import ProjectContext from '../context/Project';
 import styles from './PlaceLayerModal.module.css';
 
 type Props = EditContainerProps & {
@@ -35,33 +34,16 @@ const PlaceLayerModal: AbstractComponent<any> = (props: Props) => {
   const [loading, setLoading] = useState(false);
   const [tab, setTab] = useState(props.item.content ? Tabs.file : Tabs.url);
   const [geoLayers, setGeoLayers] = useState([]);
-  const { project } = useContext(ProjectContext);
+  const { projectId } = useParams();
 
   const { t } = useTranslation();
 
   /**
-   * Fetch and set the list of georeferenced layers
-   * from the map_library_url, if valid.
+   * Fetch and set the list of georeferenced layers from the map library.
    */
   useEffect(() => {
-    if (project.map_library_url) {
-      try {
-        const axios = PlacesService.getAxios();
-        axios.get(project.map_library_url, {
-          transformRequest: [(data, headers) => {
-            // delete authorization header for external request
-            // eslint-disable-next-line no-param-reassign
-            delete headers.Authorization;
-            return data;
-          }]
-        }).then(({ data }) => {
-          setGeoLayers(data);
-        });
-      } catch {
-        setGeoLayers([]);
-      }
-    }
-  }, [project.map_library_url]);
+    ProjectsService.fetchMapLibrary(projectId).then(({ data }) => setGeoLayers(data));
+  }, []);
 
   /**
    * Sets a memo-ized version of the parsed and formatted content.

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -553,7 +553,8 @@
       "name": "Name",
       "sharing": "Sharing",
       "fairCopyCloudUrl": "FairCopy.cloud URL",
-      "faircopyCloudConnectedModel": "FairCopy.cloud connected model"
+      "faircopyCloudConnectedModel": "FairCopy.cloud connected model",
+      "mapLibraryUrl": "Map library URL"
     },
     "messages": {
       "clear": {

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -476,6 +476,7 @@
   "PlaceLayerModal": {
     "labels": {
       "content": "Content",
+      "mapLibraryLayer": "Map Library Layer",
       "name": "Name",
       "type": "Type",
       "url": "URL"
@@ -487,6 +488,7 @@
     },
     "tabs": {
       "file": "File",
+      "mapLibrary": "Map Library",
       "url": "URL"
     },
     "title": {

--- a/client/src/pages/Project.js
+++ b/client/src/pages/Project.js
@@ -141,6 +141,13 @@ const ProjectForm = (props: Props) => {
               value={props.item.faircopy_cloud_project_model_id}
             />
           </Form.Input>
+          <Form.Input
+            error={props.isError('map_library_url')}
+            label={t('Project.labels.mapLibraryUrl')}
+            required={props.isRequired('map_library_url')}
+            onChange={props.onTextInputChange.bind(this, 'map_library_url')}
+            value={props.item.map_library_url}
+          />
           <div
             className={styles.section}
           >

--- a/client/src/services/Projects.js
+++ b/client/src/services/Projects.js
@@ -146,6 +146,18 @@ class Projects extends BaseService {
 
     return this.getAxios().post(`${this.getBaseUrl()}/${id}/import_data`, payload, config);
   }
+
+  /**
+   * Calls the /projects/:id/map_library API endpoint.
+   *
+   * @param id
+   *
+   * @returns {*}
+   */
+  fetchMapLibrary(id: number): Promise<any> {
+    return this.getAxios().get(`${this.getBaseUrl()}/${id}/map_library`);
+  }
+
 }
 
 const ProjectsService: Projects = new Projects();

--- a/client/src/transforms/Project.js
+++ b/client/src/transforms/Project.js
@@ -28,7 +28,8 @@ class Project extends BaseTransform {
       'description',
       'discoverable',
       'faircopy_cloud_url',
-      'faircopy_cloud_project_model_id'
+      'faircopy_cloud_project_model_id',
+      'map_library_url'
     ];
   }
 

--- a/client/src/types/Project.js
+++ b/client/src/types/Project.js
@@ -7,4 +7,5 @@ export type Project = {
   discoverable: boolean,
   faircopy_cloud_url: string,
   faircopy_cloud_project_model_id: number,
+  map_library_url: string,
 };

--- a/client/src/utils/PlaceLayers.js
+++ b/client/src/utils/PlaceLayers.js
@@ -38,6 +38,12 @@ const getLayerTypeOptions = () => _.map(_.keys(LayerTypeLabels), (key) => ({
   text: LayerTypeLabels[key]
 }));
 
+const getMapLibraryOptions = (layers: Array<any>) => _.map(layers, ({ name, url }) => ({
+  key: url,
+  value: url,
+  text: name,
+}));
+
 /**
  * Validates the passed place layer.
  *
@@ -68,6 +74,7 @@ const validate = (layer: PlaceLayerType) => {
 export default {
   getLayerTypeOptions,
   getLayerTypeView,
+  getMapLibraryOptions,
   LayerTypeLabels,
   LayerTypes,
   validate

--- a/db/migrate/20250204210235_add_map_library_url_to_core_data_connector_projects.rb
+++ b/db/migrate/20250204210235_add_map_library_url_to_core_data_connector_projects.rb
@@ -1,0 +1,5 @@
+class AddMapLibraryUrlToCoreDataConnectorProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_projects, :map_library_url, :string
+  end
+end

--- a/db/migrate/20250204210235_add_map_library_url_to_core_data_connector_projects.rb
+++ b/db/migrate/20250204210235_add_map_library_url_to_core_data_connector_projects.rb
@@ -1,5 +1,0 @@
-class AddMapLibraryUrlToCoreDataConnectorProjects < ActiveRecord::Migration[7.0]
-  def change
-    add_column :core_data_connector_projects, :map_library_url, :string
-  end
-end

--- a/db/migrate/20250211200555_add_map_library_url_to_core_data_connector_projects.core_data_connector.rb
+++ b/db/migrate/20250211200555_add_map_library_url_to_core_data_connector_projects.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250204210235)
+class AddMapLibraryUrlToCoreDataConnectorProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_projects, :map_library_url, :string
+  end
+end


### PR DESCRIPTION
## In this PR

Per #380:
- Add map library URL configuration to project
- Add map layers fetching, and resulting dropdown options, to place form

## Notes/Questions

- Can you take a look at the fetching logic here? It's a bit unusual since we're doing an external fetch inside CDC. I figured it's best to use an existing `BaseService` subclass rather than introducing an Axios dependency, but AWS won't accept the GET request if it has an authorization header, so I had to remove it.
   - The try/catch is in case the URL is invalid or the fetch otherwise fails.
- The `layer.id || layer.uid` is required to allow showing and hiding layers on the map before saving the record, as at that point the layers only have a `uid` property and no `id` property. Otherwise, at that point, the page crashes if you try to show/hide layers.