### PR TITLE
Fixes for Installing Local Dev Environment

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2026_04_02_204332) do
-  create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,4 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
-CoreDataConnector::User.create!(name: 'Administrator', email: 'admin@example.com', password: 'password', password_confirmation: 'password', admin: true)
+CoreDataConnector::User.create!(name: 'Administrator', email: 'admin@example.com', password: 'Changeme1!!', password_confirmation: 'Changeme1!!', role: CoreDataConnector::User::ROLE_ADMIN)


### PR DESCRIPTION
This PR includes two fixes related to provisioning a local development environment:

* Removed "heroku_ext" from schema.rb, which was introduced unintentionally in an earlier PR and prevents `db:schema:load` and  `db:migrate` from working.
* Updated seeds.rb to create a new admin user with the correct parameters.