### PR TITLE
Fix record creation

### DIFF
--- a/client/src/hooks/useEditContainer.js
+++ b/client/src/hooks/useEditContainer.js
@@ -55,7 +55,7 @@ const useEditContainer = (options: Options) => {
   }, []);
 
   useEffect(() => {
-    if (itemProp) {
+    if (itemProp && !_.isEqual(itemProp, originalItem)) {
       setItem(itemProp);
       setOriginalItem(itemProp);
     }

--- a/client/src/hooks/useEditContainer.js
+++ b/client/src/hooks/useEditContainer.js
@@ -55,7 +55,7 @@ const useEditContainer = (options: Options) => {
   }, []);
 
   useEffect(() => {
-    if (itemProp && !_.isEqual(itemProp, originalItem)) {
+    if (itemProp && !ObjectUtils.isEqual(itemProp, originalItem)) {
       setItem(itemProp);
       setOriginalItem(itemProp);
     }


### PR DESCRIPTION
# Summary

This PR fixes #600. The root cause is that the item was being reset to its default state on every render when `id` was undefined, so the `project_model_id` insertion would be immediately overwritten.