### PR TITLE
Update connector gem to v0.1.84

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.83'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.84'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: ef4d47a332fa98f50eaac44ab5ef186b604351ce
-  tag: v0.1.83
+  revision: 2f631a302789259f8f4b90d425100a4060738c07
+  tag: v0.1.84
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)


### PR DESCRIPTION
# Summary

This PR updates `core-data-connector` to v0.1.84, which includes https://github.com/performant-software/core-data-connector/pull/140 and https://github.com/performant-software/core-data-connector/pull/139.