### PR TITLE
Event forms: match UDF FuzzyDate behavior (#478)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-ey
 gem 'user_defined_fields', git: 'https://github.com/performant-software/user-defined-fields.git', tag: 'v0.1.14'
 
 # Fuzzy dates
-gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.1'
+gem 'fuzzy_dates', git: 'https://github.com/performant-software/fuzzy-dates.git', tag: 'v0.1.2'
 
 # Email filtering
 gem 'mail_safe', '~> 0.3.4', group: [:development, :staging]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,8 +22,8 @@ GIT
 
 GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
-  revision: c83271acb4837325d026a63229f89059984648f5
-  tag: v0.1.1
+  revision: 1572b9c3370922aace98e9e2db139a30c55fda48
+  tag: v0.1.2
   specs:
     fuzzy_dates (0.1.0)
       rails (>= 6.0.3.2, < 9)

--- a/client/package.json
+++ b/client/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@bunchtogether/vite-plugin-flow": "^1.0.2",
     "@performant-software/geospatial": "^3.1.3",
-    "@performant-software/semantic-components": "^3.1.4",
-    "@performant-software/shared-components": "^3.1.4",
-    "@performant-software/user-defined-fields": "^3.1.4",
+    "@performant-software/semantic-components": "^3.1.5",
+    "@performant-software/shared-components": "^3.1.5",
+    "@performant-software/user-defined-fields": "^3.1.5",
     "@peripleo/maplibre": "^0.8.7",
     "@peripleo/peripleo": "^0.8.7",
     "@samvera/clover-iiif": "^2.18.3",

--- a/client/src/components/EventForm.js
+++ b/client/src/components/EventForm.js
@@ -24,7 +24,7 @@ const EventForm = (props: Props) => {
   const onFuzzyDateChange = useCallback((attribute, data) => {
     props.onSetState({
       [attribute]: {
-        ...data,
+        ...FuzzyDateTransform.toData(data),
         id: props.item[attribute]?.id,
         _destroy: !data.startDate
       }

--- a/client/src/transforms/Event.js
+++ b/client/src/transforms/Event.js
@@ -47,18 +47,6 @@ class Event extends MergeableTransform {
       text: event.name
     };
   }
-
-  /**
-   * Returns the passed event object serialized for PUT/POST requests.
-   *
-   * @param event
-   * @param attributes
-   *
-   * @returns {*}
-   */
-  toPayload(event: EventType, attributes: any = {}) {
-    return super.toPayload(event, attributes);
-  }
 }
 
 const EventTransform: Event = new Event();

--- a/client/src/transforms/Event.js
+++ b/client/src/transforms/Event.js
@@ -57,11 +57,7 @@ class Event extends MergeableTransform {
    * @returns {*}
    */
   toPayload(event: EventType, attributes: any = {}) {
-    return super.toPayload(event, {
-      ...FuzzyDateTransform.toPayload(event, 'start_date'),
-      ...FuzzyDateTransform.toPayload(event, 'end_date'),
-      ...attributes
-    });
+    return super.toPayload(event, attributes);
   }
 }
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1842,10 +1842,10 @@
     react-map-gl "^8.0.4"
     underscore "^1.13.7"
 
-"@performant-software/semantic-components@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-3.1.4.tgz#4483d832ba48149327357fcfb144686df55710e5"
-  integrity sha512-TtyBvDj7NdYFuDha0kd2K7RnrUA3BKrI75fV8SWhxp3Vk2A6PiX3IjPttnS7ex+jZ1r7YebFFt1gUxLIDeywRg==
+"@performant-software/semantic-components@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@performant-software/semantic-components/-/semantic-components-3.1.5.tgz#f4df74d1cbb07fab3d67b87ff0f4a846310ea257"
+  integrity sha512-1fRIdEG9ZQOtHGbTRBj5IRrvMzydFdSeWwgyssBdRNAiVoyPSdF++GiletaDwXBY62GhhlAeMxnaxD+Zk/5JDA==
   dependencies:
     "@react-google-maps/api" "^2.20.7"
     axios "^1.10.0"
@@ -1863,10 +1863,10 @@
     zotero-api-client "^0.40.0"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/shared-components@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-3.1.4.tgz#308a412a1cb9eee4e6b5f0be384736d6f4516e63"
-  integrity sha512-n33fY3aBPFevVNeqbuCdARoOfFWyMoghUaWyqfzmlh+56pciNrX8ktDgLD/y/+MSxicRd4nn3p0R3PDTsXQozw==
+"@performant-software/shared-components@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@performant-software/shared-components/-/shared-components-3.1.5.tgz#4734383ab95b7b0a5cbbb843627f128212c5dab0"
+  integrity sha512-0EfqlEPq+CzykMjhc9+zHSu9xQkevsqnx917LF9YUn6GvASo8D4Nu/oIeRNeI9h+nPncXM+P3KYR2JnpCOMOjQ==
   dependencies:
     "@rails/activestorage" "^8.0.201"
     "@react-google-maps/api" "^2.20.7"
@@ -1882,10 +1882,10 @@
     underscore "^1.13.7"
     zotero-translation-client "^5.0.1"
 
-"@performant-software/user-defined-fields@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-3.1.4.tgz#0df3a485acf5bc9e70e2c28fc1553c9091a244a1"
-  integrity sha512-Desp4Qzv47bYD2uby6bB+k+AOwk2QdaUTDvjz/HUXxQDnsyxaZa1innrfAiG/6i33tngBnQyWkF1ZEj2YXxI7w==
+"@performant-software/user-defined-fields@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@performant-software/user-defined-fields/-/user-defined-fields-3.1.5.tgz#cad63e73605cd54d8eb5ea2794c5f2558b85111e"
+  integrity sha512-AHFiNJz7JJ5lDHbu6QIpl7HSRPS/ivyEwCmWsTWIat0iWOH4Kamiaxb5fhncigr0KFuCxdlJNFeY6TaK8aHI1g==
   dependencies:
     i18next "^25.3.2"
     semantic-ui-react "^2.1.5"


### PR DESCRIPTION
Leaving as draft until new releases of `react-components` libraries.

## In this PR
Per #478:
- In Event forms' FuzzyDate fields, match user-defined fields' FuzzyDate behavior, by transforming values using `FuzzyDateTransform.toData` during the `onChange` callback, and passing that data as-is to the API

## Questions

Postgres has a limit that dates must be more recent than 4713 BC. Should we communicate the limitation to the user somehow if they try to enter dates before that?