### PR TITLE
Upgrade `core-data-connector`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,7 +57,7 @@ POSTMARK_FROM=no-reply@app.coredata.cloud
 POSTMARK_INTERVAL=24
 
 # Rails environment
-RAILS_ENV=staging
+RAILS_ENV=development
 
 # A base secret for Rails.
 SECRET_KEY_BASE=339485u34895u4398u58394u543u59834u958u347y62347632t47235467235674

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.100'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.102'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 221746d3dabb7c71808e51d01d16984dd2814cb8
-  tag: v0.1.100
+  revision: 6541e3f18229783db0ae6a5129e3338257d861bc
+  tag: v0.1.102
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)


### PR DESCRIPTION
# Summary

This PR upgrades the CDC gem to v0.1.102 to bring in the primary place name faceting from https://github.com/performant-software/core-data-connector/pull/164. (It appears to also include the v0.1.101 upgrade which updated the `triple_eye_effable` gem.)

I also updated the example `.env` file with the correct value for `RAILS_ENV` for local dev builds.