### PR TITLE
Upgrade `core-data-connector` to v0.1.78

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.77'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.78'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 04f020d6822c64c7f6ca5d36561a553432a5974d
-  tag: v0.1.77
+  revision: a7a176a647fefdfd2a8607952e8af2f794ff8ccf
+  tag: v0.1.78
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)


### PR DESCRIPTION
# Summary

This PR upgrades `core-data-connector` to the latest version, which includes https://github.com/performant-software/core-data-connector/pull/132