### PR TITLE
Rename Clerk `satelliteDomain` prop to `isSatellite`

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,9 +34,9 @@ const ClerkWrapper = () => {
       <ClerkProvider
         allowedRedirectOrigins={[import.meta.env.VITE_CLERK_DOMAIN]}
         domain={import.meta.env.VITE_CLERK_DOMAIN}
+        isSatellite={import.meta.env.VITE_CLERK_IS_SATELLITE}
         publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}
         signInUrl={import.meta.env.VITE_CLERK_SIGN_IN_URL}
-        satelliteDomain={import.meta.env.VITE_CLERK_IS_SATELLITE}
       >
         <App />
       </ClerkProvider>);


### PR DESCRIPTION
# Summary

This PR fixes an incorrect prop name in the Clerk Provider.