### PR TITLE
Updating Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 395df746c26bd809d940c70dd962d6cba05b91fb
-  tag: v0.1.105
+  revision: 183566cfb0b4bba09180943cdb2dac790ac5511a
+  tag: v0.1.106
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)


### PR DESCRIPTION
### In this PR
Oops this should have been part of PR #524 . Updates the `Gemfile.lock` file with the new `core-data-connector` version.