### PR TITLE
Add new Clerk-related environment variables and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,4 +97,5 @@ VITE_AUTH_PROVIDER=clerk
 VITE_CLERK_PUBLISHABLE_KEY=my_key
 CLERK_SECRET_KEY=my_super_secret_key
 VITE_CLERK_SIGN_IN_FORCE_REDIRECT_URL=http://localhost:3000/projects
-
+VITE_CLERK_IS_SATELLITE=true
+VITE_CLERK_DOMAIN=staging.performant.studio

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,6 +32,7 @@ const ClerkWrapper = () => {
   if (import.meta.env.VITE_CLERK_PUBLISHABLE_KEY) {
     return (
       <ClerkProvider
+        allowedRedirectOrigins={[import.meta.env.VITE_CLERK_DOMAIN]}
         publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}
       >
         <App />


### PR DESCRIPTION
# Summary

As part of the ongoing saga of getting Clerk working on Core Data Staging, this PR documents some new environment variables and passes an `allowedRedirectOrigins` prop to the Clerk provider.