### PR TITLE
Add user-defined fields to Taxonomies (#398)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.79'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.80'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 6cde3b379a84af735d74d41fb8b97217587f5520
-  tag: v0.1.79
+  revision: efccbf69c857c0b58917a17cee2f4959ce729160
+  tag: v0.1.80
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/client/src/components/TaxonomyItemForm.js
+++ b/client/src/components/TaxonomyItemForm.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { EditContainerProps } from '@performant-software/shared-components';
+import { UserDefinedFieldsForm } from '@performant-software/user-defined-fields';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form } from 'semantic-ui-react';
@@ -23,6 +24,17 @@ const TaxonomyItemForm = (props: Props) => {
         required={props.isRequired('name')}
         value={props.item.name}
       />
+      { props.item.project_model_id && (
+        <UserDefinedFieldsForm
+          data={props.item.user_defined}
+          defineableId={props.item.project_model_id}
+          defineableType='CoreDataConnector::ProjectModel'
+          isError={props.isError}
+          onChange={(userDefined) => props.onSetState({ user_defined: userDefined })}
+          onClearValidationError={props.onClearValidationError}
+          tableName='CoreDataConnector::Taxonomy'
+        />
+      )}
     </Form>
   );
 };

--- a/client/src/pages/ProjectModel.js
+++ b/client/src/pages/ProjectModel.js
@@ -160,34 +160,32 @@ const ProjectModelForm = (props: Props) => {
               required={props.isRequired('allow_identifiers')}
             />
           </SimpleEditPage.Tab>
-          { props.item.model_class !== 'CoreDataConnector::Taxonomy' && (
-            <SimpleEditPage.Tab
-              key='fields'
-              name={t('ProjectModel.tabs.fields')}
-            >
-              <UserDefinedFieldsEmbeddedList
-                actions={[{
-                  name: 'edit',
-                  icon: 'pencil'
-                }, {
-                  name: 'delete',
-                  icon: 'times'
-                }]}
-                addButton={{
-                  basic: false,
-                  color: 'blue',
-                  location: 'top'
-                }}
-                defaults={{
-                  table_name: props.item.model_class
-                }}
-                excludeColumns={['table_name', 'uuid']}
-                items={props.item.user_defined_fields}
-                onDelete={props.onDeleteChildAssociation.bind(this, 'user_defined_fields')}
-                onSave={props.onSaveChildAssociation.bind(this, 'user_defined_fields')}
-              />
-            </SimpleEditPage.Tab>
-          )}
+          <SimpleEditPage.Tab
+            key='fields'
+            name={t('ProjectModel.tabs.fields')}
+          >
+            <UserDefinedFieldsEmbeddedList
+              actions={[{
+                name: 'edit',
+                icon: 'pencil'
+              }, {
+                name: 'delete',
+                icon: 'times'
+              }]}
+              addButton={{
+                basic: false,
+                color: 'blue',
+                location: 'top'
+              }}
+              defaults={{
+                table_name: props.item.model_class
+              }}
+              excludeColumns={['table_name', 'uuid']}
+              items={props.item.user_defined_fields}
+              onDelete={props.onDeleteChildAssociation.bind(this, 'user_defined_fields')}
+              onSave={props.onSaveChildAssociation.bind(this, 'user_defined_fields')}
+            />
+          </SimpleEditPage.Tab>
           <SimpleEditPage.Tab
             key='relationships'
             name={t('ProjectModel.tabs.relationships')}

--- a/client/src/transforms/Taxonomy.js
+++ b/client/src/transforms/Taxonomy.js
@@ -24,7 +24,8 @@ class Taxonomy extends MergeableTransform {
   getPayloadKeys(): Array<string> {
     return [
       'project_model_id',
-      'name'
+      'name',
+      'user_defined'
     ];
   }
 

--- a/db/migrate/20250226180753_add_user_defined_fields_to_core_data_connector_taxonomies.core_data_connector.rb
+++ b/db/migrate/20250226180753_add_user_defined_fields_to_core_data_connector_taxonomies.core_data_connector.rb
@@ -1,0 +1,12 @@
+# This migration comes from core_data_connector (originally 20250226175155)
+class AddUserDefinedFieldsToCoreDataConnectorTaxonomies < ActiveRecord::Migration[7.0]
+  def up
+    add_column :core_data_connector_taxonomies, :user_defined, :jsonb, default: {}
+    add_index :core_data_connector_taxonomies, :user_defined, using: :gin
+  end
+
+  def down
+    remove_index :core_data_connector_taxonomies, :user_defined
+    remove_column :core_data_connector_taxonomies, :user_defined
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_20_152730) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_26_180753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -273,7 +273,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_20_152730) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.integer "z_taxonomy_id"
     t.uuid "import_id"
+    t.jsonb "user_defined", default: {}
     t.index ["project_model_id"], name: "index_core_data_connector_taxonomies_on_project_model_id"
+    t.index ["user_defined"], name: "index_core_data_connector_taxonomies_on_user_defined", using: :gin
   end
 
   create_table "core_data_connector_user_projects", force: :cascade do |t|


### PR DESCRIPTION
## In this PR

Per #398:
- Pull in `core-data-connector` migration to add UDFs to Taxonomies
- Add UDF field to Taxonomy form and payload
- Remove condition that prevented the "Fields" tab from appearing in project config for Taxonomies