### PR TITLE
CDC #412 - Import analyze

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.84'
+#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.84'
+gem 'core_data_connector', path: '../core-data-connector'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.84'
-gem 'core_data_connector', path: '../core-data-connector'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.85'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 2f631a302789259f8f4b90d425100a4060738c07
-  tag: v0.1.84
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -65,6 +43,26 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -158,8 +156,6 @@ GEM
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86_64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,26 @@
 GIT
+  remote: https://github.com/performant-software/core-data-connector.git
+  revision: 1d88985ed4496725a0ceb9a6ada888d022171662
+  tag: v0.1.85
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
+
+GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -43,26 +65,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -156,6 +158,8 @@ GEM
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)

--- a/client/src/components/ImportCompareModal.js
+++ b/client/src/components/ImportCompareModal.js
@@ -60,7 +60,7 @@ const ImportCompareModal = (props: Props) => {
   const attributes = useMemo(() => _.map(props.attributes, (attribute) => ({
     ...attribute,
     conflict: _.some(items, (i) => !ObjectUtils.isEqual(item[attribute.name], i[attribute.name]))
-  })), [item, items, props.attributes])
+  })), [item, items, props.attributes]);
 
   /**
    * Clears the passed attribute from the current item.

--- a/client/src/components/ImportCompareModal.js
+++ b/client/src/components/ImportCompareModal.js
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const ImportCompareModal = (props: Props) => {
-  const [item, setItem] = useState(props.item.import);
+  const [item, setItem] = useState(props.item.result);
 
   const { renderUserDefined } = useMergeable();
   const { t } = useTranslation();
@@ -31,7 +31,10 @@ const ImportCompareModal = (props: Props) => {
    * @type {[]}
    */
   const items = useMemo(() => {
-    const value = [];
+    const value = [{
+      ...props.item.import,
+      label: t('ImportCompareModal.labels.incoming')
+    }];
 
     if (props.item.db) {
       value.push({ ...props.item.db, label: t('ImportCompareModal.labels.existing') });
@@ -112,7 +115,7 @@ const ImportCompareModal = (props: Props) => {
           attributes={props.attributes}
           item={item}
           items={items}
-          label={t('ImportCompareModal.labels.incoming')}
+          label={t('ImportCompareModal.labels.result')}
           onAttributeSelection={onUpdate}
           onClearAttribute={onClear}
           renderValue={renderValue}

--- a/client/src/components/ImportCompareModal.js
+++ b/client/src/components/ImportCompareModal.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { ObjectJs as ObjectUtils } from '@performant-software/shared-components';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal } from 'semantic-ui-react';
@@ -49,6 +50,17 @@ const ImportCompareModal = (props: Props) => {
 
     return value;
   }, [props.item]);
+
+  /**
+   * Memo-izes the attributes and adds a "conflict" property for any where the values conflicts
+   * between any of the items.
+   *
+   * @type {[]}
+   */
+  const attributes = useMemo(() => _.map(props.attributes, (attribute) => ({
+    ...attribute,
+    conflict: _.some(items, (i) => !ObjectUtils.isEqual(item[attribute.name], i[attribute.name]))
+  })), [item, items, props.attributes])
 
   /**
    * Clears the passed attribute from the current item.
@@ -112,7 +124,7 @@ const ImportCompareModal = (props: Props) => {
       />
       <Modal.Content>
         <MergeTable
-          attributes={props.attributes}
+          attributes={attributes}
           item={item}
           items={items}
           label={t('ImportCompareModal.labels.result')}

--- a/client/src/components/ImportModal.js
+++ b/client/src/components/ImportModal.js
@@ -64,7 +64,7 @@ const ImportModal = (props: Props) => {
         value.push({
           ...attribute,
           editable: attribute.name !== 'uuid',
-          hidden: index > MAX_DEFAULT_COLUMNS,
+          hidden: index > MAX_DEFAULT_COLUMNS
         });
       }
     });
@@ -179,7 +179,7 @@ const ImportModal = (props: Props) => {
    * Memoizes the list of items to display on the import table.
    */
   const importItems = _.map(items, (item, index) => ({
-    ...item.import,
+    ...item.result,
     index,
     status: item.status
   }));
@@ -260,7 +260,7 @@ const ImportModal = (props: Props) => {
       status = Status.resolved;
     }
 
-    _.extend(newItem, { import: item, status });
+    _.extend(newItem, { result: item, status });
 
     setData(newData);
     setSelectedIndex(null);

--- a/client/src/components/ImportModal.js
+++ b/client/src/components/ImportModal.js
@@ -50,6 +50,19 @@ const ImportModal = (props: Props) => {
   const { t } = useTranslation();
 
   /**
+   * Renders a wrapper `div` around the content for the passed item and attribute.
+   *
+   * @type {function(*, {name: *}): *}
+   */
+  const renderCell = useCallback((item, { name }) => (
+    <div
+      className={styles.cell}
+    >
+      { item[name] }
+    </div>
+  ), []);
+
+  /**
    * Memo-izes the table display columns.
    *
    * @type {[]}
@@ -64,7 +77,8 @@ const ImportModal = (props: Props) => {
         value.push({
           ...attribute,
           editable: attribute.name !== 'uuid',
-          hidden: index > MAX_DEFAULT_COLUMNS
+          hidden: index > MAX_DEFAULT_COLUMNS,
+          render: (item) => renderCell(item, attribute)
         });
       }
     });
@@ -81,7 +95,7 @@ const ImportModal = (props: Props) => {
     });
 
     return value;
-  }, [data, fileName]);
+  }, [data, fileName, renderCell]);
 
   /**
    * Returns the count of records with the (optional) passed statuses.

--- a/client/src/components/ImportModal.module.css
+++ b/client/src/components/ImportModal.module.css
@@ -9,7 +9,3 @@
 .importModal > .content .duplicatesCheckbox {
   margin-left: 1em;
 }
-
-.importModal > .content > table > thead > tr > th {
-  text-wrap: nowrap;
-}

--- a/client/src/components/ImportModal.module.css
+++ b/client/src/components/ImportModal.module.css
@@ -9,3 +9,11 @@
 .importModal > .content .duplicatesCheckbox {
   margin-left: 1em;
 }
+
+.importModal > .content .cell {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}

--- a/client/src/components/MergeTable.js
+++ b/client/src/components/MergeTable.js
@@ -3,12 +3,18 @@
 import cx from 'classnames';
 import React, { type Element } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Header, Table } from 'semantic-ui-react';
+import {
+  Button,
+  Header,
+  Icon,
+  Table
+} from 'semantic-ui-react';
 import _ from 'underscore';
 import MergeAttribute from './MergeAttribute';
 import styles from './MergeTable.module.css';
 
 type Attribute = {
+  conflict?: boolean,
   editable?: boolean,
   label: string,
   name: string
@@ -112,6 +118,13 @@ const MergeTable = (props: Props) => {
                 verticalAlign='middle'
               >
                 { attribute.label }
+                { attribute.conflict && (
+                  <Icon
+                    className={styles.icon}
+                    color='red'
+                    name='warning circle'
+                  />
+                )}
               </Table.Cell>
               <Table.Cell
                 verticalAlign='top'

--- a/client/src/components/MergeTable.js
+++ b/client/src/components/MergeTable.js
@@ -26,9 +26,9 @@ type Props = {
   items: Array<any>,
   label: string,
   onAttributeSelection: () => void,
-  onClear: () => void,
+  onClear?: () => void,
   onClearAttribute: () => void,
-  onSelect: (item: any) => void,
+  onSelect?: (item: any) => void,
   renderValue: (item: any, attribute: Attribute, editable: boolean) => Element | string
 };
 

--- a/client/src/components/MergeTable.module.css
+++ b/client/src/components/MergeTable.module.css
@@ -85,3 +85,7 @@
 .mergeTable > table > tbody > tr > td {
   background-color: #FFFFFF;
 }
+
+.mergeTable > table > tbody > tr > td > .icon {
+  margin-left: 0.5em;
+}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -127,9 +127,10 @@
   },
   "ImportCompareModal": {
     "labels": {
-      "merged": "Merged {{index}}",
       "existing": "Existing",
-      "incoming": "Incoming"
+      "incoming": "Incoming",
+      "merged": "Merged {{index}}",
+      "result": "Result"
     },
     "title": "Compare Records"
   },

--- a/client/src/services/Projects.js
+++ b/client/src/services/Projects.js
@@ -157,7 +157,6 @@ class Projects extends BaseService {
   fetchMapLibrary(id: number): Promise<any> {
     return this.getAxios().get(`${this.getBaseUrl()}/${id}/map_library`);
   }
-
 }
 
 const ProjectsService: Projects = new Projects();

--- a/client/src/transforms/Importable.js
+++ b/client/src/transforms/Importable.js
@@ -19,7 +19,7 @@ class Importable {
       const { attributes, data, remove_duplicates: removeDuplicates } = file;
 
       files[filename] = {
-        data: _.map(data, (item) => this.toImportItem(item.import, attributes)),
+        data: _.map(data, (item) => this.toImportItem(item.result, attributes)),
         remove_duplicates: removeDuplicates
       };
     });


### PR DESCRIPTION
This pull request updates the `ImportModal` to manipulate the `result` object from the API payload, rather than the `import` object.

This pull request also adds a warning icon to the `ImportCompareModal` for any attribute where the values don't match between the Core Data record and the incoming record.

![Screenshot 2025-04-08 at 8 34 06 PM](https://github.com/user-attachments/assets/8c76dc70-26d2-4997-b12b-e6ff33fdd4fc)

Finally, this pull request also truncates the table view at 3 lines to prevent long, free text attributes from taking up the whole screen.

 ![Screenshot 2025-04-08 at 8 34 12 PM](https://github.com/user-attachments/assets/a1fa23b6-0e23-4d39-8e21-aa3e964a6541)

This pull request will remain a draft as it dependent on a `core-data-connector` [pull request](https://github.com/performant-software/core-data-connector/pull/143).