### PR TITLE
Upgrade `core-data-connector` from v0.1.122 to v0.1.124

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.122'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.124'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: f10cb17b4bf53c0389c6d3d23e25eb6173c00759
-  tag: v0.1.122
+  revision: 6ba85f8ae9f634633a5b5c4ea28a18e0cbe41a6c
+  tag: v0.1.124
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)
@@ -195,7 +195,7 @@ GEM
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
-    faker (3.6.1)
+    faker (3.8.0)
       i18n (>= 1.8.11, < 2)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
@@ -245,7 +245,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
-    multi_json (1.19.1)
+    multi_json (1.21.1)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
@@ -267,7 +267,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
-    oj (3.16.16)
+    oj (3.17.0)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     ostruct (0.6.3)

--- a/db/migrate/20260504182505_add_fcc2_project_id_to_projects.core_data_connector.rb
+++ b/db/migrate/20260504182505_add_fcc2_project_id_to_projects.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20260416013801)
+class AddFcc2ProjectIdToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_projects, :faircopy_cloud_project_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_02_204332) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_04_182505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
@@ -276,6 +276,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_02_204332) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.boolean "use_storage_key", default: true, null: false
     t.jsonb "reconciliation_credentials", default: {}
+    t.integer "faircopy_cloud_project_id"
   end
 
   create_table "core_data_connector_record_merges", force: :cascade do |t|


### PR DESCRIPTION
# Summary

This PR upgrades CDC for the updated Clerk migration Rake task in https://github.com/performant-software/core-data-connector/pull/200. I also noticed that we haven't upgraded CD staging to the prior release so I copied over and ran the new migration from https://github.com/performant-software/core-data-connector/releases/tag/v0.1.123 as well.