### PR TITLE
Switch to `buildSignInUrl` for Clerk redirect

### DIFF
--- a/client/src/components/ClerkLoginModal.js
+++ b/client/src/components/ClerkLoginModal.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Button } from 'semantic-ui-react';
-import { SignInButton } from '@clerk/react';
+import { SignInButton, useClerk } from '@clerk/react';
 import { useTranslation } from 'react-i18next';
 import styles from './ClerkLoginModal.module.css';
 
 const ClerkLoginModal = () => {
   const { t } = useTranslation();
+
+  const { buildSignInUrl } = useClerk();
 
   return (
     <div
@@ -16,7 +18,9 @@ const ClerkLoginModal = () => {
       </h1>
       <SignInButton>
         <Button
+          as='a'
           color='blue'
+          href={buildSignInUrl()}
         >
           {t('ClerkLoginModal.login')}
         </Button>

--- a/client/src/components/ClerkLoginModal.js
+++ b/client/src/components/ClerkLoginModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from 'semantic-ui-react';
-import { SignInButton, useClerk } from '@clerk/react';
+import { useClerk } from '@clerk/react';
 import { useTranslation } from 'react-i18next';
 import styles from './ClerkLoginModal.module.css';
 
@@ -16,15 +16,13 @@ const ClerkLoginModal = () => {
       <h1 className={styles.clerkModalHeader}>
         {t('ClerkLoginModal.header')}
       </h1>
-      <SignInButton>
-        <Button
-          as='a'
-          color='blue'
-          href={buildSignInUrl()}
-        >
-          {t('ClerkLoginModal.login')}
-        </Button>
-      </SignInButton>
+      <Button
+        as='a'
+        color='blue'
+        href={buildSignInUrl()}
+      >
+        {t('ClerkLoginModal.login')}
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
# Summary

This PR changes the Clerk login modal to use a URL generated by their `buildSignInUrl` function instead of their `SignInButton` component. The docs are really emphatic that `buildSignInUrl` must be used for satellite domains and it isn't clear that `SignInButton` uses that under the hood.