### PR TITLE
Bump core-data-connector to v0.1.79 (core-data-connector #133)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.78'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.79'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: a7a176a647fefdfd2a8607952e8af2f794ff8ccf
-  tag: v0.1.78
+  revision: 6cde3b379a84af735d74d41fb8b97217587f5520
+  tag: v0.1.79
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)


### PR DESCRIPTION
## In this PR

Per performant-software/core-data-connector#133, bump `core-data-connector` to `v0.1.79`.