### PR TITLE
CDC #450 - Mail safe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ IIIF_CLOUD_URL=https://iiif-cloud-staging.herokuapp.com/
 # The ID of the project in IIIF Cloud in which to store resources.
 IIIF_CLOUD_PROJECT_ID=1
 
+# In staging and test environments, the application will be allowed to send emails to this domain.
+MAILSAFE_ALLOWED_DOMAIN=@example.com
+
+# In staging and test environments, emails to all domains (not listed above) will be redirected to this address.
+MAILSAFE_REDIRECT_ADDRESS=core-data@example.com
+
 # Postmark API token.
 POSTMARK_API_TOKEN=abc123
 

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ POSTMARK_FROM=no-reply@app.coredata.cloud
 # emails within this interval.
 POSTMARK_INTERVAL=24
 
+# Rails environment
+RAILS_ENV=staging
+
 # The hostname of the Core Data Cloud CMS
 REACT_APP_HOSTNAME=http://localhost:3001
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ group :development, :test do
 
   # Environment variable management
   gem 'dotenv-rails'
+
+  # Email filtering
+  gem 'mail_safe', '~> 0.3.4'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -51,15 +51,15 @@ gem 'user_defined_fields', git: 'https://github.com/performant-software/user-def
 # Fuzzy dates
 gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.0'
 
+# Email filtering
+gem 'mail_safe', '~> 0.3.4', group: [:development, :staging]
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]
 
   # Environment variable management
   gem 'dotenv-rails'
-
-  # Email filtering
-  gem 'mail_safe', '~> 0.3.4'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,8 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mail_safe (0.3.4)
+      actionmailer (>= 3.0.0)
     marcel (1.0.2)
     method_source (1.0.0)
     mime-types (3.5.2)
@@ -300,6 +302,7 @@ DEPENDENCIES
   fuzzy_dates!
   jwt (~> 2.4, >= 2.4.1)
   jwt_auth!
+  mail_safe (~> 0.3.4)
   pagy (~> 5.10)
   pg (~> 1.5.3)
   postmark-rails (~> 0.22.1)

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -69,7 +69,14 @@ const UserProjects: AbstractComponent<any> = () => {
       value.push({
         name: 'core_data_connector_users.name',
         label: t('UserProjects.columns.user'),
-        resolve: (userProject) => userProject?.user.name,
+        resolve: (userProject) => userProject?.user?.name,
+        sortable: true
+      });
+
+      value.push({
+        name: 'core_data_connector_users.email',
+        label: t('UserProjects.columns.email'),
+        resolve: (userProject) => userProject?.user?.email,
         sortable: true
       });
     }

--- a/config/database.yml
+++ b/config/database.yml
@@ -34,3 +34,7 @@ docker:
 production:
   <<: *default
   url: <%= ENV.fetch("DATABASE_URL") { '' }.gsub(/postgres/, 'postgis') %>
+
+staging:
+  <<: *default
+  url: <%= ENV.fetch("DATABASE_URL") { '' }.gsub(/postgres/, 'postgis') %>

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,90 @@
+require "active_support/core_ext/integer/time"
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+
+  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # config.require_master_key = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.asset_host = "http://assets.example.com"
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+
+  # Store uploaded files on the local file system (see config/storage.yml for options).
+  config.active_storage.service = :local
+
+  # Mount Action Cable outside main process or domain.
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = "wss://example.com/cable"
+  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
+  if ENV['RAILS_LOG_LEVEL'].present?
+    config.log_level = ENV['RAILS_LOG_LEVEL'].to_sym
+  else
+    config.log_level = :info
+  end
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment).
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "rails_react_template_production"
+
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Don't log any deprecations.
+  config.active_support.report_deprecations = false
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require "syslog/logger"
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+end

--- a/config/initializers/mail_safe.rb
+++ b/config/initializers/mail_safe.rb
@@ -1,0 +1,10 @@
+if defined?(MailSafe::Config)
+  if ENV['MAILSAFE_ALLOWED_DOMAIN'].present?
+    allowed_domain = Regexp.new(Regexp.escape(ENV['MAILSAFE_ALLOWED_DOMAIN']))
+    MailSafe::Config.internal_address_definition = allowed_domain
+  end
+  
+  if ENV['MAILSAFE_REDIRECT_ADDRESS'].present?
+    MailSafe::Config.replacement_address = ENV['MAILSAFE_REDIRECT_ADDRESS']
+  end
+end


### PR DESCRIPTION
This pull request adds the `mail_safe` gem to prevent emails from being sent to real addresses in staging/development environments. The `MAILSAFE_ALLOWED_DOMAIN` environoment variable can be configured to allowing sending emails to a specific domain. The `MAILSAFE_REDIRECT_ADDRESS` environment variable can be configured as the email address to receive emails in staging/development environments.

This pull request also adds an additional `staging` environment.

Finally, this pull request adds the "Email" column to the UserProjects page.

![Screenshot 2025-06-13 at 9 16 30 AM](https://github.com/user-attachments/assets/d9e8ccc1-01d2-4af1-9273-c8583951a56f)
