### PR TITLE
Refactor to avoid Clerk code in local auth mode

### DIFF
--- a/client/src/components/AuthenticationContextProvider.js
+++ b/client/src/components/AuthenticationContextProvider.js
@@ -1,54 +1,36 @@
 // @flow
-import { useAuth } from '@clerk/react';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext } from 'react';
 import { AuthenticationContext, LocalAuthenticationContext } from '../context/Authentication';
-import UsersService from '../services/Users';
+import ClerkAuthenticationContextProvider from './ClerkAuthenticationContextProvider';
 
 const PROVIDER = import.meta.env.VITE_AUTH_PROVIDER || 'local';
 
-const AuthenticationContextProvider = (props: any) => {
-  const clerkAuth = useAuth();
-  const [user, setUser] = useState(null);
+const DefaultAuthenticationContextProvider = (props: any) => {
   const localData = useContext(LocalAuthenticationContext);
-
-  /**
-   * Call the /me endpoint to get the current user's data.
-   */
-  useEffect(() => {
-    if (PROVIDER === 'clerk' && clerkAuth.isSignedIn && !user) {
-      UsersService.getMe()
-        .then(res => setUser(res.data))
-        .catch(() => clerkAuth.signOut());
-    }
-  }, [clerkAuth.isSignedIn]);
-
-  const data = useMemo(() => {
-    if (PROVIDER === 'clerk') {
-      return {
-        authenticated: clerkAuth.isSignedIn,
-        logout: clerkAuth.signOut,
-        user
-      };
-    } else {
-      return localData;
-    }
-  }, [clerkAuth, user, localData]);
-
-  /**
-   * Block the initial render so the useEffect has a chance to set up the axios interceptor.
-   */
-  const ready = useMemo(() => (
-    PROVIDER === 'local' || clerkAuth.isLoaded && (user || !clerkAuth.isSignedIn)),
-    [clerkAuth.isLoaded, user, clerkAuth.isSignedIn]
-  );
 
   return (
     <AuthenticationContext.Provider
-      value={{ ...data, provider: PROVIDER }}
+      value={{ ...localData, provider: PROVIDER }}
     >
-      { ready && props.children }
+      { props.children }
     </AuthenticationContext.Provider>
   )
+}
+
+const AuthenticationContextProvider = (props: any) => {
+  if (PROVIDER === 'clerk') {
+    return (
+      <ClerkAuthenticationContextProvider>
+        { props.children }
+      </ClerkAuthenticationContextProvider>
+    );
+  }
+
+  return (
+    <DefaultAuthenticationContextProvider>
+      { props.children }
+    </DefaultAuthenticationContextProvider>
+  );
 }
 
 export default AuthenticationContextProvider;

--- a/client/src/components/ClerkAuthenticationContextProvider.js
+++ b/client/src/components/ClerkAuthenticationContextProvider.js
@@ -1,0 +1,49 @@
+// @flow
+import { useAuth } from '@clerk/react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { AuthenticationContext } from '../context/Authentication';
+import UsersService from '../services/Users';
+
+const PROVIDER = import.meta.env.VITE_AUTH_PROVIDER || 'local';
+
+const ClerkAuthenticationContextProvider = (props: any) => {
+  const clerkAuth = useAuth();
+  const [user, setUser] = useState(null);
+
+  /**
+   * Call the /me endpoint to get the current user's data.
+   */
+  useEffect(() => {
+    if (clerkAuth.isSignedIn && !user) {
+      UsersService.getMe()
+        .then(res => setUser(res.data))
+        .catch(() => clerkAuth.signOut());
+    }
+  }, [clerkAuth.isSignedIn]);
+
+  const data = useMemo(() => {
+    return {
+      authenticated: clerkAuth.isSignedIn,
+      logout: clerkAuth.signOut,
+      user
+    };
+  }, [clerkAuth, user]);
+
+  /**
+   * Block the initial render so the useEffect has a chance to set up the axios interceptor.
+   */
+  const ready = useMemo(() => (
+    clerkAuth.isLoaded && (user || !clerkAuth.isSignedIn)),
+    [clerkAuth.isLoaded, user, clerkAuth.isSignedIn]
+  );
+
+  return (
+    <AuthenticationContext.Provider
+      value={{ ...data, provider: PROVIDER }}
+    >
+      { ready && props.children }
+    </AuthenticationContext.Provider>
+  )
+}
+
+export default ClerkAuthenticationContextProvider;


### PR DESCRIPTION
# Summary

Previously, I had Clerk's `useAuth` in the shared `AuthenticationContextProvider` because in dev mode it harmlessly returned null data and let the local auth logic do its thing. But apparently it throws an error in production. So this PR refactors the auth context to keep Clerk and local auth logic completely separate.