### PR TITLE
Bump core-data-connector to v0.1.113 (#560)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.112'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.113'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 764e3db52e51382bbaee59795599f423589bea57
-  tag: v0.1.112
+  revision: 1581556d0fceb90c72b5bc6a8b2c077ce6db3ba7
+  tag: v0.1.113
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)


### PR DESCRIPTION
### In this PR

Per #560:
- Bump the core-data-connector dependency to get the fixed nil checks