### PR TITLE
Audit log feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v1.0.0'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.2.3'
+gem 'core_data_connector', path: '../core-data-connector'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.9'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v1.0.0'
 
 # Core data
-gem 'core_data_connector', path: '../core-data-connector'
+gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.2.4'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,28 @@
 GIT
+  remote: https://github.com/performant-software/core-data-connector.git
+  revision: 18044e5df814eef4994c7b5f51a35be5afec80cc
+  tag: v0.2.4
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 11.1)
+      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
+      faker
+      fuzzy_dates
+      jwt (~> 3.2)
+      jwt_auth
+      paper_trail (>= 16.0)
+      postmark-rails (~> 0.22.1)
+      rack-cors (~> 3.0.0)
+      rails (>= 8.1, < 9)
+      resource_api
+      rgeo-geojson (~> 2.2)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 5.0)
+      typhoeus (~> 1.6)
+      user_defined_fields
+
+GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: 1572b9c3370922aace98e9e2db139a30c55fda48
   tag: v0.1.2
@@ -43,28 +67,6 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 9)
       resource_api
-
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 11.1)
-      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
-      faker
-      fuzzy_dates
-      jwt (~> 3.2)
-      jwt_auth
-      paper_trail (>= 16.0)
-      postmark-rails (~> 0.22.1)
-      rack-cors (~> 3.0.0)
-      rails (>= 8.1, < 9)
-      resource_api
-      rgeo-geojson (~> 2.2)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 5.0)
-      typhoeus (~> 1.6)
-      user_defined_fields
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 289fb313da839488c5358b2a72caf5f13bfca4aa
-  tag: v0.2.3
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 11.1)
-      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
-      faker
-      fuzzy_dates
-      jwt (~> 3.2)
-      jwt_auth
-      paper_trail (>= 16.0)
-      postmark-rails (~> 0.22.1)
-      rack-cors (~> 3.0.0)
-      rails (>= 8.1, < 9)
-      resource_api
-      rgeo-geojson (~> 2.2)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 5.0)
-      typhoeus (~> 1.6)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: 1572b9c3370922aace98e9e2db139a30c55fda48
   tag: v0.1.2
@@ -67,6 +43,28 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 9)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 11.1)
+      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
+      faker
+      fuzzy_dates
+      jwt (~> 3.2)
+      jwt_auth
+      paper_trail (>= 16.0)
+      postmark-rails (~> 0.22.1)
+      rack-cors (~> 3.0.0)
+      rails (>= 8.1, < 9)
+      resource_api
+      rgeo-geojson (~> 2.2)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 5.0)
+      typhoeus (~> 1.6)
+      user_defined_fields
 
 GEM
   remote: https://rubygems.org/

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -37,7 +37,7 @@
     "models": {
       "Event": "event",
       "Instance": "instance",
-      "Item": "taxonomy item",
+      "Item": "item",
       "MediaContent": "media content",
       "Organization": "organization",
       "OrganizationName": "organization name",
@@ -1152,7 +1152,7 @@
       "event": "Event",
       "fields": "Fields",
       "name": "Name",
-      "type": "Type",
+      "model": "Model",
       "user": "User",
       "updateType": "Update Type",
       "uuid": "Record UUID"

--- a/client/src/pages/Project.js
+++ b/client/src/pages/Project.js
@@ -9,7 +9,6 @@ import { IoSearchOutline } from 'react-icons/io5';
 import { useNavigate } from 'react-router';
 import {
   Button,
-  Confirm,
   Form,
   Header,
   Icon,

--- a/client/src/pages/ProjectAuditLog.js
+++ b/client/src/pages/ProjectAuditLog.js
@@ -27,6 +27,15 @@ const ProjectAuditLog = () => {
     return `/projects/${projectId}/${version.roots[0].project_model_id}/${version.roots[0].id}`
   }, [])
 
+  const isEditable = useCallback((version) => {
+    if (EDITABLE_EVENTS.includes(version.event)) {
+      return true;
+    }
+
+    // allow editing the root if the change belongs to a secondary model
+    return !version.roots.map(r => r.record_type).includes(version.record_type);
+  }, [])
+
   if (!canEditProjectSettings(projectId)) {
     return <UnauthorizedRedirect />;
   }
@@ -37,7 +46,7 @@ const ProjectAuditLog = () => {
       <RecordVersions
         actions={[{
           // prevent the user from being directed to the edit page for destroyed records
-          accept: (v) => EDITABLE_EVENTS.includes(v.event),
+          accept: isEditable,
           name: 'edit',
           render: (v) => getEditButton(v, {
             idField: 'item_id',
@@ -52,9 +61,9 @@ const ProjectAuditLog = () => {
             hidden: true
           },
           {
-            name: 'root_record_type',
-            label: t('Versions.columns.type'),
-            render: (v) => renderRootField(v, 'record_type')
+            name: 'root_record_name',
+            label: t('Versions.columns.model'),
+            render: (v) => renderRootField(v, 'project_model_name')
           },
           {
             name: 'root_display_name',

--- a/client/src/pages/ProjectAuditLog.js
+++ b/client/src/pages/ProjectAuditLog.js
@@ -10,8 +10,6 @@ import useParams from '../hooks/ParsedParams';
 import { useTranslation } from 'react-i18next';
 import { getEditButton } from '../utils/Tables';
 
-const EDITABLE_EVENTS = ['update', 'create'];
-
 const ProjectAuditLog = () => {
   const { projectId } = useParams();
   const { canEditProjectSettings } = usePermissions();
@@ -21,20 +19,14 @@ const ProjectAuditLog = () => {
     return version.roots.map(r => (
       <p key={r.uuid}>{r[fieldName]}</p>
     ));
-  }, [])
+  }, []);
 
   const resolveEditUrl = useCallback((version) => {
     return `/projects/${projectId}/${version.roots[0].project_model_id}/${version.roots[0].id}`
-  }, [])
+  }, []);
 
-  const isEditable = useCallback((version) => {
-    if (EDITABLE_EVENTS.includes(version.event)) {
-      return true;
-    }
-
-    // allow editing the root if the change belongs to a secondary model
-    return !version.roots.map(r => r.record_type).includes(version.record_type);
-  }, [])
+  // allow editing the root if the change belongs to a secondary model
+  const isEditable = useCallback((version) => version.roots.some(r => !r.deleted), []);
 
   if (!canEditProjectSettings(projectId)) {
     return <UnauthorizedRedirect />;

--- a/client/src/types/Version.js
+++ b/client/src/types/Version.js
@@ -14,8 +14,9 @@ export type Version = {
     root_record_type: string,
     root_display_name: string,
     root_uuid: string,
-    root_project_model_id: number
-  },
+    root_project_model_id: number,
+    deleted: boolean
+  }[],
   user: User,
   record_type: string,
   attributes: {


### PR DESCRIPTION
# Summary

This PR:
* fixes the label for Items, which previously included the word taxonomy
* replace the Type column with Model, which shows the actual name of the model that the record belongs to
* updates the `accept` callback that determines whether to render the edit button for a version row in ProjectAuditLog to check for https://github.com/performant-software/core-data-connector/pull/215's new `deleted` boolean instead of just blanket allowing/disallowing depending on update type, which was broken in ways beyond what's described in https://github.com/performant-software/core-data-cloud/issues/655 (e.g. an `update` row for a record that was later deleted would previously still show an edit button)