### PR TITLE
Bump connector to v0.1.130 (#613)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.129'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.130'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: ef0a7e07df3004645e2b3bd91ade95044b5cbebc
-  tag: v0.1.129
+  revision: edb3a9cbe2d31b6b308659b804177445bfe0cf23
+  tag: v0.1.130
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)


### PR DESCRIPTION
### In this PR

Per #613:
- Bump core-data-connector to v0.1.130 for changes from performant-software/core-data-connector#206