### PR TITLE
CDC #443 - User passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,11 +28,15 @@ IIIF_CLOUD_URL=https://iiif-cloud-staging.herokuapp.com/
 # The ID of the project in IIIF Cloud in which to store resources.
 IIIF_CLOUD_PROJECT_ID=1
 
-#
+# Postmark API token.
 POSTMARK_API_TOKEN=abc123
 
-#
-POSTMARK_EMAIL_FROM=no-reply@app.coredata.cloud
+# Postmark "from" email. This address must be setup in the "Send Signatures" section of PostMark.
+POSTMARK_FROM=no-reply@app.coredata.cloud
+
+# Postmark email interval (in hours). The application will not allow users to send multiple
+# emails within this interval.
+POSTMARK_INTERVAL=24
 
 # The hostname of the Core Data Cloud CMS
 REACT_APP_HOSTNAME=http://localhost:3001
@@ -42,6 +46,10 @@ REACT_APP_IIIF_MANIFEST_ITEM_LIMIT=1000
 
 # MapTiler API key.
 REACT_APP_MAP_TILER_KEY=abc
+
+# Postmark email interval (in hours). The application will not allow users to send multiple
+# emails within this interval.
+REACT_APP_POSTMARK_INTERVAL=24
 
 # A base secret for Rails.
 SECRET_KEY_BASE=339485u34895u4398u58394u543u59834u958u347y62347632t47235467235674

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ IIIF_CLOUD_URL=https://iiif-cloud-staging.herokuapp.com/
 # The ID of the project in IIIF Cloud in which to store resources.
 IIIF_CLOUD_PROJECT_ID=1
 
+#
+POSTMARK_API_TOKEN=abc123
+
+#
+POSTMARK_EMAIL_FROM=no-reply@app.coredata.cloud
+
 # The hostname of the Core Data Cloud CMS
 REACT_APP_HOSTNAME=http://localhost:3001
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'jwt', '~> 2.4', '>= 2.4.1'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.18'
 
+# Transactional emails
+gem 'postmark-rails', '~> 0.22.1'
+
 # Resource API
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.12'
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.2'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.90'
+#gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.90'
+gem 'core_data_connector', path: '../core-data-connector'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 13e37c91306b8766fbde8fb168d4512b94a8316a
-  tag: v0.1.90
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 8.0)
-      faker
-      fuzzy_dates
-      jwt (~> 2.7.1)
-      jwt_auth
-      rack-cors (~> 2.0.1)
-      rails (>= 6.0.3.2, < 8)
-      resource_api
-      rexml (~> 3.2)
-      rgeo-geojson (~> 2.1)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 0.14)
-      typhoeus (~> 1.4)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: fa3f237882f9c89888f82af41f6fe2b8ff2281a3
   tag: v0.1.0
@@ -65,6 +43,26 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 8)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 8.0)
+      faker
+      fuzzy_dates
+      jwt (~> 2.7.1)
+      jwt_auth
+      rack-cors (~> 2.0.1)
+      rails (>= 6.0.3.2, < 8)
+      resource_api
+      rexml (~> 3.2)
+      rgeo-geojson (~> 2.1)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 0.14)
+      typhoeus (~> 1.4)
+      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -158,8 +156,6 @@ GEM
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ PATH
       fuzzy_dates
       jwt (~> 2.7.1)
       jwt_auth
+      postmark-rails (~> 0.22.1)
       rack-cors (~> 2.0.1)
       rails (>= 6.0.3.2, < 8)
       resource_api
@@ -156,6 +157,8 @@ GEM
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)
@@ -166,6 +169,7 @@ GEM
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
+    json (2.12.2)
     jwt (2.7.1)
     loofah (2.21.3)
       crass (~> 1.0.2)
@@ -209,6 +213,11 @@ GEM
     pagy (5.10.1)
       activesupport
     pg (1.5.3)
+    postmark (1.25.1)
+      json
+    postmark-rails (0.22.1)
+      actionmailer (>= 3.0.0)
+      postmark (>= 1.21.3, < 2.0)
     puma (5.6.7)
       nio4r (~> 2.0)
     pundit (2.3.1)
@@ -291,6 +300,7 @@ DEPENDENCIES
   jwt_auth!
   pagy (~> 5.10)
   pg (~> 1.5.3)
+  postmark-rails (~> 0.22.1)
   puma (~> 5.0)
   rack-cors (~> 2.0.1)
   rails (~> 7.0.7)

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import AuthenticatedRoute from './components/AuthenticatedRoute';
 import Layout from './components/Layout';
 import Login from './pages/Login';
 import Logout from './pages/Logout';
+import PasswordReset from './pages/PasswordReset';
 import Project from './pages/Project';
 import ProjectContextProvider from './components/ProjectContextProvider';
 import ProjectEdit from './pages/ProjectEdit';
