### PR TITLE
Clerk login redirect button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,10 @@ VITE_AUTH_PROVIDER=clerk
 # Clerk config (only needed if using Clerk for authentication)
 VITE_CLERK_PUBLISHABLE_KEY=my_key
 CLERK_SECRET_KEY=my_super_secret_key
+VITE_CLERK_SIGN_IN_URL=https://staging.performant.studio/sso
 VITE_CLERK_SIGN_IN_FORCE_REDIRECT_URL=http://localhost:3000/projects
 VITE_CLERK_IS_SATELLITE=true
 VITE_CLERK_DOMAIN=staging.performant.studio
+
+# Vite environment
+VITE_ENV=development

--- a/client/src/components/ClerkLoginModal.js
+++ b/client/src/components/ClerkLoginModal.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from 'semantic-ui-react';
+import { SignInButton } from '@clerk/react';
+import { useTranslation } from 'react-i18next';
+import styles from './ClerkLoginModal.module.css';
+
+const ClerkLoginModal = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={styles.clerkModal}
+    >
+      <h1 className={styles.clerkModalHeader}>
+        {t('ClerkLoginModal.header')}
+      </h1>
+      <SignInButton>
+        <Button
+          color='blue'
+        >
+          {t('ClerkLoginModal.login')}
+        </Button>
+      </SignInButton>
+    </div>
+  );
+}
+
+export default ClerkLoginModal;

--- a/client/src/components/ClerkLoginModal.module.css
+++ b/client/src/components/ClerkLoginModal.module.css
@@ -1,0 +1,17 @@
+.clerkModal {
+  background-color: white;
+  border-radius: 8px;
+  padding: 48px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.clerkModalHeader {
+  margin-bottom: 28px;
+  font-size: 26px;
+  font-weight: bold;
+  color: #333;
+  text-align: center;
+}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -28,6 +28,10 @@
       "subject": "Subject Access Points"
     }
   },
+  "ClerkLoginModal": {
+    "header": "Welcome to Core Data Cloud",
+    "login": "Sign in with Performant Studio"
+  },
   "GeoNamesForm": {
     "labels": {
       "username": "Username"

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -9,6 +9,7 @@ import { Navigate } from 'react-router';
 import { AuthenticationContext } from '../context/Authentication';
 import styles from './Login.module.css';
 import { SignIn } from '@clerk/react';
+import ClerkLoginModal from '../components/ClerkLoginModal';
 
 const Login: ComponentType<any> = () => {
   const { authenticated, provider } = useContext(AuthenticationContext);
@@ -27,7 +28,14 @@ const Login: ComponentType<any> = () => {
         />
       )}
       { provider === 'clerk' && (
-        <SignIn />
+        <>
+          { import.meta.env.VITE_ENV === 'development' && (
+            <SignIn />
+          )}
+          { import.meta.env.VITE_ENV !== 'development' && (
+            <ClerkLoginModal />
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
# Summary

This PR replaces the Clerk login modal on the Core Data homepage with a button that redirects the user to Performant Studio (whose URL is set via environment variables). This was necessary because of Clerk's limitations around signing in on satellite domains.

## Note

The full redirect-based authentication is impossible to test on a local dev project, so I expect to end up with one or two more PRs soon after this one to address whatever issues come up.