### PR TITLE
Add primary domain redirect middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,7 @@ POSTMARK_INTERVAL=24
 
 # The canonical domain for the application. Requests made against any other domain are redirected
 # here, preserving the path and query string. Leave blank to disable redirects.
+# Must be a bare domain (e.g. fairdata.performant.studio NOT https://fairdata.performant.studio)
 PRIMARY_DOMAIN=
 
 # Rails environment

--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@ POSTMARK_FROM=no-reply@app.coredata.cloud
 # emails within this interval.
 POSTMARK_INTERVAL=24
 
+# The canonical domain for the application. Requests made against any other domain are redirected
+# here, preserving the path and query string. Leave blank to disable redirects.
+PRIMARY_DOMAIN=
+
 # Rails environment
 RAILS_ENV=development
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative '../lib/canonical_domain_redirect'
+
 module RailsReactTemplate
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -23,6 +25,9 @@ module RailsReactTemplate
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Redirect requests for non-canonical domains before any other processing.
+    config.middleware.insert_before 0, CanonicalDomainRedirect
 
     # Configure Postmark for transactional emails
     config.action_mailer.delivery_method = :postmark

--- a/lib/canonical_domain_redirect.rb
+++ b/lib/canonical_domain_redirect.rb
@@ -1,0 +1,28 @@
+class CanonicalDomainRedirect
+
+  def initialize(app)
+    @app = app
+    @primary_domain = ENV['PRIMARY_DOMAIN'].presence
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+    return @app.call(env) unless redirect?(request)
+
+    location = "#{request.scheme}://#{@primary_domain}#{request.fullpath}"
+
+    # Use 308 for POST/PUT/etc requests to preserve body data
+    status = request.get? || request.head? ? 301 : 308
+
+    [status, { 'Location' => location, 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache' }, []]
+  end
+
+  private
+
+  def redirect?(request)
+    return false if @primary_domain.nil?
+
+    host = request.host
+    host.present? && host.downcase != @primary_domain.split(':').first
+  end
+end


### PR DESCRIPTION
# Summary

This PR adds Rack middleware to perform 301/308 redirects to a canonical domain set via the PRIMARY_DOMAIN environment variable. This will help support our migration to `fairdata.performant.studio` by keeping old routes working for places where they're still linked.

This can't be properly tested locally so I can't promise it won't break staging 🤪