### PR TITLE
Never show manual password setting, "reset password" checkbox for new user invites (#555)

### DIFF
--- a/client/src/components/UserForm.js
+++ b/client/src/components/UserForm.js
@@ -9,12 +9,13 @@ import type { User } from '../types/User';
 import UserRoles from '../utils/UserRoles';
 
 type Props = EditContainerProps & {
-  item: User
+  item: User,
+  isNew?: boolean
 };
 
 const UserForm: AbstractComponent<any> = (props: Props) => {
   const { t } = useTranslation();
-  const isNew = !props.item.id;
+  const isNew = props.isNew || !props.item.id;
 
   return (
     <>

--- a/client/src/components/UserModal.js
+++ b/client/src/components/UserModal.js
@@ -15,6 +15,7 @@ type Props = EditContainerProps & {
 
 const UserModal: AbstractComponent<any> = (props: Props) => {
   const { t } = useTranslation();
+  const isNew = !props.item.id;
 
   return (
     <Modal
@@ -30,8 +31,9 @@ const UserModal: AbstractComponent<any> = (props: Props) => {
       <Modal.Content>
         <UserForm
           {...props}
+          isNew={isNew}
         />
-        { !UserUtils.isSingleSignOn(props.item.email) && (
+        { !isNew && !UserUtils.isSingleSignOn(props.item.email) && (
           <UserPassword
             {...props}
           />

--- a/client/src/pages/User.js
+++ b/client/src/pages/User.js
@@ -16,12 +16,13 @@ import { useTranslation } from 'react-i18next';
 import withReactRouterEditPage from '../hooks/ReactRouterEditPage';
 
 type Props = EditContainerProps & {
-  item: UserType
+  item: UserType,
+  isNew?: boolean
 };
 
 const UserFormComponent = (props: Props) => {
   const { t } = useTranslation();
-  const isNew = !props.item.id;
+  const isNew = props.isNew || !props.item.id;
 
   if (!PermissionsService.canEditUsers()) {
     return <UnauthorizedRedirect />;
@@ -45,6 +46,7 @@ const UserFormComponent = (props: Props) => {
         >
           <UserForm
             {...props}
+            isNew={isNew}
           />
           { !isNew && !UserUtils.isSingleSignOn(props.item.email) && (
             <UserPassword

--- a/client/src/pages/UserProject.js
+++ b/client/src/pages/UserProject.js
@@ -166,6 +166,7 @@ const UserProjectForm = (props: Props) => {
             { !PermissionsService.canEditUsers() && isOwner && isNew && (
               <UserForm
                 {...props}
+                isNew
               />
             )}
             <Form.Dropdown


### PR DESCRIPTION
### In this PR

Per #555:
- Fixes some missed cases where the admin would have to manually set a password, or be shown a (nonfunctional) "must reset password" checkbox, when inviting a new user. (Nonfunctional because newly invited users always have to set a new password.)