### PR TITLE
Add Linux bundle platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.20.0)
@@ -268,10 +269,13 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
     ostruct (0.6.3)
     pagy (5.10.1)
       activesupport
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
     postmark (1.25.1)
       json
     postmark-rails (0.22.1)
@@ -375,6 +379,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.225)


### PR DESCRIPTION
# Summary

This PR fixes a build error on Heroku where the Linux platform wasn't enabled in the lockfile.