### PR TITLE
Hide more UI elements in Clerk mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,3 +103,10 @@ VITE_CLERK_DOMAIN=staging.performant.studio
 
 # Vite environment
 VITE_ENV=development
+
+# The variables below are only used by the Clerk migration Rake task
+
+# The default organization to add users to in the Clerk migration script
+CLERK_MIGRATION_DEFAULT_DOMAIN=performantsoftware.com
+# The domain whose users should be configured as global admins in the Clerk migration script
+CLERK_MIGRATION_GLOBAL_ADMIN_DOMAIN=performantsoftware.com

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.118'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.119'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: dde57c3a8df2b4f3ed544c04efd6762e25b6f079
-  tag: v0.1.118
+  revision: 7c930684bb695bf2feb1214e4886d86228f20b07
+  tag: v0.1.119
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)

--- a/client/src/components/UserForm.js
+++ b/client/src/components/UserForm.js
@@ -41,6 +41,7 @@ const UserForm: AbstractComponent<any> = (props: Props) => {
         <>
           <Form.Dropdown
             error={props.isError('role')}
+            disabled={isSSO()}
             label={t('UserForm.labels.role')}
             onChange={props.onTextInputChange.bind(this, 'role')}
             options={UserRoles.getRoleOptions()}

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -3,6 +3,7 @@
 import { ListTable, Toaster } from '@performant-software/semantic-components';
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useState,
@@ -24,6 +25,7 @@ import UserRoles from '../utils/UserRoles';
 import UsersService from '../services/Users';
 import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
+import { AuthenticationContext } from '../context/Authentication';
 
 const UserProjects: AbstractComponent<any> = () => {
   const [errors, setErrors] = useState([]);
@@ -38,6 +40,7 @@ const UserProjects: AbstractComponent<any> = () => {
     canEditUsers,
     canInviteUserProject
   } = usePermissions();
+  const { provider } = useContext(AuthenticationContext);
 
   const ids = useMemo(() => ({ project_id: projectId, user_id: userId }), [projectId, userId]);
 
@@ -146,6 +149,45 @@ const UserProjects: AbstractComponent<any> = () => {
     return <UnauthorizedRedirect />;
   }
 
+  const actions = useMemo(() => {
+    let list = [
+      {
+        name: 'edit',
+        icon: 'pencil',
+        onClick: (item) => navigate(`${item.id}`)
+      }, {
+        icon: 'times',
+        name: 'delete'
+      }
+    ];
+
+    if (provider === 'local') {
+      list.push(
+        {
+          accept: (item) => canInviteUserProject(item),
+          icon: 'mail outline',
+          name: 'invite',
+          onClick: onInviteUser,
+          popup: {
+            content: t('UserProjects.actions.invite.content'),
+            title: t('UserProjects.actions.invite.header')
+          }
+        }
+      );
+    }
+
+    list.push(
+      {
+        accept: () => !!userId,
+        icon: 'arrow right',
+        name: 'navigate',
+        onClick: (item) => navigate(`/projects/${item.project_id}`)
+      }
+    );
+
+    return list;
+  }, [])
+
   return (
     <>
       { userId && user && (
@@ -164,28 +206,7 @@ const UserProjects: AbstractComponent<any> = () => {
         <UserEditMenu />
       )}
       <ListTable
-        actions={[{
-          name: 'edit',
-          icon: 'pencil',
-          onClick: (item) => navigate(`${item.id}`)
-        }, {
-          icon: 'times',
-          name: 'delete'
-        }, {
-          accept: (item) => canInviteUserProject(item),
-          icon: 'mail outline',
-          name: 'invite',
-          onClick: onInviteUser,
-          popup: {
-            content: t('UserProjects.actions.invite.content'),
-            title: t('UserProjects.actions.invite.header')
-          }
-        }, {
-          accept: () => !!userId,
-          icon: 'arrow right',
-          name: 'navigate',
-          onClick: (item) => navigate(`/projects/${item.project_id}`)
-        }]}
+        actions={actions}
         addButton={{
           basic: false,
           color: 'blue',

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -79,34 +79,35 @@ const Users: AbstractComponent<any> = () => {
         onClick: () => navigate('new')
       };
     }
-  }, [])
+  }, []);
 
-  return (
-    <>
-      <ListTable
-        actions={listTableActions}
-        addButton={addButton}
-        collectionName='users'
-        columns={[{
-          name: 'name',
-          label: t('Users.columns.name'),
-          sortable: true
-        }, {
-          name: 'email',
-          label: t('Users.columns.email'),
-          sortable: true
-        }, {
-          name: 'role',
-          label: t('Users.columns.role'),
-          resolve: (user) => UserRoles.getRoleView(user.role),
-          sortable: true
-        }, {
-          name: 'last_sign_in_at',
-          label: t('Users.columns.lastSignIn'),
-          resolve: (user) => DateTimeUtils.getTimestamp(user.last_sign_in_at),
-          sortable: true,
-          hidden: true
-        }, {
+  const columns = useMemo(() => {
+    const baseList = [
+      {
+        name: 'name',
+        label: t('Users.columns.name'),
+        sortable: true
+      }, {
+        name: 'email',
+        label: t('Users.columns.email'),
+        sortable: true
+      }, {
+        name: 'role',
+        label: t('Users.columns.role'),
+        resolve: (user) => UserRoles.getRoleView(user.role),
+        sortable: true
+      }, {
+        name: 'last_sign_in_at',
+        label: t('Users.columns.lastSignIn'),
+        resolve: (user) => DateTimeUtils.getTimestamp(user.last_sign_in_at),
+        sortable: true,
+        hidden: true
+      }
+    ];
+
+    if (provider === 'local') {
+      baseList.push(
+        {
           name: 'last_invited_at',
           label: t('Users.columns.lastInvited'),
           resolve: (user) => DateTimeUtils.getTimestamp(user.last_invited_at),
@@ -122,7 +123,20 @@ const Users: AbstractComponent<any> = () => {
           ),
           sortable: true,
           hidden: true
-        }]}
+        }
+      );
+    }
+
+    return baseList;
+  }, []);
+
+  return (
+    <>
+      <ListTable
+        actions={listTableActions}
+        addButton={addButton}
+        collectionName='users'
+        columns={columns}
         onDelete={(user) => UsersService.delete(user)}
         onLoad={(params) => UsersService.fetchAll(params)}
         searchable


### PR DESCRIPTION
# Summary

This PR updates Core Data to hide more UI elements related to local user management when running in Clerk mode.

* disable the role field in the user form
  * I left the edit form in place even though all fields are now disabled - it still seems useful to be able to see the data, and it would be a bit of a (mostly permissions-related) refactoring job to make the user form inaccessible while keeping the `UserProjects` form accessible
* hide the resend invitation button from the users list
* hide the "last invited at" column
* hide the "required password change" column

It also adds the new Rake task environment variables to the example `.env` file.