### PR TITLE
CDC #441 - Archive projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ gem 'jwt', '~> 2.4', '>= 2.4.1'
 gem 'bcrypt', '~> 3.1.18'
 
 # Resource API
-#gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.12'
-gem 'resource_api', path: '../resource-api'
+gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.13'
 
 # Authentication
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -31,13 +31,15 @@ gem 'jwt', '~> 2.4', '>= 2.4.1'
 gem 'bcrypt', '~> 3.1.18'
 
 # Resource API
-gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.12'
+#gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.12'
+gem 'resource_api', path: '../resource-api'
 
 # Authentication
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.90'
+#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.90'
+gem 'core_data_connector', path: '../core-data-connector'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.90'
-gem 'core_data_connector', path: '../core-data-connector'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.91'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,16 @@ GIT
       rails (~> 7.0.7)
 
 GIT
+  remote: https://github.com/performant-software/resource-api.git
+  revision: c5c4ac16d490cc4f5013c39ee08e9422408d3b74
+  tag: v0.5.13
+  specs:
+    resource_api (0.1.0)
+      pagy (~> 5.10)
+      pundit (~> 2.3.1)
+      rails (>= 7.0, < 8)
+
+GIT
   remote: https://github.com/performant-software/triple-eye-effable.git
   revision: e36a09bb6b182149719cb1e7c3aa8c785886093c
   tag: v0.2.1
@@ -53,14 +63,6 @@ PATH
       typesense (~> 0.14)
       typhoeus (~> 1.4)
       user_defined_fields
-
-PATH
-  remote: ../resource-api
-  specs:
-    resource_api (0.1.0)
-      pagy (~> 5.10)
-      pundit (~> 2.3.1)
-      rails (>= 7.0, < 8)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,27 @@
 GIT
+  remote: https://github.com/performant-software/core-data-connector.git
+  revision: 2eec3d31fdc3ec6092ddf9c86562b7fe968d22bd
+  tag: v0.1.91
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      postmark-rails (~> 0.22.1)
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
+
+GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -43,26 +66,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
-
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -168,6 +171,7 @@ GEM
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
+    json (2.12.2)
     jwt (2.7.1)
     loofah (2.21.3)
       crass (~> 1.0.2)
@@ -211,6 +215,11 @@ GEM
     pagy (5.10.1)
       activesupport
     pg (1.5.3)
