### PR TITLE
Disable ActiveRecord variant feature to silence warning

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  config.active_storage.variant_processor = :disabled
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
+  config.active_storage.variant_processor = :disabled
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -32,6 +32,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
+  config.active_storage.variant_processor = :disabled
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
+  config.active_storage.variant_processor = :disabled
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
# Summary

This PR fixes a warning in the latest version of Rails:

```
W, [2026-06-10T19:17:20.068790 #27]  WARN -- : Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
```

We don't use this feature, so I disabled it across all the config files.