### PR TITLE
Edit button links

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -50,6 +50,11 @@ textarea {
   border-bottom: 1px solid rgba(34, 36, 38, 0.1);
 }
 
+.list.data-table-column-selector > table > tbody > tr > td.actions-cell .ui.basic.button {
+  border: none;
+  box-shadow: none;
+}
+
 .dropdown-button.ui.buttons > .ui.dropdown:last-child .menu.right {
   left: 0;
   right: auto;

--- a/client/src/pages/Events.js
+++ b/client/src/pages/Events.js
@@ -22,6 +22,7 @@ import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
 import MergeButton from '../components/MergeButton';
 import useSelectable from '../hooks/Selectable';
+import { getEditButton } from '../utils/Tables';
 
 const Events: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -84,8 +85,7 @@ const Events: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (event) => navigate(`${event.id}`)
+          render: getEditButton
         }, {
           accept: (event) => canDeleteRecord(projectModel, event),
           icon: 'times',

--- a/client/src/pages/Instances.js
+++ b/client/src/pages/Instances.js
@@ -22,6 +22,7 @@ import useSelectable from '../hooks/Selectable';
 import { useTranslation } from 'react-i18next';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const Instances: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -75,8 +76,7 @@ const Instances: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (instance) => navigate(`${instance.id}`)
+          render: getEditButton
         }, {
           accept: (instance) => canDeleteRecord(projectModel, instance),
           icon: 'times',

--- a/client/src/pages/Items.js
+++ b/client/src/pages/Items.js
@@ -22,6 +22,7 @@ import useSelectable from '../hooks/Selectable';
 import { useTranslation } from 'react-i18next';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const Items: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -75,8 +76,7 @@ const Items: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (item) => navigate(`${item.id}`)
+          render: getEditButton
         }, {
           accept: (item) => canDeleteRecord(projectModel, item),
           icon: 'times',

--- a/client/src/pages/MediaContents.js
+++ b/client/src/pages/MediaContents.js
@@ -15,6 +15,7 @@ import useSelectable from '../hooks/Selectable';
 import { useTranslation } from 'react-i18next';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const MediaContents = () => {
   const [view, setView] = useState(Views.all);
@@ -62,9 +63,8 @@ const MediaContents = () => {
       />
       <ItemList
         actions={[{
-          basic: false,
           name: 'edit',
-          onClick: (mediaContent) => navigate(`${mediaContent.id}`)
+          render: getEditButton
         }, {
           accept: (mediaContent) => canDeleteRecord(projectModel, mediaContent),
           basic: false,

--- a/client/src/pages/Organizations.js
+++ b/client/src/pages/Organizations.js
@@ -21,6 +21,7 @@ import useParams from '../hooks/ParsedParams';
 import useSelectable from '../hooks/Selectable';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const Organizations: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -73,8 +74,7 @@ const Organizations: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (organization) => navigate(`${organization.id}`)
+          render: getEditButton
         }, {
           accept: (organization) => canDeleteRecord(projectModel, organization),
           icon: 'times',

--- a/client/src/pages/People.js
+++ b/client/src/pages/People.js
@@ -22,6 +22,7 @@ import Views from '../constants/ListViews';
 import useParams from '../hooks/ParsedParams';
 import useSelectable from '../hooks/Selectable';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const People: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -78,8 +79,7 @@ const People: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (person) => navigate(`${person.id}`)
+          render: getEditButton
         }, {
           accept: (person) => canDeleteRecord(projectModel, person),
           icon: 'times',

--- a/client/src/pages/Places.js
+++ b/client/src/pages/Places.js
@@ -23,6 +23,7 @@ import useParams from '../hooks/ParsedParams';
 import useSelectable from '../hooks/Selectable';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const Places: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -86,8 +87,7 @@ const Places: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (place) => navigate(`${place.id}`)
+          render: getEditButton
         }, {
           accept: (place) => canDeleteRecord(projectModel, place),
           icon: 'times',

--- a/client/src/pages/ProjectModels.js
+++ b/client/src/pages/ProjectModels.js
@@ -9,6 +9,7 @@ import ProjectModelsService from '../services/ProjectModels';
 import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
+import { getEditButton } from '../utils/Tables';
 
 const ProjectModels = () => {
   const navigate = useNavigate();
@@ -29,8 +30,7 @@ const ProjectModels = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (projectModel) => navigate(`${projectModel.id}`)
+          render: getEditButton
         }, {
           name: 'delete',
           icon: 'times'

--- a/client/src/pages/TaxonomyItems.js
+++ b/client/src/pages/TaxonomyItems.js
@@ -15,6 +15,7 @@ import useSelectable from '../hooks/Selectable';
 import { useTranslation } from 'react-i18next';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
+import { getEditButton } from '../utils/Tables';
 
 const TaxonomyItems = () => {
   const [view, setView] = useState(Views.all);
@@ -68,8 +69,7 @@ const TaxonomyItems = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (taxonomy) => navigate(`${taxonomy.id}`)
+          render: getEditButton
         }, {
           accept: (taxonomy) => canDeleteRecord(projectModel, taxonomy),
           icon: 'times',

--- a/client/src/pages/UserProjects.js
+++ b/client/src/pages/UserProjects.js
@@ -26,6 +26,7 @@ import UsersService from '../services/Users';
 import useParams from '../hooks/ParsedParams';
 import Validation from '../utils/Validation';
 import { AuthenticationContext } from '../context/Authentication';
+import { getEditButton } from '../utils/Tables';
 
 const UserProjects: AbstractComponent<any> = () => {
   const [errors, setErrors] = useState([]);
@@ -155,8 +156,7 @@ const UserProjects: AbstractComponent<any> = () => {
     let list = [
       {
         name: 'edit',
-        icon: 'pencil',
-        onClick: (item) => navigate(`${item.id}`)
+        render: getEditButton
       }, {
         icon: 'times',
         name: 'delete'

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -5,7 +5,7 @@ import { Message } from 'semantic-ui-react';
 import { BooleanIcon, ListTable, Toaster } from '@performant-software/semantic-components';
 import React, { type AbstractComponent, useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import DateTimeUtils from '../utils/DateTime';
 import usePermissions from '../hooks/Permissions';
 import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
@@ -13,6 +13,7 @@ import UserRoles from '../utils/UserRoles';
 import UsersService from '../services/Users';
 import Validation from '../utils/Validation';
 import { AuthenticationContext } from '../context/Authentication';
+import { getEditButton } from '../utils/Tables';
 
 const Users: AbstractComponent<any> = () => {
   const [errors, setErrors] = useState([]);
@@ -46,7 +47,7 @@ const Users: AbstractComponent<any> = () => {
     let list = [
       {
         name: 'edit',
-        onClick: (item) => navigate(`${item.id}`)
+        render: getEditButton
       }, {
         name: 'delete'
       }

--- a/client/src/pages/Users.js
+++ b/client/src/pages/Users.js
@@ -5,7 +5,7 @@ import { Message } from 'semantic-ui-react';
 import { BooleanIcon, ListTable, Toaster } from '@performant-software/semantic-components';
 import React, { type AbstractComponent, useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import DateTimeUtils from '../utils/DateTime';
 import usePermissions from '../hooks/Permissions';
 import UnauthorizedRedirect from '../components/UnauthorizedRedirect';

--- a/client/src/pages/WebAuthorities.js
+++ b/client/src/pages/WebAuthorities.js
@@ -10,6 +10,7 @@ import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import WebAuthoritiesService from '../services/WebAuthorities';
 import WebAuthorityUtils from '../utils/WebAuthorities';
+import { getEditButton } from '../utils/Tables';
 
 const WebAuthorities = () => {
   const { projectId } = useParams();
@@ -30,8 +31,7 @@ const WebAuthorities = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (authority) => navigate(`${authority.id}`)
+          render: getEditButton
         }, {
           name: 'delete',
           icon: 'times'

--- a/client/src/pages/Works.js
+++ b/client/src/pages/Works.js
@@ -21,6 +21,7 @@ import useSelectable from '../hooks/Selectable';
 import Views from '../constants/ListViews';
 import WindowUtils from '../utils/Window';
 import WorksService from '../services/Works';
+import { getEditButton } from '../utils/Tables';
 
 const Works: AbstractComponent<any> = () => {
   const [view, setView] = useState(Views.all);
@@ -73,8 +74,7 @@ const Works: AbstractComponent<any> = () => {
       <ListTable
         actions={[{
           name: 'edit',
-          icon: 'pencil',
-          onClick: (work) => navigate(`${work.id}`)
+          render: getEditButton
         }, {
           accept: (work) => canDeleteRecord(projectModel, work),
           icon: 'times',

--- a/client/src/utils/Tables.js
+++ b/client/src/utils/Tables.js
@@ -14,26 +14,23 @@ export const EditButton = ({ item }: Props) => {
 
   const TriggerButton = useMemo(() => (
     <Button
+      as={Link}
       basic
       compact
       icon='pencil'
+      to={`${item.id}`}
     />
   ), [])
 
   return (
-    <Link
-      to={`${item.id}`}
-    >
-      <Popup
-        content={t('Common.actions.navigate.content')}
-        header={t('Common.actions.navigate.title')}
-        hideOnScroll
-        mouseEnterDelay={500}
-        position='top right'
-        trigger={TriggerButton}
-      />
-
-    </Link>
+    <Popup
+      content={t('Common.actions.navigate.content')}
+      header={t('Common.actions.navigate.title')}
+      hideOnScroll
+      mouseEnterDelay={500}
+      position='top right'
+      trigger={TriggerButton}
+    />
   )
 }
 

--- a/client/src/utils/Tables.js
+++ b/client/src/utils/Tables.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router';
 import { Button, Popup } from 'semantic-ui-react';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +12,16 @@ type Props = {
 export const EditButton = ({ item }: Props) => {
   const { t } = useTranslation();
 
+  const TriggerButton = useMemo(() => (
+    <Button
+      basic
+      compact
+      icon='pencil'
+    />
+  ), [])
+
   return (
     <Link
-
       to={`${item.id}`}
     >
       <Popup
@@ -23,11 +30,7 @@ export const EditButton = ({ item }: Props) => {
         hideOnScroll
         mouseEnterDelay={500}
         position='top right'
-        trigger={<Button
-          basic
-          compact
-          icon='edit outline'
-        />}
+        trigger={TriggerButton}
       />
 
     </Link>

--- a/client/src/utils/Tables.js
+++ b/client/src/utils/Tables.js
@@ -1,0 +1,42 @@
+// @flow
+
+import React from 'react';
+import { Link } from 'react-router';
+import { Button, Popup } from 'semantic-ui-react';
+import { useTranslation } from 'react-i18next';
+
+type Props = {
+  item: { id: string }
+}
+
+export const EditButton = ({ item }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <Link
+
+      to={`${item.id}`}
+    >
+      <Popup
+        content={t('Common.actions.navigate.content')}
+        header={t('Common.actions.navigate.title')}
+        hideOnScroll
+        mouseEnterDelay={500}
+        position='top right'
+        trigger={<Button
+          basic
+          compact
+          icon='edit outline'
+        />}
+      />
+
+    </Link>
+  )
+}
+
+export const getEditButton = (item: any) => (
+  <EditButton
+    key={`edit-${item.id}`}
+    item={item}
+  />
+);


### PR DESCRIPTION
# Summary

This PR addresses #615 by turning the edit buttons in all list tables into React Router `Link` components.

Although it's mentioned as a UX thing in the SOW, this is also a big improvement to accessibility as buttons that navigate on click are considered poor practice vs. idiomatic links.

* adds a new `EditButton` component with an accompanying `getEditButton` helper function
  * this is heavily based on (i.e. originally copy-pasted from) the default functionality of the `DataTable` component from `react-components`, but wraps the button in a React Router `Link` component. This couldn't be done on the `react-components` side because RC shouldn't assume that it's running in a React-Router-based environment
* updates each table's edit action object to replace `onClick: (record) => navigate(`${record.id}`)` with `render: getEditButton`

## Testing Notes

Make sure the edit buttons on all these pages work:
<img width="202" height="446" alt="Screenshot 2026-05-13 at 4 05 31 PM" src="https://github.com/user-attachments/assets/704ef398-c487-4515-af44-5e4572472b47" />

Secondly, make sure I didn't miss any edit buttons elsewhere in the UI that should be turned into links.