+    postmark (1.25.1)
+      json
+    postmark-rails (0.22.1)
+      actionmailer (>= 3.0.0)
+      postmark (>= 1.21.3, < 2.0)
     puma (5.6.7)
       nio4r (~> 2.0)
     pundit (2.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 13e37c91306b8766fbde8fb168d4512b94a8316a
-  tag: v0.1.90
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -39,16 +17,6 @@ GIT
       rails (~> 7.0.7)
 
 GIT
-  remote: https://github.com/performant-software/resource-api.git
-  revision: dd731cd55db4c6eaed503c35b2e67ad3b87d7d97
-  tag: v0.5.12
-  specs:
-    resource_api (0.1.0)
-      pagy (~> 5.10)
-      pundit (~> 2.3.1)
-      rails (>= 7.0, < 8)
-
-GIT
   remote: https://github.com/performant-software/triple-eye-effable.git
   revision: e36a09bb6b182149719cb1e7c3aa8c785886093c
   tag: v0.2.1
@@ -65,6 +33,34 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
+
+PATH
+  remote: ../resource-api
+  specs:
+    resource_api (0.1.0)
+      pagy (~> 5.10)
+      pundit (~> 2.3.1)
+      rails (>= 7.0, < 8)
 
 GEM
   remote: https://rubygems.org/

--- a/client/src/components/AuthenticatedRoute.js
+++ b/client/src/components/AuthenticatedRoute.js
@@ -3,6 +3,7 @@
 import React, { type ComponentType, type Node } from 'react';
 import { Navigate } from 'react-router-dom';
 import AuthenticationService from '../services/Authentication';
+import UnauthorizedToaster from './UnauthorizedToaster';
 
 type Props = {
   children: Array<Node>
@@ -13,7 +14,12 @@ const AuthenticatedRoute: ComponentType<any> = ({ children }: Props) => {
     return <Navigate to='/' />;
   }
 
-  return children;
+  return (
+    <>
+      { children }
+      <UnauthorizedToaster />
+    </>
+  );
 };
 
 export default AuthenticatedRoute;

--- a/client/src/components/ProjectModeLink.js
+++ b/client/src/components/ProjectModeLink.js
@@ -16,7 +16,7 @@ const ProjectModeLink = () => {
   const { projectId } = useParams();
   const { t } = useTranslation();
 
-  if (!(projectId && PermissionsService.canEditProject(projectId))) {
+  if (!(projectId && PermissionsService.canEditProjectSettings(projectId))) {
     return null;
   }
 

--- a/client/src/components/ProjectModelFactory.js
+++ b/client/src/components/ProjectModelFactory.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { useContext } from 'react';
-import { Navigate } from 'react-router-dom';
 import Event from '../pages/Event';
 import Instance from '../pages/Instance';
 import Item from '../pages/Item';
@@ -13,6 +12,7 @@ import Place from '../pages/Place';
 import ProjectContext from '../context/Project';
 import TaxonomyItem from '../pages/TaxonomyItem';
 import { Types } from '../utils/ProjectModels';
+import UnauthorizedRedirect from './UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import Work from '../pages/Work';
 
@@ -24,12 +24,7 @@ const ProjectModelFactory = () => {
    * Return to the projects list if the user does not have permissions to edit this project.
    */
   if (!PermissionsService.canEditProjectData(projectId)) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   const className = projectModel?.model_class_view;

--- a/client/src/components/ProjectModelFactory.js
+++ b/client/src/components/ProjectModelFactory.js
@@ -1,20 +1,37 @@
 // @flow
 
 import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
 import Event from '../pages/Event';
 import Instance from '../pages/Instance';
 import Item from '../pages/Item';
 import MediaContent from '../pages/MediaContent';
 import Organization from '../pages/Organization';
+import PermissionsService from '../services/Permissions';
 import Person from '../pages/Person';
 import Place from '../pages/Place';
 import ProjectContext from '../context/Project';
-import { Types } from '../utils/ProjectModels';
 import TaxonomyItem from '../pages/TaxonomyItem';
+import { Types } from '../utils/ProjectModels';
+import useParams from '../hooks/ParsedParams';
 import Work from '../pages/Work';
 
 const ProjectModelFactory = () => {
   const { projectModel } = useContext(ProjectContext);
+  const { projectId } = useParams();
+
+  /**
+   * Return to the projects list if the user does not have permissions to edit this project.
+   */
+  if (!PermissionsService.canEditProjectData(projectId)) {
+    return (
+      <Navigate
+        replace
+        to='/projects'
+      />
+    );
+  }
+
   const className = projectModel?.model_class_view;
 
   if (!className) {

--- a/client/src/components/ProjectModelsFactory.js
+++ b/client/src/components/ProjectModelsFactory.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { useContext } from 'react';
-import { Navigate } from 'react-router-dom';
 import Events from '../pages/Events';
 import Instances from '../pages/Instances';
 import Items from '../pages/Items';
@@ -13,6 +12,7 @@ import Places from '../pages/Places';
 import ProjectContext from '../context/Project';
 import TaxonomyItems from '../pages/TaxonomyItems';
 import { Types } from '../utils/ProjectModels';
+import UnauthorizedRedirect from './UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import Works from '../pages/Works';
 
@@ -24,12 +24,7 @@ const ProjectModelsFactory = () => {
    * Return to the projects list if the user does not have permissions to edit this project.
    */
   if (!PermissionsService.canEditProjectData(projectId)) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   const className = projectModel?.model_class_view;

--- a/client/src/components/ProjectModelsFactory.js
+++ b/client/src/components/ProjectModelsFactory.js
@@ -1,20 +1,37 @@
 // @flow
 
 import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
 import Events from '../pages/Events';
 import Instances from '../pages/Instances';
 import Items from '../pages/Items';
 import MediaContents from '../pages/MediaContents';
 import Organizations from '../pages/Organizations';
 import People from '../pages/People';
+import PermissionsService from '../services/Permissions';
 import Places from '../pages/Places';
 import ProjectContext from '../context/Project';
 import TaxonomyItems from '../pages/TaxonomyItems';
-import Works from '../pages/Works';
 import { Types } from '../utils/ProjectModels';
+import useParams from '../hooks/ParsedParams';
+import Works from '../pages/Works';
 
 const ProjectModelsFactory = () => {
   const { projectModel } = useContext(ProjectContext);
+  const { projectId } = useParams();
+
+  /**
+   * Return to the projects list if the user does not have permissions to edit this project.
+   */
+  if (!PermissionsService.canEditProjectData(projectId)) {
+    return (
+      <Navigate
+        replace
+        to='/projects'
+      />
+    );
+  }
+
   const className = projectModel?.model_class_view;
 
   if (!className) {

--- a/client/src/components/UnauthorizedRedirect.js
+++ b/client/src/components/UnauthorizedRedirect.js
@@ -1,0 +1,18 @@
+// @flow
+
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+type Props = {
+  to?: string
+};
+
+const UnauthorizedRedirect = ({ to = '/projects' }: Props) => (
+  <Navigate
+    replace
+    state={{ unauthorized: true }}
+    to={to}
+  />
+);
+
+export default UnauthorizedRedirect;

--- a/client/src/components/UnauthorizedToaster.js
+++ b/client/src/components/UnauthorizedToaster.js
@@ -1,0 +1,59 @@
+// @flow
+
+import { Toaster } from '@performant-software/semantic-components';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Message } from 'semantic-ui-react';
+
+type Props = {
+  content?: string,
+  header?: string
+};
+
+const UnauthorizedToaster = (props: Props) => {
+  const [redirect, setRedirect] = useState(false);
+
+  const location = useLocation();
+  const { t } = useTranslation();
+
+  /**
+   * Callback fired when the toaster is dismissed.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onDismiss = useCallback(() => {
+    // Set the redirect attribute to "false" to hide to toaster.
+    setRedirect(false);
+
+    // Replace the location state so that the redirect message does not keep getting displayed.
+    window.history.replaceState({}, '');
+  }, []);
+
+  useEffect(() => {
+    if (location.state?.unauthorized) {
+      setRedirect(true);
+    }
+  }, [location.state]);
+
+  if (!redirect) {
+    return null;
+  }
+
+  return (
+    <Toaster
+      onDismiss={onDismiss}
+      timeout={5000}
+      type='negative'
+    >
+      <Message.Header
+        content={props.header || t('UnauthorizedToaster.messages.redirect.header')}
+      />
+      <Message.Content
+        content={props.content || t('UnauthorizedToaster.messages.redirect.content')}
+      />
+    </Toaster>
+  );
+};
+
+export default UnauthorizedToaster;

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -560,12 +560,15 @@
       "danger": "Danger Zone",
       "description": "Description",
       "name": "Name",
-      "sharing": "Sharing",
       "fairCopyCloudUrl": "FairCopy.cloud URL",
       "faircopyCloudConnectedModel": "FairCopy.cloud connected model",
       "mapLibraryUrl": "Map library URL"
     },
     "messages": {
+      "archive": {
+        "content": "Project members will no longer be able to access project data",
+        "header": "Archive Project"
+      },
       "clear": {
         "content": "Do you really want to clear all data from this project? This action cannot be undone.",
         "header": "Are you sure?"

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -929,6 +929,7 @@
     "columns": {
       "project": "Project",
       "role": "Role",
+      "type": "Type",
       "user": "User"
     },
     "labels": {

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -869,6 +869,14 @@
       "name": "Name"
     }
   },
+  "UnauthorizedToaster": {
+    "messages": {
+      "redirect": {
+        "content": "You do not have permission to access that resource.",
+        "header": "Unable to access resource"
+      }
+    }
+  },
   "User": {
     "labels": {
       "allUsers": "All Users"

--- a/client/src/pages/Project.js
+++ b/client/src/pages/Project.js
@@ -24,9 +24,10 @@ import ProjectModelTransform from '../transforms/ProjectModel';
 import { type Project as ProjectType } from '../types/Project';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import ProjectsService from '../services/Projects';
+import { SlLock } from 'react-icons/sl';
 import styles from './Project.module.css';
-import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 import useParams from '../hooks/ParsedParams';
+import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
 type Props = EditContainerProps & {
   item: ProjectType
@@ -81,7 +82,7 @@ const ProjectForm = (props: Props) => {
   /**
    * Return to the projects list if the user does not have permissions to edit this project.
    */
-  if (!PermissionsService.canEditProject(projectId)) {
+  if (!PermissionsService.canEditProjectSettings(projectId)) {
     return (
       <Navigate
         replace
@@ -151,9 +152,6 @@ const ProjectForm = (props: Props) => {
           <div
             className={styles.section}
           >
-            <Header
-              content={t('Project.labels.sharing')}
-            />
             <Message
               className={cx(styles.ui, styles.message)}
               color='blue'
@@ -179,6 +177,36 @@ const ProjectForm = (props: Props) => {
               </Message.Content>
             </Message>
           </div>
+          { PermissionsService.canArchiveProject() && (
+            <div
+              className={styles.section}
+            >
+              <Message
+                className={cx(styles.ui, styles.message)}
+                color='yellow'
+                icon
+              >
+                <Icon>
+                  <SlLock />
+                </Icon>
+                <Message.Content
+                  className={styles.content}
+                >
+                  <Message.Header
+                    className={styles.header}
+                    content={t('Project.messages.archive.header')}
+                  />
+                  <Form.Checkbox
+                    checked={props.item.archived}
+                    className={styles.field}
+                    label={t('Project.messages.archive.content')}
+                    error={props.isError('archived')}
+                    onChange={props.onCheckboxInputChange.bind(this, 'archived')}
+                  />
+                </Message.Content>
+              </Message>
+            </div>
+          )}
           { PermissionsService.canDeleteProject(props.item.id) && (
             <div
               className={styles.section}

--- a/client/src/pages/Project.js
+++ b/client/src/pages/Project.js
@@ -6,7 +6,7 @@ import cx from 'classnames';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoSearchOutline } from 'react-icons/io5';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   Button,
   Confirm,
@@ -26,6 +26,7 @@ import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import ProjectsService from '../services/Projects';
 import { SlLock } from 'react-icons/sl';
 import styles from './Project.module.css';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
@@ -83,12 +84,7 @@ const ProjectForm = (props: Props) => {
    * Return to the projects list if the user does not have permissions to edit this project.
    */
   if (!PermissionsService.canEditProjectSettings(projectId)) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/ProjectEdit.js
+++ b/client/src/pages/ProjectEdit.js
@@ -1,9 +1,11 @@
 // @flow
 
 import React, { useContext } from 'react';
-import ProjectContext from '../context/Project';
 import { Navigate } from 'react-router-dom';
 import _ from 'underscore';
+import PermissionsService from '../services/Permissions';
+import ProjectContext from '../context/Project';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 
 const ProjectEdit = () => {
@@ -19,6 +21,16 @@ const ProjectEdit = () => {
     return null;
   }
 
+  /**
+   * Redirect to the projects page if the user does not have permissions to access the project settings or data.
+   */
+  if (!(PermissionsService.canEditProjectSettings(projectId) || PermissionsService.canEditProjectData(projectId))) {
+    return <UnauthorizedRedirect />;
+  }
+
+  /**
+   * Redirect to the project edit page if no models have been added.
+   */
   if (loadedProjectModels && !projectModel) {
     return (
       <Navigate

--- a/client/src/pages/ProjectImportExport.js
+++ b/client/src/pages/ProjectImportExport.js
@@ -12,6 +12,7 @@ import {
 } from 'react-icons/bs';
 import { FaCode } from 'react-icons/fa';
 import { SlGraph } from 'react-icons/sl';
+import { Navigate } from 'react-router-dom';
 import {
   Button,
   Container,
@@ -181,6 +182,18 @@ const ProjectImportExport = () => {
       .catch(onImportError)
       .finally(() => setImportData(false));
   }, [onImportError, projectId]);
+
+  /**
+   * Return to the projects list if the user does not have permissions to edit this project.
+   */
+  if (!PermissionsService.canEditProjectSettings(projectId)) {
+    return (
+      <Navigate
+        replace
+        to='/projects'
+      />
+    );
+  }
 
   return (
     <Container

--- a/client/src/pages/ProjectImportExport.js
+++ b/client/src/pages/ProjectImportExport.js
@@ -12,7 +12,6 @@ import {
 } from 'react-icons/bs';
 import { FaCode } from 'react-icons/fa';
 import { SlGraph } from 'react-icons/sl';
-import { Navigate } from 'react-router-dom';
 import {
   Button,
   Container,
@@ -32,6 +31,7 @@ import ProjectContext from '../context/Project';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import ProjectsService from '../services/Projects';
 import styles from './ProjectImportExport.module.css';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 
 const ProjectImportExport = () => {
@@ -187,12 +187,7 @@ const ProjectImportExport = () => {
    * Return to the projects list if the user does not have permissions to edit this project.
    */
   if (!PermissionsService.canEditProjectSettings(projectId)) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/ProjectModels.js
+++ b/client/src/pages/ProjectModels.js
@@ -3,10 +3,11 @@
 import { ListTable } from '@performant-software/semantic-components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import PermissionsService from '../services/Permissions';
 import ProjectModelsService from '../services/ProjectModels';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 
 const ProjectModels = () => {
@@ -18,12 +19,7 @@ const ProjectModels = () => {
    * Return to the projects list if the user does not have permissions to edit this project.
    */
   if (!PermissionsService.canEditProjectSettings(projectId)) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/ProjectModels.js
+++ b/client/src/pages/ProjectModels.js
@@ -3,7 +3,8 @@
 import { ListTable } from '@performant-software/semantic-components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
+import PermissionsService from '../services/Permissions';
 import ProjectModelsService from '../services/ProjectModels';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import useParams from '../hooks/ParsedParams';
@@ -12,6 +13,18 @@ const ProjectModels = () => {
   const navigate = useNavigate();
   const { projectId } = useParams();
   const { t } = useTranslation();
+
+  /**
+   * Return to the projects list if the user does not have permissions to edit this project.
+   */
+  if (!PermissionsService.canEditProjectSettings(projectId)) {
+    return (
+      <Navigate
+        replace
+        to='/projects'
+      />
+    );
+  }
 
   return (
     <>

--- a/client/src/pages/Projects.js
+++ b/client/src/pages/Projects.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { ItemList, ItemViews } from '@performant-software/semantic-components';
+import cx from 'classnames';
 import React, { type AbstractComponent, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoSearchOutline } from 'react-icons/io5';
@@ -9,6 +10,8 @@ import { Icon } from 'semantic-ui-react';
 import PermissionsService from '../services/Permissions';
 import ProjectDescription from '../components/ProjectDescription';
 import ProjectsService from '../services/Projects';
+import { SlLock } from 'react-icons/sl';
+import styles from './Projects.module.css';
 
 const Projects: AbstractComponent<any> = () => {
   const navigate = useNavigate();
@@ -33,10 +36,15 @@ const Projects: AbstractComponent<any> = () => {
       addButton={addButton}
       as={Link}
       asProps={(project) => ({
-        to: `${project.id}/edit`,
-        raised: true
+        className: cx(
+          styles.card,
+          { [styles.disabled]: project.archived && !PermissionsService.canArchiveProject() }
+        ),
+        raised: true,
+        to: `${project.id}/edit`
       })}
       basic={false}
+      className={styles.projects}
       collectionName='projects'
       defaultView={ItemViews.grid}
       hideToggle
@@ -49,13 +57,22 @@ const Projects: AbstractComponent<any> = () => {
       )}
       renderEmptyList={() => null}
       renderExtra={(project) => (
-        <Icon
-          color='blue'
+        <Icon.Group
+          className={styles.icons}
         >
-          { project.discoverable && (
-            <IoSearchOutline />
+          { project.archived && (
+            <Icon>
+              <SlLock />
+            </Icon>
           )}
-        </Icon>
+          { project.discoverable && (
+            <Icon
+              color='blue'
+            >
+              <IoSearchOutline />
+            </Icon>
+          )}
+        </Icon.Group>
       )}
       onLoad={(params) => ProjectsService.fetchAll(params)}
       session={{

--- a/client/src/pages/Projects.module.css
+++ b/client/src/pages/Projects.module.css
@@ -1,0 +1,4 @@
+.projects .card.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/client/src/pages/User.js
+++ b/client/src/pages/User.js
@@ -3,9 +3,9 @@
 import { SimpleEditPage } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import React, { type AbstractComponent } from 'react';
-import { Navigate } from 'react-router-dom';
 import ItemHeader from '../components/ItemHeader';
 import PermissionsService from '../services/Permissions';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import { type User as UserType } from '../types/User';
 import UserEditMenu from '../components/UserEditMenu';
 import UserForm from '../components/UserForm';
@@ -23,12 +23,7 @@ const UserFormComponent = (props: Props) => {
   const { t } = useTranslation();
 
   if (!PermissionsService.canEditUsers()) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/UserProject.js
+++ b/client/src/pages/UserProject.js
@@ -4,13 +4,13 @@ import { AssociatedDropdown, SimpleEditPage } from '@performant-software/semanti
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import React, { useEffect, useMemo, type AbstractComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router-dom';
 import { Form } from 'semantic-ui-react';
 import ItemHeader from '../components/ItemHeader';
 import ItemLayout from '../components/ItemLayout';
 import PermissionsService from '../services/Permissions';
 import Project from '../transforms/Project';
 import ProjectsService from '../services/Projects';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import User from '../transforms/User';
 import type { UserProject as UserProjectType } from '../types/UserProject';
 import UserForm from '../components/UserForm';
@@ -84,22 +84,22 @@ const UserProjectForm = (props: Props) => {
     }
   }, []);
 
+  /**
+   * Redirect to the project edit page if we're in a project context and the user cannot edit user projects.
+   */
   if (params.projectId && !PermissionsService.canEditUserProjects(params.projectId)) {
     return (
-      <Navigate
-        replace
+      <UnauthorizedRedirect
         to={`/projects/${params.projectId}/edit`}
       />
     );
   }
 
+  /**
+   * Redirect to the projects page if we're in a user context and the users cannot edit users.
+   */
   if (params.userId && !PermissionsService.canEditUsers()) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -39,6 +39,9 @@ const UserProjects: AbstractComponent<any> = () => {
     }
   }, []);
 
+  /**
+   * Return to the projects list if the user does not have permissions to edit this project.
+   */
   if (projectId && !PermissionsService.canEditUserProjects(projectId)) {
     return (
       <Navigate
@@ -48,6 +51,9 @@ const UserProjects: AbstractComponent<any> = () => {
     );
   }
 
+  /**
+   * Return to the projects list if the user does not have permissions to edit users.
+   */
   if (userId && !PermissionsService.canEditUsers()) {
     return (
       <Navigate

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -8,10 +8,11 @@ import React, {
   type AbstractComponent
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import ItemHeader from '../components/ItemHeader';
 import PermissionsService from '../services/Permissions';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import UserEditMenu from '../components/UserEditMenu';
 import UserProjectRoles from '../utils/UserProjectRoles';
 import UserProjectsService from '../services/UserProjects';
@@ -90,8 +91,7 @@ const UserProjects: AbstractComponent<any> = () => {
    */
   if (projectId && !PermissionsService.canEditUserProjects(projectId)) {
     return (
-      <Navigate
-        replace
+      <UnauthorizedRedirect
         to={`/projects/${projectId}/edit`}
       />
     );
@@ -101,12 +101,7 @@ const UserProjects: AbstractComponent<any> = () => {
    * Return to the projects list if the user does not have permissions to edit users.
    */
   if (userId && !PermissionsService.canEditUsers()) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -3,8 +3,9 @@
 import { ListTable } from '@performant-software/semantic-components';
 import React, { type AbstractComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import PermissionsService from '../services/Permissions';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import UserRoles from '../utils/UserRoles';
 import UsersService from '../services/Users';
 
@@ -13,12 +14,7 @@ const Users: AbstractComponent<any> = () => {
   const { t } = useTranslation();
 
   if (!PermissionsService.canEditUsers()) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/WebAuthorities.js
+++ b/client/src/pages/WebAuthorities.js
@@ -3,9 +3,10 @@
 import React from 'react';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import { ListTable } from '@performant-software/semantic-components';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import PermissionsService from '../services/Permissions';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import WebAuthoritiesService from '../services/WebAuthorities';
 import WebAuthorityUtils from '../utils/WebAuthorities';
@@ -19,12 +20,7 @@ const WebAuthorities = () => {
    * Return to the projects list if the user does not have permissions to edit this project.
    */
   if (!PermissionsService.canEditProjectSettings(projectId)) {
-    return (
-      <Navigate
-        replace
-        to='/projects'
-      />
-    );
+    return <UnauthorizedRedirect />;
   }
 
   return (

--- a/client/src/pages/WebAuthorities.js
+++ b/client/src/pages/WebAuthorities.js
@@ -3,8 +3,9 @@
 import React from 'react';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import { ListTable } from '@performant-software/semantic-components';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import PermissionsService from '../services/Permissions';
 import useParams from '../hooks/ParsedParams';
 import WebAuthoritiesService from '../services/WebAuthorities';
 import WebAuthorityUtils from '../utils/WebAuthorities';
@@ -13,6 +14,18 @@ const WebAuthorities = () => {
   const { projectId } = useParams();
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  /**
+   * Return to the projects list if the user does not have permissions to edit this project.
+   */
+  if (!PermissionsService.canEditProjectSettings(projectId)) {
+    return (
+      <Navigate
+        replace
+        to='/projects'
+      />
+    );
+  }
 
   return (
     <>

--- a/client/src/pages/WebAuthority.js
+++ b/client/src/pages/WebAuthority.js
@@ -6,11 +6,13 @@ import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form } from 'semantic-ui-react';
 import AtomForm from '../components/AtomForm';
-import GeonamesForm from "../components/GeonamesForm";
 import DplaForm from '../components/DplaForm';
+import GeonamesForm from '../components/GeonamesForm';
 import ItemLayout from '../components/ItemLayout';
 import ItemHeader from '../components/ItemHeader';
+import PermissionsService from '../services/Permissions';
 import styles from './ProjectModel.module.css';
+import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
 import type { WebAuthority as WebAuthorityType } from '../types/WebAuthority';
@@ -55,6 +57,10 @@ const WebAuthorityPage = (props: Props) => {
       props.onSetState({ project_id: projectId });
     }
   }, []);
+
+  if (!PermissionsService.canEditProjectSettings(projectId)) {
+    return <UnauthorizedRedirect />;
+  }
 
   return (
     <ItemLayout>

--- a/client/src/services/Permissions.js
+++ b/client/src/services/Permissions.js
@@ -1,10 +1,11 @@
 // @flow
 
 import _ from 'underscore';
-import type { User as UserType } from '../types/User';
 import type { Ownable as OwnableType } from '../types/Ownable';
 import type { ProjectModel as ProjectModelType } from '../types/ProjectModel';
 import SessionService from './Session';
+import type { User as UserType } from '../types/User';
+import type { UserProject } from '../types/UserProject';
 import UserProjectRoles from '../utils/UserProjectRoles';
 import UserRoles from '../utils/UserRoles';
 
@@ -12,6 +13,15 @@ import UserRoles from '../utils/UserRoles';
  * Class responsible for permissions business logic.
  */
 class Permissions {
+  /**
+   * An admin user can archive a project.
+   *
+   * @returns {boolean}
+   */
+  canArchiveProject(): boolean {
+    return this.isAdmin();
+  }
+
   /**
    * An admin user or a member user can create a new project.
    *
@@ -34,7 +44,7 @@ class Permissions {
       return false;
     }
 
-    return this.isAdmin() || this.isOwner(projectId);
+    return this.isAdmin() || (this.isOwner(projectId) && !this.isArchived(projectId));
   }
 
   /**
@@ -45,8 +55,15 @@ class Permissions {
    *
    * @returns {boolean}
    */
-  canDeleteRecord(projectModel: ProjectModelType, record: OwnableType) {
+  canDeleteRecord(projectModel: ProjectModelType, record: OwnableType): boolean {
     if (!(projectModel && record)) {
+      return false;
+    }
+
+    /**
+     * Records cannot be deleted from archived projects.
+     */
+    if (this.isArchived(projectModel.project_id)) {
       return false;
     }
 
@@ -68,19 +85,32 @@ class Permissions {
   }
 
   /**
-   * An admin user or project owner can edit a project.
+   * An admin user can always modify project data. A project owner or editor can modify the project data if the project
+   * is not archived.
    *
    * @param projectId
    *
    * @returns {boolean}
    */
-  canEditProject(projectId: number): boolean {
+  canEditProjectData(projectId: number): boolean {
+    return this.isAdmin() || ((this.isOwner(projectId) || this.isEditor(projectId)) && !this.isArchived(projectId));
+  }
+
+  /**
+   * An admin user can always modify project settings. A project owner can modify project settings if the project
+   * is not archived.
+   *
+   * @param projectId
+   *
+   * @returns {boolean}
+   */
+  canEditProjectSettings(projectId: number): boolean {
     // New projects can always be edited
     if (!projectId) {
       return true;
     }
 
-    return this.isAdmin() || this.isOwner(projectId);
+    return this.isAdmin() || (this.isOwner(projectId) && !this.isArchived(projectId));
   }
 
   /**
@@ -91,7 +121,7 @@ class Permissions {
    * @returns {boolean}
    */
   canEditUserProjects(projectId: number): boolean {
-    return this.isAdmin() || (this.isMember() && this.isOwner(projectId));
+    return this.isAdmin() || (this.isMember() && this.isOwner(projectId) && !this.isArchived(projectId));
   }
 
   /**
@@ -132,12 +162,60 @@ class Permissions {
   }
 
   /**
+   * Returns the user project record for the project with the passed ID for the current user.
+   *
+   * @param projectId
+   *
+   * @returns {*}
+   */
+  getUserProject(projectId: number): UserProject {
+    const userProjects = this.getUserProjects();
+    return _.findWhere(userProjects, { project_id: projectId });
+  }
+
+  /**
+   * Returns the user project records for the current user.
+   *
+   * @returns {Array<UserProject>}
+   */
+  getUserProjects(): Array<UserProject> {
+    const user = this.getUser();
+    const { user_projects: userProjects } = user || {};
+
+    return userProjects;
+  }
+
+  /**
    * Returns true if the current user has the "admin" role.
    *
    * @returns {boolean}
    */
   isAdmin(): boolean {
     return UserRoles.isAdmin(this.getUser());
+  }
+
+  /**
+   * Returns true if the passed project is archived.
+   *
+   * @param projectId
+   *
+   * @returns {boolean}
+   */
+  isArchived(projectId: number): boolean {
+    const userProject = this.getUserProject(projectId);
+    return userProject?.project?.archived;
+  }
+
+  /**
+   * Returns true if the current user has the editor role in the passed project.
+   *
+   * @param projectId
+   *
+   * @returns {boolean}
+   */
+  isEditor(projectId: number): boolean {
+    const userProject = this.getUserProject(projectId);
+    return UserProjectRoles.isEditor(userProject);
   }
 
   /**
@@ -166,13 +244,8 @@ class Permissions {
    * @returns {boolean}
    */
   isOwner(projectId: number): boolean {
-    const user = this.getUser();
-    const { user_projects: userProjects } = user || {};
-
-    return !!_.findWhere(userProjects, {
-      project_id: projectId,
-      role: UserProjectRoles.Roles.owner.value
-    });
+    const userProject = this.getUserProject(projectId);
+    return UserProjectRoles.isOwner(userProject);
   }
 }
 

--- a/client/src/transforms/Project.js
+++ b/client/src/transforms/Project.js
@@ -29,7 +29,8 @@ class Project extends BaseTransform {
       'discoverable',
       'faircopy_cloud_url',
       'faircopy_cloud_project_model_id',
-      'map_library_url'
+      'map_library_url',
+      'archived'
     ];
   }
 

--- a/client/src/types/Project.js
+++ b/client/src/types/Project.js
@@ -8,4 +8,5 @@ export type Project = {
   faircopy_cloud_url: string,
   faircopy_cloud_project_model_id: number,
   map_library_url: string,
+  archived: boolean
 };

--- a/client/src/utils/UserProjectRoles.js
+++ b/client/src/utils/UserProjectRoles.js
@@ -2,6 +2,7 @@
 
 import _ from 'underscore';
 import i18n from '../i18n/i18n';
+import type { UserProject } from '../types/UserProject';
 
 type RolesType = {
   [key: string]: {
@@ -21,19 +22,61 @@ const Roles: RolesType = {
   }
 };
 
+/**
+ * Returns the list of role options.
+ *
+ * @returns {*}
+ */
 const getRoleOptions = (): any => _.map(_.keys(Roles), (key) => ({
   key: Roles[key].value,
   value: Roles[key].value,
   text: Roles[key].label
 }));
 
+/**
+ * Returns the label for the passed role value.
+ *
+ * @param value
+ *
+ * @returns {*}
+ */
 const getRoleView = (value: string): string => {
   const role = _.findWhere(_.values(Roles), { value });
   return role?.label;
 };
 
+/**
+ * Returns true if the passed user project has the passed role.
+ *
+ * @param userProject
+ * @param role
+ *
+ * @returns {boolean}
+ */
+const hasRole = (userProject: UserProject, role: string): boolean => userProject?.role === role;
+
+/**
+ * Returns true if the passed user project record has the editor role.
+ *
+ * @param userProject
+ *
+ * @returns {boolean}
+ */
+const isEditor = (userProject: UserProject) => hasRole(userProject, Roles.editor.value);
+
+/**
+ * Returns true if the passed user project record has the owner role.
+ *
+ * @param userProject
+ *
+ * @returns {boolean}
+ */
+const isOwner = (userProject: UserProject) => hasRole(userProject, Roles.owner.value);
+
 export default {
   Roles,
   getRoleOptions,
-  getRoleView
+  getRoleView,
+  isEditor,
+  isOwner
 };

--- a/db/migrate/20250603163023_add_archived_to_projects.core_data_connector.rb
+++ b/db/migrate/20250603163023_add_archived_to_projects.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250603154715)
+class AddArchivedToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_projects, :archived, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_03_111812) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_03_163023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -224,6 +224,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_03_111812) do
     t.string "faircopy_cloud_url"
     t.integer "faircopy_cloud_project_model_id"
     t.string "map_library_url"
+    t.boolean "archived", default: false, null: false
   end
 
   create_table "core_data_connector_record_merges", force: :cascade do |t|


### PR DESCRIPTION
This pull request adds the archive checkbox to the project edit page (only available to admin users), updates the projects list to "disable" clicking on any archived projects, and adds redirects to the various pages for users who do not have access.

## Admin

### Archive Project
Admin users will have the ability to mark a project as archived.

![Screenshot 2025-06-05 at 3 44 31 PM](https://github.com/user-attachments/assets/af8ac1b2-71fe-4b4e-a8ed-0d4da88ccfe3)

### Projects List
On the projects list, a lock icon will display on the project card to indicate the project is archived, but admin users will still be able to view/modify the project.

![Screenshot 2025-06-05 at 3 44 40 PM](https://github.com/user-attachments/assets/3ca6389d-1a3e-41ec-9e0c-55ae03c2d121)

## Non-admin

### Projects List
For non-admin users, the project card will appear "disabled" an users will not be allowed to click on the link to view the project.

![Screenshot 2025-06-05 at 3 44 53 PM](https://github.com/user-attachments/assets/6985292b-eddf-4409-8497-4236294b03dc)

### Redirect
If a non-admin user attempts to access a resource for which they do not have permissions, they will be redirected elsewhere and a notification will be displayed.

![Screenshot 2025-06-11 at 10 22 22 AM](https://github.com/user-attachments/assets/9c06f2ad-dea0-4a3a-aa94-fe5394badb06)
