### PR TITLE
Reconciliation API update: bump CDC to v0.1.126 (#545)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.125'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.126'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 487ac25911fd6942d9242fb24772233f76fb0dcf
-  tag: v0.1.125
+  revision: 2981eff560c78389579ed12d5bb2cc053ea09f42
+  tag: v0.1.126
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)


### PR DESCRIPTION
### In this PR

Per #545:
- Bump core-data-connector gem to v0.1.126 for reconciliation api updates