### PR TITLE
Bump connector to v0.1.128 (#545)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.127'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.128'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: 40972191326d787f6d51186738940aee3b75d9de
-  tag: v0.1.127
+  revision: f608cdffcce37189c566e7b4b2fc292583eb783b
+  tag: v0.1.128
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)


### PR DESCRIPTION
### In this PR

Per #545:
- Bump cdc to v0.1.128 to get the fix for the redirect URL

After this is merged, I'll do some quick testing on staging and then should be ready for prod if it all works.