### PR TITLE
Text input deletion guard for major types of data

### DIFF
--- a/client/src/components/ConfirmDeleteChallenge.js
+++ b/client/src/components/ConfirmDeleteChallenge.js
@@ -1,0 +1,72 @@
+// @flow
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Button,
+  Form,
+  Modal
+} from 'semantic-ui-react';
+
+type Props = {
+  name: string,
+  onClose: () => void,
+  onConfirm: () => void
+};
+
+const ConfirmDeleteChallenge = (props: Props) => {
+  const [userInput, setUserInput] = useState('');
+  const { t } = useTranslation();
+
+  const onSubmit = () => {
+    if (userInput === props.name) {
+      props.onConfirm();
+    }
+  }
+
+  return (
+    <Modal
+      as={Form}
+      centered={false}
+      onClose={props.onClose}
+      onSubmit={onSubmit}
+      open
+      size='tiny'
+    >
+      <Modal.Header
+        content={t('ConfirmDeleteChallenge.header')}
+      />
+      <Modal.Content>
+        <p>
+          { t('ConfirmDeleteChallenge.messages.intro') }
+          &nbsp;
+          <strong>{ props.name }</strong>
+          &nbsp;
+          { t('ConfirmDeleteChallenge.messages.toConfirm') }
+        </p>
+        <Form.Input
+          autoFocus
+          fluid
+          onChange={(e, { value }) => setUserInput(value)}
+          value={userInput}
+          type='text'
+        />
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          content={t('Common.buttons.cancel')}
+          onClick={props.onClose}
+          type='button'
+        />
+        <Button
+          color='red'
+          content={t('ConfirmDeleteChallenge.buttons.delete')}
+          disabled={userInput !== props.name}
+          type='submit'
+        />
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default ConfirmDeleteChallenge;

--- a/client/src/components/ConfirmDeleteChallenge.js
+++ b/client/src/components/ConfirmDeleteChallenge.js
@@ -7,6 +7,7 @@ import {
   Form,
   Modal
 } from 'semantic-ui-react';
+import styles from './ConfirmDeleteChallenge.module.css';
 
 type Props = {
   name: string,
@@ -36,7 +37,9 @@ const ConfirmDeleteChallenge = (props: Props) => {
       <Modal.Header
         content={t('ConfirmDeleteChallenge.header')}
       />
-      <Modal.Content>
+      <Modal.Content
+        className={styles.confirmDeleteChallengeContent}
+      >
         <p>
           { t('ConfirmDeleteChallenge.messages.intro') }
           &nbsp;

--- a/client/src/components/ConfirmDeleteChallenge.module.css
+++ b/client/src/components/ConfirmDeleteChallenge.module.css
@@ -1,0 +1,3 @@
+.confirmDeleteChallengeContent p {
+  font-size: 1rem;
+}

--- a/client/src/components/ProjectModelRelationshipModal.js
+++ b/client/src/components/ProjectModelRelationshipModal.js
@@ -10,6 +10,7 @@ import type { ProjectModelRelationship as ProjectModelRelationshipType } from '.
 import ProjectModelsService from '../services/ProjectModels';
 import ProjectModelTransform from '../transforms/ProjectModel';
 import useParams from '../hooks/ParsedParams';
+import ConfirmDeleteChallenge from './ConfirmDeleteChallenge';
 
 type Props = EditContainerProps & {
   item: ProjectModelRelationshipType
@@ -198,6 +199,13 @@ const ProjectModelRelationshipModal = (props: Props) => {
           items={props.item.user_defined_fields}
           onDelete={props.onDeleteChildAssociation.bind(this, 'user_defined_fields')}
           onSave={props.onSaveChildAssociation.bind(this, 'user_defined_fields')}
+          renderDeleteModal={({ selectedItem, onConfirm, onCancel }) => (
+            <ConfirmDeleteChallenge
+              name={selectedItem.column_name}
+              onClose={onCancel}
+              onConfirm={onConfirm}
+            />)
+          }
         />
       </TabbedModal.Tab>
       { props.children }

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -32,6 +32,16 @@
     "header": "Welcome to Core Data Cloud",
     "login": "Sign in with Performant Studio"
   },
+  "ConfirmDeleteChallenge": {
+    "buttons": {
+      "delete": "Delete"
+    },
+    "header": "Confirm Delete",
+    "messages": {
+      "intro": "This is a destructive action. Please type",
+      "toConfirm": "to confirm."
+    }
+  },
   "GeoNamesForm": {
     "labels": {
       "username": "Username"

--- a/client/src/pages/Project.js
+++ b/client/src/pages/Project.js
@@ -29,6 +29,7 @@ import styles from './Project.module.css';
 import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import useReactRouterEditPage from '../hooks/useReactRouterEditPage';
+import ConfirmDeleteChallenge from '../components/ConfirmDeleteChallenge';
 
 type Props = EditContainerProps & {
   item: ProjectType
@@ -298,22 +299,13 @@ const Project = (props: Props) => {
                     icon='times'
                     onClick={() => setClearModal(true)}
                   />
-                  <Confirm
-                    centered={false}
-                    confirmButton={(
-                      <Button
-                        disabled={clearing}
-                        content={t('Common.buttons.ok')}
-                        loading={clearing}
-                        primary
-                      />
-                    )}
-                    content={t('Project.messages.clear.content')}
-                    header={t('Project.messages.clear.header')}
-                    open={clearModal}
-                    onCancel={() => setClearModal(false)}
-                    onConfirm={onClear}
-                  />
+                  {clearModal && (
+                    <ConfirmDeleteChallenge
+                      name={item.name}
+                      onClose={() => setClearModal(false)}
+                      onConfirm={onClear}
+                    />
+                  )}
                   { cleared && (
                     <Toaster
                       onDismiss={() => setCleared(false)}
@@ -344,22 +336,13 @@ const Project = (props: Props) => {
                     icon='trash'
                     onClick={() => setDeleteModal(true)}
                   />
-                  <Confirm
-                    centered={false}
-                    confirmButton={(
-                      <Button
-                        disabled={deleting}
-                        content={t('Common.buttons.ok')}
-                        loading={deleting}
-                        primary
-                      />
-                    )}
-                    content={t('Project.messages.delete.content')}
-                    header={t('Project.messages.delete.header')}
-                    open={deleteModal}
-                    onCancel={() => setDeleteModal(false)}
-                    onConfirm={onDelete}
-                  />
+                  {deleteModal && (
+                    <ConfirmDeleteChallenge
+                      name={item.name}
+                      onClose={() => setDeleteModal(false)}
+                      onConfirm={onDelete}
+                    />
+                  )}
                 </Segment>
               </SegmentGroup>
             </div>

--- a/client/src/pages/ProjectModel.js
+++ b/client/src/pages/ProjectModel.js
@@ -33,6 +33,7 @@ import ModelClassDropdown from '../components/ModelClassDropdown';
 import ProjectContext from '../context/Project';
 import type { ProjectModel as ProjectModelType } from '../types/ProjectModel';
 import ProjectModelRelationshipModal from '../components/ProjectModelRelationshipModal';
+import ConfirmDeleteChallenge from '../components/ConfirmDeleteChallenge';
 import ProjectModelAccessesService from '../services/ProjectModelAccesses';
 import ProjectModelsService from '../services/ProjectModels';
 import ProjectModelsUtils from '../utils/ProjectModels';
@@ -222,6 +223,14 @@ const ProjectModel = (props: Props) => {
               items={item.user_defined_fields}
               onDelete={editPageProps.onDeleteChildAssociation.bind(this, 'user_defined_fields')}
               onSave={editPageProps.onSaveChildAssociation.bind(this, 'user_defined_fields')}
+              renderDeleteModal={({ selectedItem, onConfirm, onCancel }) => (
+                <ConfirmDeleteChallenge
+                  name={selectedItem.column_name}
+                  onClose={onCancel}
+                  onConfirm={onConfirm}
+                />
+                )
+              }
             />
           </SimpleEditPage.Tab>
           <SimpleEditPage.Tab
@@ -266,6 +275,13 @@ const ProjectModel = (props: Props) => {
                 component: ProjectModelRelationshipModal
               }}
               onDelete={onDeleteRelationship}
+              renderDeleteModal={({ selectedItem, onConfirm, onCancel }) => (
+                <ConfirmDeleteChallenge
+                  name={selectedItem.name}
+                  onClose={onCancel}
+                  onConfirm={onConfirm}
+                />)
+              }
               onSave={onSaveRelationship}
             />
           </SimpleEditPage.Tab>

--- a/client/src/pages/ProjectModels.js
+++ b/client/src/pages/ProjectModels.js
@@ -10,6 +10,7 @@ import ProjectSettingsMenu from '../components/ProjectSettingsMenu';
 import UnauthorizedRedirect from '../components/UnauthorizedRedirect';
 import useParams from '../hooks/ParsedParams';
 import { getEditButton } from '../utils/Tables';
+import ConfirmDeleteChallenge from '../components/ConfirmDeleteChallenge';
 
 const ProjectModels = () => {
   const navigate = useNavigate();
@@ -62,6 +63,13 @@ const ProjectModels = () => {
         }]}
         onDelete={(projectModel) => ProjectModelsService.delete(projectModel)}
         onLoad={(params) => ProjectModelsService.fetchAll({ ...params, project_id: projectId })}
+        renderDeleteModal={({ selectedItem, onConfirm, onCancel }) => (
+          <ConfirmDeleteChallenge
+            name={selectedItem.name}
+            onClose={onCancel}
+            onConfirm={onConfirm}
+          />)
+        }
         searchable
         session={{
           key: `project_models_${projectId}`,


### PR DESCRIPTION
# Summary

This PR adds a new dialog (`ConfirmDeleteChallenge`) that requires the user to enter the name of the thing they're deleting.

This dialog is used for:

- delete project
- clear project
- delete model
- delete relationship
- delete user-defined field on model
- delete user-defined field on relationship

## Screenshot

<img width="598" height="269" alt="Screenshot 2026-05-14 at 12 11 42 PM" src="https://github.com/user-attachments/assets/d6be705a-3d78-4a1a-b0e8-a0a11f209699" />

## Testing notes

For each of the following places where this component is used, make sure:
* the record's name appears in bold text in the dialog as seen above
* the record is successfully deleted when you submit
* the record is *not* deleted when you cancel
* the record is *not* deleted when you attempt to submit without typing the name of the record (either pressing enter or clicking the submit button)

- [ ] delete project
- [ ] clear project
- [ ] delete model
- [ ] delete relationship
- [ ] delete user-defined field on model
- [ ] delete user-defined field on relationship