### PR TITLE
Upgrade `core-data-connector` gem for relationships index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.76'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.77'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 407a44862e0d08d2e18ccb4d656bfaa785b498f0
-  tag: v0.1.76
+  revision: 04f020d6822c64c7f6ca5d36561a553432a5974d
+  tag: v0.1.77
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/db/migrate/20250220152730_add_index_to_relationships.core_data_connector.rb
+++ b/db/migrate/20250220152730_add_index_to_relationships.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250219210510)
+class AddIndexToRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_index :core_data_connector_relationships, [:primary_record_id, :related_record_id, :related_record_type, :primary_record_type], name: 'index_relationships_record_ids_and_types'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_11_200555) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_20_152730) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -247,6 +248,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_11_200555) do
     t.integer "z_relationship_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "import_id"
+    t.index ["primary_record_id", "related_record_id", "related_record_type", "primary_record_type"], name: "index_relationships_record_ids_and_types"
     t.index ["primary_record_type", "primary_record_id"], name: "index_core_data_connector_relationships_on_primary_record"
     t.index ["project_model_relationship_id"], name: "index_cdc_relationships_on_project_model_relationship_id"
     t.index ["related_record_type", "related_record_id"], name: "index_core_data_connector_relationships_on_related_record"


### PR DESCRIPTION
# Summary

This PR upgrades `core-data-connector` to 0.1.77 and pulls in the migration from https://github.com/performant-software/core-data-connector/pull/131