### PR TITLE
Fix bad permission checks for user modification

### DIFF
--- a/client/src/hooks/Permissions.js
+++ b/client/src/hooks/Permissions.js
@@ -270,7 +270,7 @@ const usePermissions = () => {
    *
    * @returns {boolean}
    */
-  const canResetPassword = () => isSSO() && isAdmin();
+  const canResetPassword = () => !isSSO() || isAdmin();
 
   return useMemo(() => ({
     canArchiveProject,

--- a/client/src/hooks/Permissions.js
+++ b/client/src/hooks/Permissions.js
@@ -270,7 +270,7 @@ const usePermissions = () => {
    *
    * @returns {boolean}
    */
-  const canResetPassword = () => !isSSO() || isAdmin();
+  const canResetPassword = () => !isSSO() || (isAdmin() && !isSSO);
 
   return useMemo(() => ({
     canArchiveProject,

--- a/client/src/hooks/Permissions.js
+++ b/client/src/hooks/Permissions.js
@@ -270,7 +270,7 @@ const usePermissions = () => {
    *
    * @returns {boolean}
    */
-  const canResetPassword = () => !isSSO() || (isAdmin() && !isSSO());
+  const canResetPassword = () => !isSSO();
 
   return useMemo(() => ({
     canArchiveProject,

--- a/client/src/hooks/Permissions.js
+++ b/client/src/hooks/Permissions.js
@@ -270,7 +270,7 @@ const usePermissions = () => {
    *
    * @returns {boolean}
    */
-  const canResetPassword = () => !isSSO() || (isAdmin() && !isSSO);
+  const canResetPassword = () => !isSSO() || (isAdmin() && !isSSO());
 
   return useMemo(() => ({
     canArchiveProject,

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -43,7 +43,7 @@ const Users: AbstractComponent<any> = () => {
   }
 
   const listTableActions = useMemo(() => {
-    const baseList = [
+    let list = [
       {
         name: 'edit',
         onClick: (item) => navigate(`${item.id}`)
@@ -53,7 +53,7 @@ const Users: AbstractComponent<any> = () => {
     ];
 
     if (provider === 'local') {
-      return baseList.splice(1, 0, {
+      list.splice(1, 0, {
         accept: (item) => !item.last_sign_in_at,
         name: 'resend_invite',
         icon: 'mail outline',
@@ -65,7 +65,8 @@ const Users: AbstractComponent<any> = () => {
       });
     }
 
-    return baseList;
+
+    return list;
   }, [canEditUsers]);
 
   const addButton = useMemo(() => {


### PR DESCRIPTION
# Summary

This PR:

* fixes an incorrect conditional for `canResetPassword`
* fixes an issue where the wrong actions array was returned in the `Users` component