### PR TITLE
Add `order` field to relationship models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.83'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.86'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: ef4d47a332fa98f50eaac44ab5ef186b604351ce
-  tag: v0.1.83
+  revision: 06e8817eed5a2107baaff9c8d2ebe9cf6b605035
+  tag: v0.1.86
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 8.0)

--- a/client/src/components/RelatedEventModal.js
+++ b/client/src/components/RelatedEventModal.js
@@ -89,6 +89,16 @@ const RelatedEventModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedEvents.js
+++ b/client/src/components/RelatedEvents.js
@@ -57,6 +57,10 @@ const RelatedEvents = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, resolveDate, userDefinedColumns]);
 
   if (loading) {
@@ -74,6 +78,8 @@ const RelatedEvents = () => {
       className='compact'
       collectionName='relationships'
       columns={columns}
+      defaultSort='order'
+      defaultSortDirection='ascending'
       modal={{
         component: RelatedEventModal,
         props: {

--- a/client/src/components/RelatedInstanceModal.js
+++ b/client/src/components/RelatedInstanceModal.js
@@ -89,6 +89,16 @@ const RelatedInstanceModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedInstances.js
+++ b/client/src/components/RelatedInstances.js
@@ -36,6 +36,10 @@ const RelatedInstances = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -53,6 +57,8 @@ const RelatedInstances = () => {
       className='compact'
       collectionName='relationships'
       columns={columns}
+      defaultSort='order'
+      defaultSortDirection='ascending'
       modal={{
         component: RelatedInstanceModal,
         props: {

--- a/client/src/components/RelatedItemModal.js
+++ b/client/src/components/RelatedItemModal.js
@@ -89,6 +89,16 @@ const RelatedItemModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedItems.js
+++ b/client/src/components/RelatedItems.js
@@ -36,6 +36,10 @@ const RelatedItems = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -53,6 +57,8 @@ const RelatedItems = () => {
       className='compact'
       collectionName='relationships'
       columns={columns}
+      defaultSort='order'
+      defaultSortDirection='ascending'
       modal={{
         component: RelatedItemModal,
         props: {

--- a/client/src/components/RelatedMediaContentModal.js
+++ b/client/src/components/RelatedMediaContentModal.js
@@ -50,6 +50,16 @@ const RelatedMediaContentModal = (props: Props) => {
             src={foreignObject?.content_url}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedMediaContents.js
+++ b/client/src/components/RelatedMediaContents.js
@@ -211,6 +211,8 @@ const RelatedMediaContents = () => {
         }]}
         className={cx('compact', styles.relatedMediaContents)}
         collectionName='relationships'
+        defaultSort='order'
+        defaultSortDirection='ascending'
         defaultView={ItemViews.grid}
         dimmable={false}
         hideToggle
@@ -246,6 +248,10 @@ const RelatedMediaContents = () => {
           storage: localStorage
         }}
         sort={[{
+          name: 'order',
+          value: 'order',
+          text: t('Common.columns.order')
+        }, {
           name: 'name',
           value: 'core_data_connector_media_contents.name',
           text: t('RelatedMediaContents.sort.name')

--- a/client/src/components/RelatedOrganizationModal.js
+++ b/client/src/components/RelatedOrganizationModal.js
@@ -89,6 +89,16 @@ const RelatedOrganizationModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedOrganizations.js
+++ b/client/src/components/RelatedOrganizations.js
@@ -36,6 +36,10 @@ const RelatedOrganizations = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -52,6 +56,8 @@ const RelatedOrganizations = () => {
       }}
       className='compact'
       collectionName='relationships'
+      defaultSort='order'
+      defaultSortDirection='ascending'
       columns={columns}
       modal={{
         component: RelatedOrganizationModal,

--- a/client/src/components/RelatedPeople.js
+++ b/client/src/components/RelatedPeople.js
@@ -41,6 +41,10 @@ const RelatedPeople = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -58,6 +62,8 @@ const RelatedPeople = () => {
       className='compact'
       collectionName='relationships'
       columns={columns}
+      defaultSort='order'
+      defaultSortDirection='ascending'
       modal={{
         component: RelatedPersonModal,
         props: {

--- a/client/src/components/RelatedPersonModal.js
+++ b/client/src/components/RelatedPersonModal.js
@@ -90,6 +90,16 @@ const RelatedPersonModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedPlaceModal.js
+++ b/client/src/components/RelatedPlaceModal.js
@@ -89,6 +89,16 @@ const RelatedPlaceModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedPlaces.js
+++ b/client/src/components/RelatedPlaces.js
@@ -36,6 +36,10 @@ const RelatedPlaces = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -52,6 +56,8 @@ const RelatedPlaces = () => {
       }}
       className='compact'
       collectionName='relationships'
+      defaultSort='order'
+      defaultSortDirection='ascending'
       columns={columns}
       modal={{
         component: RelatedPlaceModal,

--- a/client/src/components/RelatedTaxonomyItemModal.js
+++ b/client/src/components/RelatedTaxonomyItemModal.js
@@ -89,6 +89,16 @@ const RelatedTaxonomyItemModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedTaxonomyItems.js
+++ b/client/src/components/RelatedTaxonomyItems.js
@@ -36,6 +36,10 @@ const RelatedTaxonomyItems = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -53,6 +57,8 @@ const RelatedTaxonomyItems = () => {
       className='compact'
       collectionName='relationships'
       columns={columns}
+      defaultSort='order'
+      defaultSortDirection='ascending'
       modal={{
         component: RelatedTaxonomyItemModal,
         props: {

--- a/client/src/components/RelatedWorkModal.js
+++ b/client/src/components/RelatedWorkModal.js
@@ -89,6 +89,16 @@ const RelatedWorkModal = (props: Props) => {
             value={props.item[foreignKey]}
           />
         </Form.Input>
+        <Form.Input
+          autoFocus
+          error={props.isError('order')}
+          label={t('Common.columns.order')}
+          min={1}
+          onChange={props.onTextInputChange.bind(this, 'order')}
+          required={props.isRequired('order')}
+          type='number'
+          value={props.item.order}
+        />
         { projectModelRelationship && (
           <UserDefinedFieldsForm
             data={props.item.user_defined}

--- a/client/src/components/RelatedWorks.js
+++ b/client/src/components/RelatedWorks.js
@@ -36,6 +36,10 @@ const RelatedWorks = () => {
     resolve: resolveAttributeValue.bind(this, 'uuid'),
     sortable: true,
     hidden: true
+  }, {
+    name: 'order',
+    label: t('Common.columns.order'),
+    sortable: true
   }, ...userDefinedColumns], [resolveAttributeValue, userDefinedColumns]);
 
   if (loading) {
@@ -53,6 +57,8 @@ const RelatedWorks = () => {
       className='compact'
       collectionName='relationships'
       columns={columns}
+      defaultSort='order'
+      defaultSortDirection='ascending'
       modal={{
         component: RelatedWorkModal,
         props: {

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -56,6 +56,7 @@
       "upload": "Upload"
     },
     "columns":{
+      "order": "Order",
       "uuid": "Identifier"
     },
     "errors": {

--- a/client/src/transforms/Relationship.js
+++ b/client/src/transforms/Relationship.js
@@ -24,6 +24,7 @@ class Relationship extends BaseTransform {
    */
   getPayloadKeys() {
     return [
+      'order',
       'project_model_relationship_id',
       'primary_record_id',
       'primary_record_type',

--- a/db/migrate/20250407161528_add_order_to_relationships.core_data_connector.rb
+++ b/db/migrate/20250407161528_add_order_to_relationships.core_data_connector.rb
@@ -1,6 +1,6 @@
 # This migration comes from core_data_connector (originally 20250407150531)
 class AddOrderToRelationships < ActiveRecord::Migration[7.0]
   def change
-    add_column :core_data_connector_relationships, :order, :integer
+    add_column :core_data_connector_relationships, :order, :integer, default: 0
   end
 end

--- a/db/migrate/20250407161528_add_order_to_relationships.core_data_connector.rb
+++ b/db/migrate/20250407161528_add_order_to_relationships.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250407150531)
+class AddOrderToRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_relationships, :order, :integer
+  end
+end

--- a/db/migrate/20250409154854_add_order_to_relationships.core_data_connector.rb
+++ b/db/migrate/20250409154854_add_order_to_relationships.core_data_connector.rb
@@ -1,6 +1,6 @@
 # This migration comes from core_data_connector (originally 20250407150531)
 class AddOrderToRelationships < ActiveRecord::Migration[7.0]
   def change
-    add_column :core_data_connector_relationships, :order, :integer, default: 0
+    add_column :core_data_connector_relationships, :order, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_07_161528) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_09_154854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -248,7 +248,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_07_161528) do
     t.integer "z_relationship_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "import_id"
-    t.integer "order", default: 0
+    t.integer "order"
     t.index ["primary_record_id", "related_record_id", "related_record_type", "primary_record_type"], name: "index_relationships_record_ids_and_types"
     t.index ["primary_record_type", "primary_record_id"], name: "index_core_data_connector_relationships_on_primary_record"
     t.index ["project_model_relationship_id"], name: "index_cdc_relationships_on_project_model_relationship_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -248,7 +248,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_07_161528) do
     t.integer "z_relationship_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "import_id"
-    t.integer "order"
+    t.integer "order", default: 0
     t.index ["primary_record_id", "related_record_id", "related_record_type", "primary_record_type"], name: "index_relationships_record_ids_and_types"
     t.index ["primary_record_type", "primary_record_id"], name: "index_core_data_connector_relationships_on_primary_record"
     t.index ["project_model_relationship_id"], name: "index_cdc_relationships_on_project_model_relationship_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_26_180753) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_07_161528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -248,6 +248,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_26_180753) do
     t.integer "z_relationship_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "import_id"
+    t.integer "order"
     t.index ["primary_record_id", "related_record_id", "related_record_type", "primary_record_type"], name: "index_relationships_record_ids_and_types"
     t.index ["primary_record_type", "primary_record_id"], name: "index_core_data_connector_relationships_on_primary_record"
     t.index ["project_model_relationship_id"], name: "index_cdc_relationships_on_project_model_relationship_id"


### PR DESCRIPTION
# Summary

(This PR depends on https://github.com/performant-software/core-data-connector/pull/142)

- updates `RelationshipTransform` to send the new `order` value from https://github.com/performant-software/core-data-connector/pull/142
- adds a new integer `Input` field on all `Related_____` modal, allowing the user to configure the order that CD sorts the related records by
- sets all relationship lists to sort by `order` by default