@@ -184,6 +185,10 @@ const App: ComponentType<any> = useDragDrop(() => (
             </Route>
           </Route>
         </Route>
+        <Route
+          path='password_reset'
+          element={<PasswordReset />}
+        />
       </Route>
     </Routes>
   </Router>

--- a/client/src/components/AuthenticatedRoute.js
+++ b/client/src/components/AuthenticatedRoute.js
@@ -1,16 +1,36 @@
 // @flow
 
-import React, { type ComponentType, type Node } from 'react';
-import { Navigate } from 'react-router-dom';
+import React, { type ComponentType, type Node, useCallback } from 'react';
+import { matchPath, Navigate, useLocation } from 'react-router-dom';
 import AuthenticationService from '../services/Authentication';
+import SessionService from '../services/Session';
 
 type Props = {
   children: Array<Node>
 };
 
 const AuthenticatedRoute: ComponentType<any> = ({ children }: Props) => {
+  const location = useLocation();
+
+  /**
+   * Returns true if the passed path matches the users current location.
+   *
+   * @type {function(*): boolean}
+   */
+  const isPath = useCallback((path) => !!matchPath({ path, exact: true }, location.pathname), [location.pathname]);
+
+  /**
+   * Navigate to the root route if the user is not authenticated.
+   */
   if (!AuthenticationService.isAuthenticated()) {
     return <Navigate to='/' />;
+  }
+
+  /**
+   * Navigate to the password reset route if the current user is required to change their password.
+   */
+  if (SessionService.isPasswordChangeRequired() && !(isPath('/password_reset') || isPath('/logout'))) {
+    return <Navigate to='/password_reset' />;
   }
 
   return children;

--- a/client/src/components/UserForm.js
+++ b/client/src/components/UserForm.js
@@ -35,16 +35,25 @@ const UserForm: AbstractComponent<any> = (props: Props) => {
         value={props.item.email}
       />
       { PermissionsService.isAdmin() && (
-        <Form.Dropdown
-          error={props.isError('role')}
-          label={t('UserForm.labels.role')}
-          onChange={props.onTextInputChange.bind(this, 'role')}
-          options={UserRoles.getRoleOptions()}
-          required={props.isRequired('role')}
-          selection
-          selectOnBlur={false}
-          value={props.item.role}
-        />
+        <>
+          <Form.Dropdown
+            error={props.isError('role')}
+            label={t('UserForm.labels.role')}
+            onChange={props.onTextInputChange.bind(this, 'role')}
+            options={UserRoles.getRoleOptions()}
+            required={props.isRequired('role')}
+            selection
+            selectOnBlur={false}
+            value={props.item.role}
+          />
+          <Form.Checkbox
+            checked={props.item.require_password_change}
+            error={props.isError('require_password_change')}
+            label={t('UserForm.labels.requirePasswordChange')}
+            onChange={props.onCheckboxInputChange.bind(this, 'require_password_change')}
+            required={props.isRequired('require_password_change')}
+          />
+        </>
       )}
     </>
   );

--- a/client/src/components/UserMenu.js
+++ b/client/src/components/UserMenu.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { RiLockPasswordLine } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
 import { Dropdown, Header, Icon } from 'semantic-ui-react';
+import PermissionsService from '../services/Permissions';
 import SessionService from '../services/Session';
 import styles from './UserMenu.module.css';
 import UserAvatar from './UserAvatar';
@@ -37,16 +38,18 @@ const UserMenu = () => {
       <Dropdown.Menu
         className={styles.menu}
       >
-        <Dropdown.Item
-          as={Link}
-          className={styles.item}
-          to='/password_reset'
-        >
-          <Icon>
-            <RiLockPasswordLine />
-          </Icon>
-          { t('UserMenu.labels.resetPassword') }
-        </Dropdown.Item>
+        { PermissionsService.canResetPassword() && (
+          <Dropdown.Item
+            as={Link}
+            className={styles.item}
+            to='/password_reset'
+          >
+            <Icon>
+              <RiLockPasswordLine />
+            </Icon>
+            { t('UserMenu.labels.resetPassword') }
+          </Dropdown.Item>
+        )}
         <Dropdown.Item
           as={Link}
           className={styles.item}

--- a/client/src/components/UserMenu.js
+++ b/client/src/components/UserMenu.js
@@ -3,6 +3,7 @@
 import cx from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { RiLockPasswordLine } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
 import { Dropdown, Header, Icon } from 'semantic-ui-react';
 import SessionService from '../services/Session';
@@ -33,9 +34,22 @@ const UserMenu = () => {
       direction='left'
       trigger={trigger}
     >
-      <Dropdown.Menu>
+      <Dropdown.Menu
+        className={styles.menu}
+      >
         <Dropdown.Item
           as={Link}
+          className={styles.item}
+          to='/password_reset'
+        >
+          <Icon>
+            <RiLockPasswordLine />
+          </Icon>
+          { t('UserMenu.labels.resetPassword') }
+        </Dropdown.Item>
+        <Dropdown.Item
+          as={Link}
+          className={styles.item}
           to='/logout'
         >
           <Icon

--- a/client/src/components/UserMenu.module.css
+++ b/client/src/components/UserMenu.module.css
@@ -7,3 +7,8 @@
 .userMenu.ui.dropdown > .ui.header {
   margin: 0rem 0rem 0rem 1rem;
 }
+
+.userMenu.ui.dropdown > .menu > .item {
+  display: flex;
+  align-items: center;
+}

--- a/client/src/components/UserPassword.js
+++ b/client/src/components/UserPassword.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Form, Message } from 'semantic-ui-react';
 
 type Props = EditContainerProps & {
+  autoFocus?: boolean,
   email: string
 };
 
@@ -19,6 +20,7 @@ const UserPassword = (props: Props) => {
         header={t('UserPassword.messages.password.header')}
       />
       <Form.Input
+        autoFocus={props.autoFocus}
         error={props.isError('password')}
         label={t('UserPassword.labels.password')}
         onChange={props.onTextInputChange.bind(this, 'password')}

--- a/client/src/components/UserPassword.js
+++ b/client/src/components/UserPassword.js
@@ -15,10 +15,18 @@ const UserPassword = (props: Props) => {
 
   return (
     <>
-      <Message
-        content={t('UserPassword.messages.password.content')}
-        header={t('UserPassword.messages.password.header')}
-      />
+      <Message>
+        <Message.Header
+          content={t('UserPassword.messages.password.header')}
+        />
+        <Message.List>
+          <Message.Item>{ t('UserPassword.messages.password.length') }</Message.Item>
+          <Message.Item>{ t('UserPassword.messages.password.number') }</Message.Item>
+          <Message.Item>{ t('UserPassword.messages.password.lower') }</Message.Item>
+          <Message.Item>{ t('UserPassword.messages.password.upper') }</Message.Item>
+          <Message.Item>{ t('UserPassword.messages.password.symbol') }</Message.Item>
+        </Message.List>
+      </Message>
       <Form.Input
         autoFocus={props.autoFocus}
         error={props.isError('password')}

--- a/client/src/components/UserStatus.js
+++ b/client/src/components/UserStatus.js
@@ -3,22 +3,29 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Label } from 'semantic-ui-react';
+import type { User as UserType } from '../types/User';
 
 type Props = {
-  lastSignIn: number
+  user: UserType
 };
 
 const UserStatus = (props: Props) => {
   const { t } = useTranslation();
 
+  if (props.user?.last_sign_in_at) {
+    return (
+      <Label
+        color='green'
+        content={t('UserStatus.labels.active')}
+        icon='checkmark'
+      />
+    );
+  }
+
   return (
     <Label
-      color={props.lastSignIn
-        ? 'green'
-        : 'undefined'}
-      content={props.lastSignIn
-        ? t('UserStatus.labels.active')
-        : t('UserStatus.labels.pending')}
+      content={t('UserStatus.labels.pending')}
+      icon='clock outline'
     />
   );
 };

--- a/client/src/components/UserStatus.js
+++ b/client/src/components/UserStatus.js
@@ -1,0 +1,26 @@
+// @flow
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Label } from 'semantic-ui-react';
+
+type Props = {
+  lastSignIn: number
+};
+
+const UserStatus = (props: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <Label
+      color={props.lastSignIn
+        ? 'green'
+        : 'undefined'}
+      content={props.lastSignIn
+        ? t('UserStatus.labels.active')
+        : t('UserStatus.labels.pending')}
+    />
+  );
+};
+
+export default UserStatus;

--- a/client/src/hooks/ReactRouterEditPage.js
+++ b/client/src/hooks/ReactRouterEditPage.js
@@ -26,11 +26,21 @@ const withReactRouterEditPage = (WrappedComponent: AbstractComponent<any>, confi
      * After save, navigate to the newly created record. We'll also add the "saved" attribute to indicate a message
      * should be displayed to the user.
      *
+     * If an "afterSave" attribute is passed, determine where to navigate based on the attribute.
+     *
      * @type {function(*, string): *}
      */
-    const afterSave = useCallback((item: any) => (
-      navigate(`${url}/${item.id}`, { state: { saved: true } })
-    ), [navigate, url]);
+    const afterSave = useCallback((item: any) => {
+      if (config.afterSave && _.isFunction(config.afterSave)) {
+        return config.afterSave(navigate, item);
+      }
+
+      if (config.afterSave && _.isString(config.afterSave)) {
+        return navigate(config.afterSave, { state: { saved: true } });
+      }
+
+      return navigate(`${url}/${item.id}`, { state: { saved: true } })
+    }, [navigate, url, config.afterSave]);
 
     /**
      * Navigates to the previous route.

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -413,6 +413,17 @@
       "name": "Name"
     }
   },
+  "PasswordReset": {
+    "labels": {
+      "back": "Back"
+    },
+    "messages": {
+      "required": {
+        "content": "You must change your password to continue.",
+        "header": "Password Reset Required"
+      }
+    }
+  },
   "People": {
     "actions": {
       "merge": {
@@ -881,12 +892,14 @@
     "labels": {
       "email": "Email",
       "name": "Name",
+      "requirePasswordChange": "Require password change",
       "role": "Role"
     }
   },
   "UserMenu": {
     "labels": {
-      "logout": "Logout"
+      "logout": "Logout",
+      "resetPassword": "Reset password"
     }
   },
   "UserModal": {
@@ -943,6 +956,7 @@
     "columns": {
       "email": "Email",
       "name": "Name",
+      "passwordChange": "Password change",
       "role": "Role"
     }
   },

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -936,6 +936,12 @@
     }
   },
   "UserProjects": {
+    "actions": {
+      "invite": {
+        "content": "Send an email invitation to the user",
+        "header": "Invite User"
+      }
+    },
     "columns": {
       "email": "Email",
       "project": "Project",
@@ -945,6 +951,13 @@
     },
     "labels": {
       "allUsers": "All Users"
+    },
+    "messages": {
+      "invitation": {
+        "content": "Your invitation was successfully sent to {{email}}.",
+        "error": "Error Sending Invitation",
+        "header": "Invitation Sent!"
+      }
     }
   },
   "UserRoles": {
@@ -963,6 +976,7 @@
   "Users": {
     "columns": {
       "email": "Email",
+      "lastInvited": "Last invited",
       "lastSignIn": "Last sign in",
       "name": "Name",
       "passwordChange": "Password change",

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -878,6 +878,12 @@
     }
   },
   "User": {
+    "errors": {
+      "password": {
+        "format": "The password you entered does not meet the requirements",
+        "match": "The passwords you entered do not match"
+      }
+    },
     "labels": {
       "allUsers": "All Users"
     }
@@ -915,8 +921,12 @@
     },
     "messages": {
       "password": {
-        "content": "Passwords must be at least eight (8) characters.",
-        "header": "Password Policy"
+        "header": "Password Policy",
+        "length": "Passwords must be at least eight (8) characters",
+        "lower": "Passwords must contain at least one lowercase character",
+        "number": "Passwords must contain at least one number",
+        "symbol": "Passwords must contain at least one symbol",
+        "upper": "Passwords must contain at least one uppercase character"
       }
     }
   },

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -937,8 +937,10 @@
   },
   "UserProjects": {
     "columns": {
+      "email": "Email",
       "project": "Project",
       "role": "Role",
+      "status": "Status",
       "user": "User"
     },
     "labels": {
@@ -952,9 +954,16 @@
       "member": "Member"
     }
   },
+  "UserStatus": {
+    "labels": {
+      "active": "Active",
+      "pending": "Pending"
+    }
+  },
   "Users": {
     "columns": {
       "email": "Email",
+      "lastSignIn": "Last sign in",
       "name": "Name",
       "passwordChange": "Password change",
       "role": "Role"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -86,8 +86,8 @@ textarea {
   min-height: unset;
 }
 
-.list > .header > .ui.grid > .row > .column > .ui.menu .ui.button.dropdown:focus,
-.list > .header > .ui.grid > .row > .column > .ui.menu .ui.button.dropdown:hover {
+.list > .header > .ui.grid > .row > .column > .ui.menu .ui.button.basic.dropdown:focus,
+.list > .header > .ui.grid > .row > .column > .ui.menu .ui.button.basic.dropdown:hover {
   background-color: transparent !important;
 }
 

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -8,6 +8,7 @@ import PermissionsService from '../services/Permissions';
 import SessionService from '../services/Session';
 import UserPassword from '../components/UserPassword';
 import UsersService from '../services/Users';
+import UserUtils from '../utils/User';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
 const PasswordResetForm = (props) => {
@@ -79,7 +80,8 @@ const PasswordReset: AbstractComponent<any> = withReactRouterEditPage(PasswordRe
       .save({ ...user, id })
       .then(({ data }) => data.user);
   },
-  required: ['password', 'password_confirmation']
+  required: ['password', 'password_confirmation'],
+  validate: UserUtils.validatePassword.bind(this)
 });
 
 export default PasswordReset;

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -1,0 +1,79 @@
+import { SimpleEditPage, Toaster } from '@performant-software/semantic-components';
+import React, { type AbstractComponent, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MessageHeader } from 'semantic-ui-react';
+import ItemHeader from '../components/ItemHeader';
+import PermissionsService from '../services/Permissions';
+import SessionService from '../services/Session';
+import UserPassword from '../components/UserPassword';
+import UsersService from '../services/Users';
+import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
+
+const PasswordResetForm = (props) => {
+  const [toaster, setToaster] = useState(SessionService.isPasswordChangeRequired());
+
+  const { t } = useTranslation();
+  const { user } = SessionService.getSession();
+
+  /**
+   * Memo-izes the "back" url based on whether the user is required to change their password.
+   *
+   * @type {string}
+   */
+  const url = useMemo(() => (SessionService.isPasswordChangeRequired() ? '/logout' : '/projects'), []);
+
+  return (
+    <>
+      <ItemHeader
+        back={{
+          label: t('PasswordReset.labels.back'),
+          url
+        }}
+        name={user?.name}
+      />
+      <SimpleEditPage
+        {...props}
+      >
+        <SimpleEditPage.Tab
+          key='default'
+        >
+          <UserPassword
+            {...props}
+            autoFocus
+          />
+        </SimpleEditPage.Tab>
+      </SimpleEditPage>
+      { toaster && (
+        <Toaster
+          onDismiss={() => setToaster(false)}
+          timeout={0}
+          type='warning'
+        >
+          <MessageHeader
+            content={t('PasswordReset.messages.required.header')}
+          />
+          <p>{ t('PasswordReset.messages.required.content') }</p>
+        </Toaster>
+      )}
+    </>
+  );
+};
+
+const PasswordReset: AbstractComponent<any> = withReactRouterEditPage(PasswordResetForm, {
+  afterSave: (navigate) => (
+    SessionService
+      .reset()
+      .then(() => navigate('/projects', { state: { saved: true } }))
+  ),
+  onSave: (user) => {
+    const currentUser = PermissionsService.getUser();
+    const { id } = currentUser;
+
+    return UsersService
+      .save({ ...user, id })
+      .then(({ data }) => data.user);
+  },
+  required: ['password', 'password_confirmation']
+});
+
+export default PasswordReset;

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -1,6 +1,7 @@
 import { SimpleEditPage, Toaster } from '@performant-software/semantic-components';
 import React, { type AbstractComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Navigate } from 'react-router-dom';
 import { MessageHeader } from 'semantic-ui-react';
 import ItemHeader from '../components/ItemHeader';
 import PermissionsService from '../services/Permissions';
@@ -14,6 +15,18 @@ const PasswordResetForm = (props) => {
 
   const { t } = useTranslation();
   const { user } = SessionService.getSession();
+
+  /**
+   * Navigate to the projects list if the current user does not have permissions to reset passwords.
+   */
+  if (!PermissionsService.canResetPassword()) {
+    return (
+      <Navigate
+        replace
+        to='/projects'
+      />
+    );
+  }
 
   return (
     <>

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -1,5 +1,5 @@
 import { SimpleEditPage, Toaster } from '@performant-software/semantic-components';
-import React, { type AbstractComponent, useMemo, useState } from 'react';
+import React, { type AbstractComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MessageHeader } from 'semantic-ui-react';
 import ItemHeader from '../components/ItemHeader';
@@ -15,19 +15,12 @@ const PasswordResetForm = (props) => {
   const { t } = useTranslation();
   const { user } = SessionService.getSession();
 
-  /**
-   * Memo-izes the "back" url based on whether the user is required to change their password.
-   *
-   * @type {string}
-   */
-  const url = useMemo(() => (SessionService.isPasswordChangeRequired() ? '/logout' : '/projects'), []);
-
   return (
     <>
       <ItemHeader
-        back={{
+        back={SessionService.isPasswordChangeRequired() ? undefined : {
           label: t('PasswordReset.labels.back'),
-          url
+          url: '/projects'
         }}
         name={user?.name}
       />

--- a/client/src/pages/Projects.js
+++ b/client/src/pages/Projects.js
@@ -4,15 +4,18 @@ import { ItemList, ItemViews } from '@performant-software/semantic-components';
 import React, { type AbstractComponent, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoSearchOutline } from 'react-icons/io5';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Icon } from 'semantic-ui-react';
 import PermissionsService from '../services/Permissions';
 import ProjectDescription from '../components/ProjectDescription';
 import ProjectsService from '../services/Projects';
 
 const Projects: AbstractComponent<any> = () => {
+  const location = useLocation();
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  const { saved } = location?.state || {};
 
   /**
    * Memo-izes the add button value based on the current user's permissions.
@@ -58,6 +61,7 @@ const Projects: AbstractComponent<any> = () => {
         </Icon>
       )}
       onLoad={(params) => ProjectsService.fetchAll(params)}
+      saved={saved}
       session={{
         key: 'projects',
         storage: localStorage

--- a/client/src/pages/User.js
+++ b/client/src/pages/User.js
@@ -73,7 +73,8 @@ const User: AbstractComponent<any> = withReactRouterEditPage(UserFormComponent, 
       .save(user)
       .then(({ data }) => data.user)
   ),
-  required: ['name', 'email', 'role']
+  required: ['name', 'email', 'role'],
+  validate: UserUtils.validatePassword.bind(this)
 });
 
 export default User;

--- a/client/src/pages/UserProject.js
+++ b/client/src/pages/UserProject.js
@@ -15,12 +15,9 @@ import User from '../transforms/User';
 import type { UserProject as UserProjectType } from '../types/UserProject';
 import UserForm from '../components/UserForm';
 import UserModal from '../components/UserModal';
-import UserPassword from '../components/UserPassword';
 import UserProjectRoles from '../utils/UserProjectRoles';
 import UserProjectsService from '../services/UserProjects';
-import UserRoles from '../utils/UserRoles';
 import UsersService from '../services/Users';
-import UserUtils from '../utils/User';
 import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
@@ -46,30 +43,6 @@ const UserProjectForm = (props: Props) => {
    * @type {boolean}
    */
   const isOwner = useMemo(() => PermissionsService.isOwner(props.item.project_id), [props.item.project_id]);
-
-  /**
-   * Memo-izes if the password is editable for the current user.
-   */
-  const isPasswordEditable = useMemo(() => {
-    // Passwords for single sign on users cannot be changed
-    if (UserUtils.isSingleSignOn(props.item.user?.email)) {
-      return false;
-    }
-
-    let value = false;
-
-    // Users with edit permissions on users can change a password
-    if (PermissionsService.canEditUsers()) {
-      value = true;
-    }
-
-    // Project owners can change a password for guest users
-    if (isOwner && (isNew || UserRoles.isGuest(props.item.user))) {
-      value = true;
-    }
-
-    return value;
-  }, [isNew, isOwner, props.item.user]);
 
   /*
    * For a new record, set the foreign key ID based on the route parameters.
@@ -186,11 +159,6 @@ const UserProjectForm = (props: Props) => {
               selectOnBlur={false}
               value={props.item.role}
             />
-            { isPasswordEditable && (
-              <UserPassword
-                {...props}
-              />
-            )}
           </SimpleEditPage.Tab>
         </SimpleEditPage>
       </ItemLayout.Content>

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -15,6 +15,7 @@ import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import UserEditMenu from '../components/UserEditMenu';
 import UserProjectRoles from '../utils/UserProjectRoles';
 import UserProjectsService from '../services/UserProjects';
+import UserStatus from '../components/UserStatus';
 import UsersService from '../services/Users';
 import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
@@ -96,19 +97,34 @@ const UserProjects: AbstractComponent<any> = () => {
         columns={[{
           name: 'core_data_connector_projects.name',
           label: t('UserProjects.columns.project'),
-          resolve: (userProject) => userProject?.project.name,
+          resolve: (userProject) => userProject?.project?.name,
           sortable: true,
           hidden: !!projectId
         }, {
           name: 'core_data_connector_users.name',
           label: t('UserProjects.columns.user'),
-          resolve: (userProject) => userProject?.user.name,
+          resolve: (userProject) => userProject?.user?.name,
+          sortable: true,
+          hidden: !!userId
+        }, {
+          name: 'core_data_connector_users.email',
+          label: t('UserProjects.columns.email'),
+          resolve: (userProject) => userProject?.user?.email,
           sortable: true,
           hidden: !!userId
         }, {
           name: 'core_data_connector_user_projects.role',
           label: t('UserProjects.columns.role'),
           resolve: (userProject) => UserProjectRoles.getRoleView(userProject.role),
+          sortable: true
+        }, {
+          name: 'core_data_connector_users.last_sign_in_at',
+          label: t('UserProjects.columns.status'),
+          render: (userProject) => (
+            <UserStatus
+              lastSignIn={userProject.user?.last_sign_in_at}
+            />
+          ),
           sortable: true
         }]}
         collectionName='user_projects'

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { ListTable } from '@performant-software/semantic-components';
+import { BooleanIcon, ListTable } from '@performant-software/semantic-components';
 import React, { type AbstractComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate } from 'react-router-dom';
@@ -49,6 +49,16 @@ const Users: AbstractComponent<any> = () => {
         label: t('Users.columns.role'),
         resolve: (user) => UserRoles.getRoleView(user.role),
         sortable: true
+      }, {
+        name: 'required_password_change',
+        label: t('Users.columns.passwordChange'),
+        render: (user) => (
+          <BooleanIcon
+            value={user.require_password_change}
+          />
+        ),
+        sortable: true,
+        hidden: true
       }]}
       onDelete={(user) => UsersService.delete(user)}
       onLoad={(params) => UsersService.fetchAll(params)}

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -4,6 +4,7 @@ import { BooleanIcon, ListTable } from '@performant-software/semantic-components
 import React, { type AbstractComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate } from 'react-router-dom';
+import DateTimeUtils from '../utils/DateTime';
 import PermissionsService from '../services/Permissions';
 import UserRoles from '../utils/UserRoles';
 import UsersService from '../services/Users';
@@ -48,6 +49,11 @@ const Users: AbstractComponent<any> = () => {
         name: 'role',
         label: t('Users.columns.role'),
         resolve: (user) => UserRoles.getRoleView(user.role),
+        sortable: true
+      }, {
+        name: 'last_sign_in_at',
+        label: t('Users.columns.lastSignIn'),
+        resolve: (user) => DateTimeUtils.getTimestamp(user.last_sign_in_at),
         sortable: true
       }, {
         name: 'required_password_change',

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -54,7 +54,14 @@ const Users: AbstractComponent<any> = () => {
         name: 'last_sign_in_at',
         label: t('Users.columns.lastSignIn'),
         resolve: (user) => DateTimeUtils.getTimestamp(user.last_sign_in_at),
-        sortable: true
+        sortable: true,
+        hidden: true
+      }, {
+        name: 'last_invited_at',
+        label: t('Users.columns.lastInvited'),
+        resolve: (user) => DateTimeUtils.getTimestamp(user.last_invited_at),
+        sortable: true,
+        hidden: true
       }, {
         name: 'required_password_change',
         label: t('Users.columns.passwordChange'),

--- a/client/src/services/Permissions.js
+++ b/client/src/services/Permissions.js
@@ -156,6 +156,16 @@ class Permissions {
   }
 
   /**
+   * An admin user and a user who does not log in via SSO can change their password.
+   *
+   * @returns {boolean}
+   */
+  canResetPassword() {
+    const user = this.getUser();
+    return this.isAdmin() || !user.sso;
+  }
+
+  /**
    * Returns a reference to the currently logged in user.
    *
    * @returns {User}

--- a/client/src/services/Session.js
+++ b/client/src/services/Session.js
@@ -38,6 +38,16 @@ class Session {
   }
 
   /**
+   * Returns true if the current session's user is required to change their password.
+   *
+   * @returns {boolean}
+   */
+  isPasswordChangeRequired(): boolean {
+    const { user } = this.getSession();
+    return user?.require_password_change;
+  }
+
+  /**
    * Re-fetches the user and creates a new session.
    *
    * @returns {Promise<R>|Promise<R|unknown>|Promise<void>|*}

--- a/client/src/services/UserProjects.js
+++ b/client/src/services/UserProjects.js
@@ -39,6 +39,17 @@ class UserProjects extends BaseService {
       .save(userProject)
       .then((response) => SessionService.reset().then(() => response));
   }
+
+  /**
+   * Sends an invitation email to the user of the passed user project.
+   *
+   * @param userProject
+   *
+   * @returns {*}
+   */
+  sendInvitation(userProject: UserProjectType): Promise<any> {
+    return this.getAxios().post(`${this.getBaseUrl()}/${userProject.id}/invite`);
+  }
 }
 
 const UserProjectsService: UserProjects = new UserProjects();

--- a/client/src/transforms/User.js
+++ b/client/src/transforms/User.js
@@ -29,6 +29,7 @@ class User extends BaseTransform {
       'admin',
       'password',
       'password_confirmation',
+      'require_password_change',
       'role'
     ];
   }

--- a/client/src/types/User.js
+++ b/client/src/types/User.js
@@ -6,6 +6,7 @@ export type User = {
   id: number,
   name: string,
   email: string,
+  last_invited_at: number,
   last_sign_in_at: number,
   password: string,
   password_confirmation: string,

--- a/client/src/types/User.js
+++ b/client/src/types/User.js
@@ -6,6 +6,7 @@ export type User = {
   id: number,
   name: string,
   email: string,
+  last_sign_in_at: number,
   password: string,
   password_confirmation: string,
   require_password_change: boolean,

--- a/client/src/types/User.js
+++ b/client/src/types/User.js
@@ -6,6 +6,9 @@ export type User = {
   id: number,
   name: string,
   email: string,
+  password: string,
+  password_confirmation: string,
+  require_password_change: boolean,
   role: 'admin' | 'member' | 'guest',
   user_projects: Array<UserProject>
 };

--- a/client/src/types/User.js
+++ b/client/src/types/User.js
@@ -12,5 +12,6 @@ export type User = {
   password_confirmation: string,
   require_password_change: boolean,
   role: 'admin' | 'member' | 'guest',
+  sso: boolean,
   user_projects: Array<UserProject>
 };

--- a/client/src/utils/DateTime.js
+++ b/client/src/utils/DateTime.js
@@ -1,3 +1,21 @@
+// @flow
+
+const MS_TO_HOURS = 1000 * 60 * 60;
+
+/**
+ * Returns the duration (in hours) of the passed date string.
+ *
+ * @param value
+ *
+ * @returns {number}
+ */
+const getDurationInHours = (value: string) => {
+  const date = new Date(value);
+  const duration = Date.now() - date;
+
+  return duration / MS_TO_HOURS;
+};
+
 /**
  * Returns the formatted timestamp for the passed value.
  *
@@ -15,5 +33,6 @@ const getTimestamp = (value: number) => {
 };
 
 export default {
+  getDurationInHours,
   getTimestamp
 };

--- a/client/src/utils/DateTime.js
+++ b/client/src/utils/DateTime.js
@@ -1,0 +1,19 @@
+/**
+ * Returns the formatted timestamp for the passed value.
+ *
+ * @param value
+ *
+ * @returns {string|null}
+ */
+const getTimestamp = (value: number) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+export default {
+  getTimestamp
+};

--- a/client/src/utils/User.js
+++ b/client/src/utils/User.js
@@ -1,6 +1,10 @@
 // @flow
 
 import _ from 'underscore';
+import i18n from '../i18n/i18n';
+import type { User as UserType } from '../types/User';
+
+const PASSWORD_FORMAT = /(?=.{8,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@$!%*?&])/;
 
 const SSO_DOMAINS = process.env.REACT_APP_SSO_DOMAINS
   ? process.env.REACT_APP_SSO_DOMAINS.split(',')
@@ -15,6 +19,28 @@ const SSO_DOMAINS = process.env.REACT_APP_SSO_DOMAINS
  */
 const isSingleSignOn = (email: string) => _.some(SSO_DOMAINS, (domain) => email?.endsWith(domain));
 
+/**
+ * Validates the password for the passed user.
+ *
+ * @param user
+ *
+ * @returns {null|{password: *}}
+ */
+const validatePassword = (user: UserType) => {
+  // Password must match confirmation
+  if (user.password !== user.password_confirmation) {
+    return { password: i18n.t('User.errors.password.match') };
+  }
+
+  // Password must match format
+  if (!user.password.match(PASSWORD_FORMAT)) {
+    return { password: i18n.t('User.errors.password.format') };
+  }
+
+  return null;
+};
+
 export default {
-  isSingleSignOn
+  isSingleSignOn,
+  validatePassword
 };

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,9 @@ module RailsReactTemplate
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Configure Postmark for transactional emails
+    config.action_mailer.delivery_method = :postmark
+    config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/db/migrate/20250606134837_add_require_password_change_to_users.core_data_connector.rb
+++ b/db/migrate/20250606134837_add_require_password_change_to_users.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250606134315)
+class AddRequirePasswordChangeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_users, :require_password_change, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250609140147_add_last_sign_in_to_users.core_data_connector.rb
+++ b/db/migrate/20250609140147_add_last_sign_in_to_users.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250609135907)
+class AddLastSignInToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_users, :last_sign_in_at, :timestamp
+  end
+end

--- a/db/migrate/20250609160515_add_last_invited_at_to_users.core_data_connector.rb
+++ b/db/migrate/20250609160515_add_last_invited_at_to_users.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20250609155308)
+class AddLastInvitedAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :core_data_connector_users, :last_invited_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_09_140147) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_09_160515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -298,6 +298,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_09_140147) do
     t.string "role"
     t.boolean "require_password_change", default: false, null: false
     t.datetime "last_sign_in_at", precision: nil
+    t.datetime "last_invited_at", precision: nil
   end
 
   create_table "core_data_connector_web_authorities", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_06_134837) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_09_140147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -297,6 +297,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_06_134837) do
     t.uuid "sso_id"
     t.string "role"
     t.boolean "require_password_change", default: false, null: false
+    t.datetime "last_sign_in_at", precision: nil
   end
 
   create_table "core_data_connector_web_authorities", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_03_111812) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_06_134837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -296,6 +296,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_03_111812) do
     t.datetime "updated_at", null: false
     t.uuid "sso_id"
     t.string "role"
+    t.boolean "require_password_change", default: false, null: false
   end
 
   create_table "core_data_connector_web_authorities", force: :cascade do |t|


### PR DESCRIPTION
This pull request adds the `PasswordReset` page and removes the password/confirmation fields from the `UserProject` page. Admin users will still have the ability to set an explicit password for a user.

**Note:** This pull request will remain a draft until a release of the `core_data_connector` is done.

## User Invitations
Project owners (with a "member" user type) will still have the ability to add users to their project, but no longer are required to enter a specific password.

![Screenshot 2025-06-11 at 11 39 41 AM](https://github.com/user-attachments/assets/fa6d067a-414c-4afd-921d-600a338083db)

## Email
For a user new to the system, an invitation email will be sent with a temporary password (typo in email has been corrected in the email template on Postmark).

![Screenshot 2025-06-11 at 11 53 34 AM](https://github.com/user-attachments/assets/4990060e-ef4d-45f6-9eed-de0ddbd30963)

## Re-send Invitation
For users who have not yet been logged in, another email invitation may be sent once every 24 hours.

![Screenshot 2025-06-11 at 12 15 12 PM](https://github.com/user-attachments/assets/32687261-9bac-4728-8f74-cdccf03e422c)

## Reset Password
All users will now have the ability to reset their own passwords via the "Reset Password" menu option.

![Screenshot 2025-06-11 at 12 15 42 PM](https://github.com/user-attachments/assets/4711aacd-b403-426c-9766-21ba1ad1143a)
![Screenshot 2025-06-11 at 12 15 47 PM](https://github.com/user-attachments/assets/b3d3fb67-6e76-496f-828a-d4a697bc0ca5)
