### PR TITLE
Improved merge info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v0.1.3'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.131'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.1.132'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/performant-software/core-data-connector.git
-  revision: b7b79fe03326aa2f6899010859ba61f5b147de03
-  tag: v0.1.131
+  revision: f91d534c8c1f5e82557d425e97d1b7c224fa6ac6
+  tag: v0.1.132
   specs:
     core_data_connector (0.1.0)
       activerecord-postgis-adapter (~> 11.0)

--- a/client/src/components/RelatedRecordMerges.js
+++ b/client/src/components/RelatedRecordMerges.js
@@ -42,6 +42,10 @@ const RelatedRecordMerges = () => {
       className='compact'
       collectionName='record_merges'
       columns={[{
+        name: 'merged_name',
+        label: t('Common.columns.name'),
+        sortable: true
+      }, {
         name: 'merged_uuid',
         label: t('Common.columns.uuid'),
         sortable: true

--- a/client/src/components/RelatedRecordMerges.js
+++ b/client/src/components/RelatedRecordMerges.js
@@ -47,7 +47,7 @@ const RelatedRecordMerges = () => {
         sortable: true
       }, {
         name: 'created_at',
-        label: t('RelatedRecordMerges.columns.created'),
+        label: t('RelatedRecordMerges.columns.mergeDate'),
         resolve: (recordMerge) => new Date(recordMerge.created_at).toLocaleDateString(),
         sortable: true
       }]}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -892,7 +892,7 @@
   },
   "RelatedRecordMerges": {
     "columns": {
-      "created": "Created"
+      "mergeDate": "Merge date"
     }
   },
   "RelatedTaxonomyItems": {

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -73,7 +73,8 @@
     },
     "columns":{
       "order": "Order",
-      "uuid": "Identifier"
+      "uuid": "Identifier",
+      "name": "Name"
     },
     "errors": {
       "header": "An error occurred saving the record",

--- a/db/migrate/20260514201623_add_merged_name_to_record_merges.core_data_connector.rb
+++ b/db/migrate/20260514201623_add_merged_name_to_record_merges.core_data_connector.rb
@@ -1,0 +1,6 @@
+# This migration comes from core_data_connector (originally 20260514201613)
+class AddMergedNameToRecordMerges < ActiveRecord::Migration[8.0]
+  def change
+    add_column :core_data_connector_record_merges, :merged_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_04_182505) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_14_201623) do
+  create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
@@ -285,6 +286,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_182505) do
     t.string "merged_uuid"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "merged_name"
     t.index ["mergeable_type", "mergeable_id"], name: "index_core_data_connector_record_merges_on_mergeable"
   end
 


### PR DESCRIPTION
# Summary

This PR addresses #614.

- updates the label for the existing "created by" column to say "merge date" to be more clear what the date actually comes from
- adds a name column containing the name of the record that was merged

## Screenshot

<img width="1121" height="161" alt="Screenshot 2026-05-15 at 11 29 34 AM" src="https://github.com/user-attachments/assets/a3a114d7-fcde-49b3-8544-98f61b5eb1c4" />

## Testing notes

Merging is supported for the following record types, so make sure merging still works for each one and that a `name` value is set for every merged record:

- [ ] events
- [ ] instances
- [ ] items
- [ ] media content
- [ ] organizations
- [ ] people
- [ ] places
- [ ] taxonomies
- [ ] works