### PR TITLE
Integrate connector gem into main repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 
 # IntelliJ
 .idea
+
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,6 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 # Authentication
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v1.0.0'
 
-# Core data
-gem 'core_data_connector', path: '../core-data-connector'
-
 # Record versioning / audit log
 gem 'paper_trail', '>= 16.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gem 'rails', '~> 8.1.3'
 # Use Postgres as the database for Active Record
 gem 'pg', '~> 1.6.3'
 
+# Geospatial column types and GeoJSON serialization
+gem 'activerecord-postgis-adapter', '~> 11.1'
+gem 'rgeo-geojson', '~> 2.2'
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 8.0.2'
 
@@ -30,6 +34,10 @@ gem 'postmark-rails', '~> 0.22.1'
 # CSV processing
 gem 'csv', '~> 3.3.5'
 
+# Zip archive processing for imports and exports.
+# Note: the gem is named `rubyzip` but ships `lib/zip.rb`, so the require path must be given.
+gem 'rubyzip', '~> 2.3.2', require: 'zip'
+
 # Resource API
 gem 'resource_api', git: 'https://github.com/performant-software/resource-api.git', tag: 'v0.5.17'
 
@@ -37,7 +45,17 @@ gem 'resource_api', git: 'https://github.com/performant-software/resource-api.gi
 gem 'jwt_auth', git: 'https://github.com/performant-software/jwt-auth.git', tag: 'v1.0.0'
 
 # Core data
-gem 'core_data_connector', git: 'https://github.com/performant-software/core-data-connector.git', tag: 'v0.2.4'
+gem 'core_data_connector', path: '../core-data-connector'
+
+# Record versioning / audit log
+gem 'paper_trail', '>= 16.0'
+
+# CORS for the public and reconciliation APIs
+gem 'rack-cors', '~> 3.0.0', require: 'rack/cors'
+
+# Typesense search and reconciliation
+gem 'typesense', '~> 5.0'
+gem 'typhoeus', '~> 1.6'
 
 # IIIF
 gem 'triple_eye_effable', git: 'https://github.com/performant-software/triple-eye-effable.git', tag: 'v0.2.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,4 @@
 GIT
-  remote: https://github.com/performant-software/core-data-connector.git
-  revision: 18044e5df814eef4994c7b5f51a35be5afec80cc
-  tag: v0.2.4
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 11.1)
-      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
-      faker
-      fuzzy_dates
-      jwt (~> 3.2)
-      jwt_auth
-      paper_trail (>= 16.0)
-      postmark-rails (~> 0.22.1)
-      rack-cors (~> 3.0.0)
-      rails (>= 8.1, < 9)
-      resource_api
-      rgeo-geojson (~> 2.2)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 5.0)
-      typhoeus (~> 1.6)
-      user_defined_fields
-
-GIT
   remote: https://github.com/performant-software/fuzzy-dates.git
   revision: 1572b9c3370922aace98e9e2db139a30c55fda48
   tag: v0.1.2
@@ -67,6 +43,27 @@ GIT
     user_defined_fields (0.1.0)
       rails (>= 6.0.3.2, < 9)
       resource_api
+
+PATH
+  remote: ../core-data-connector
+  specs:
+    core_data_connector (0.1.0)
+      activerecord-postgis-adapter (~> 11.1)
+      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
+      fuzzy_dates
+      jwt (~> 3.2)
+      jwt_auth
+      paper_trail (>= 16.0)
+      postmark-rails (~> 0.22.1)
+      rack-cors (~> 3.0.0)
+      rails (>= 8.1, < 9)
+      resource_api
+      rgeo-geojson (~> 2.2)
+      rubyzip (~> 2.3.2)
+      triple_eye_effable
+      typesense (~> 5.0)
+      typhoeus (~> 1.6)
+      user_defined_fields
 
 GEM
   remote: https://rubygems.org/
@@ -201,8 +198,6 @@ GEM
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
-    faker (3.8.0)
-      i18n (>= 1.8.11, < 2)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -393,6 +388,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-postgis-adapter (~> 11.1)
   aws-sdk-s3 (~> 1.225)
   bcrypt (~> 3.1.22)
   bootsnap
@@ -407,13 +403,19 @@ DEPENDENCIES
   jwt_auth!
   mail_safe (~> 0.3.4)
   ostruct (~> 0.6.3)
+  paper_trail (>= 16.0)
   pg (~> 1.6.3)
   postmark-rails (~> 0.22.1)
   puma (~> 8.0.2)
+  rack-cors (~> 3.0.0)
   rails (~> 8.1.3)
   resource_api!
+  rgeo-geojson (~> 2.2)
+  rubyzip (~> 2.3.2)
   sidekiq (~> 8.1.6)
   triple_eye_effable!
+  typesense (~> 5.0)
+  typhoeus (~> 1.6)
   tzinfo-data
   user_defined_fields!
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,27 +44,6 @@ GIT
       rails (>= 6.0.3.2, < 9)
       resource_api
 
-PATH
-  remote: ../core-data-connector
-  specs:
-    core_data_connector (0.1.0)
-      activerecord-postgis-adapter (~> 11.1)
-      clerk-sdk-ruby (~> 5.1, >= 5.1.2)
-      fuzzy_dates
-      jwt (~> 3.2)
-      jwt_auth
-      paper_trail (>= 16.0)
-      postmark-rails (~> 0.22.1)
-      rack-cors (~> 3.0.0)
-      rails (>= 8.1, < 9)
-      resource_api
-      rgeo-geojson (~> 2.2)
-      rubyzip (~> 2.3.2)
-      triple_eye_effable
-      typesense (~> 5.0)
-      typhoeus (~> 1.6)
-      user_defined_fields
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -394,7 +373,6 @@ DEPENDENCIES
   bootsnap
   bundler-audit (~> 0.9.3)
   clerk-sdk-ruby (~> 5.1, >= 5.1.3)
-  core_data_connector!
   csv (~> 3.3.5)
   debug (~> 1.11.0)
   dotenv-rails (~> 3.2.0)

--- a/app/controllers/concerns/core_data_connector/authentication_controller_override.rb
+++ b/app/controllers/concerns/core_data_connector/authentication_controller_override.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module AuthenticationControllerOverride
+    include ClerkAuthenticatable
+
+    def login
+      if is_clerk?
+        return render status: :unauthorized
+      end
+
+      super
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
+++ b/app/controllers/concerns/core_data_connector/clerk_authenticatable.rb
@@ -1,0 +1,93 @@
+# Conditionally require Clerk because it injects some sort of
+# extra auth layer that breaks username/password auth.
+if ENV['VITE_AUTH_PROVIDER'] == 'clerk'
+  require 'clerk'
+end
+
+module CoreDataConnector
+  module ClerkAuthenticatable
+    private
+
+    def authenticate_clerk_request
+      token = clerk_token
+      return render_unauthorized unless token.present?
+
+      clerk_session = clerk_client.verify_token(token)
+      clerk_id = clerk_session["sub"]
+
+      @current_user = User.find_by(sso_id: clerk_id)
+
+      # If the user exists in Clerk but not in FairData,
+      # create a local account for them automatically.
+      if @current_user.nil?
+        clerk_user = get_clerk_data(clerk_id)
+        @current_user = create_user_from_clerk(clerk_user)
+      end
+
+      return render_not_found unless @current_user
+
+      @current_user
+    rescue StandardError => error
+      log_error(error)
+      render_unauthorized
+    end
+
+    def create_user_from_clerk(clerk_user)
+      user = User.new(
+        sso_id: clerk_user.id,
+        email: clerk_user.email_addresses.first.email_address,
+        name: [clerk_user.first_name, clerk_user.last_name].join(" "),
+        role: 'member',
+        # satisfy the Rails validator even though we won't be using this password
+        password: Users::Passwords.generate_user_password,
+        require_password_change: false
+      )
+
+      user.save!
+
+      user
+    end
+
+    # The Clerk-issued JWT to verify: the __session cookie set by a browser,
+    # or a Bearer token from a non-browser client (the pstudio CLI's OAuth
+    # login). Both are Clerk JWTs, verified the same way against Clerk's JWKS;
+    # sub is the Clerk user id in either case.
+    def clerk_token
+      request.cookies["__session"].presence || bearer_token
+    end
+
+    def bearer_token
+      header = request.headers["Authorization"]
+      return nil unless header&.start_with?("Bearer ")
+
+      header.split(" ", 2).last
+    end
+
+    def get_clerk_data(clerk_id)
+      clerk_client.users.get(user_id: clerk_id).user
+    end
+
+    def clerk_client
+      @clerk_client ||= Clerk::SDK.new(secret_key: ENV.fetch("CLERK_SECRET_KEY"))
+    end
+
+    def render_unauthorized
+      render json: { error: I18n.t("errors.users.unauthorized") }, status: :unauthorized
+    end
+
+    def render_not_found
+      render json: { error: I18n.t("errors.users.not_found") }, status: :unauthorized
+    end
+
+    # Returns whether to use Clerk to authenticate the request
+    def is_clerk?
+      # backward compat for FCC 1's username/password login
+      return false if request.headers['client'] == 'faircopy-cloud-1'
+
+      # backward compat for FCC 2's username/password login
+      return false if request.headers['user-agent'] == 'node'
+
+      ENV['VITE_AUTH_PROVIDER'] == 'clerk'
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/manifestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/manifestable_controller.rb
@@ -1,0 +1,23 @@
+module CoreDataConnector
+  module ManifestableController
+    extend ActiveSupport::Concern
+
+    included do
+
+      def create_manifests
+        item = find_record(item_class)
+        authorize item
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(item_class, {
+          id: item.id,
+          project_model_relationship_id: params[:project_model_relationship_id],
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+        })
+
+        render status: :ok
+      end
+
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/manifests_controller.rb
+++ b/app/controllers/concerns/core_data_connector/manifests_controller.rb
@@ -1,0 +1,126 @@
+module CoreDataConnector
+  module ManifestsController
+    extend ActiveSupport::Concern
+
+    # This module should be included in the relationships_controller in order to handle generating IIIF manifests
+    # after records are added/removed.
+    included do
+      # Actions
+      after_action :update_manifests_on_create, only: :create
+      after_action :update_manifests_on_upload, only: :upload
+      after_action :update_manifests_on_delete, only: :destroy
+      after_action :update_manifests_on_update, only: :update
+      before_action :set_record_for_manifest, only: :destroy
+
+      private
+
+      # Returns the record to update the manifest for the passed relationship.
+      def record_to_update(relationship)
+        record = nil
+  
+        if relationship.related_record_type == MediaContent.to_s
+          record = relationship.primary_record
+        elsif relationship.primary_record_type == MediaContent.to_s && relationship.project_model_relationship.allow_inverse?
+          record = relationship.related_record
+        end
+
+        # Only create manifests for models that include the Manifestable concern
+        return nil unless record.is_a?(Manifestable)
+
+        record
+      end
+
+      # For deleting a relationship, we'll track the record and project_model_relationship_id in the before_action,
+      # since the relationship wont exist after.
+      def set_record_for_manifest
+        relationship = Relationship.find(params[:id])
+        @record = record_to_update(relationship)
+        @project_model_relationship_id = relationship.project_model_relationship_id
+      end
+
+      # After creating a single relationships, generate the manifests for the target model.
+      def update_manifests_on_create
+        relationship_params = params[:relationship]
+
+        relationship = Relationship.find_by(
+          project_model_relationship_id: relationship_params[:project_model_relationship_id],
+          primary_record_id: relationship_params[:primary_record_id],
+          primary_record_type: relationship_params[:primary_record_type],
+          related_record_id: relationship_params[:related_record_id],
+          related_record_type: relationship_params[:related_record_type]
+        )
+
+        return unless relationship.present?
+
+        record = record_to_update(relationship)
+
+        return if record.nil?
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(record.class, {
+          id: record.id,
+          project_model_relationship_id: relationship.project_model_relationship_id,
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+        })
+      end
+
+      # After the relationship has been deleted, re-create the manifest for the target model.
+      def update_manifests_on_delete
+        return if @record.nil? || @project_model_relationship_id.nil?
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(@record.class, {
+          id: @record.id,
+          project_model_relationship_id: @project_model_relationship_id,
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+        })
+      end
+
+      # After updating a relationship, generate the manifests for the target models
+      def update_manifests_on_update
+        relationship = Relationship.find(params[:id])
+
+        record = record_to_update(relationship)
+
+        return if record.nil?
+
+        service = Iiif::Manifest.new
+        service.reset_manifests_by_type(record.class, {
+          id: record.id,
+          project_model_relationship_id: relationship.project_model_relationship_id,
+          limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+        })
+      end
+
+      # After uploading new relationships, generate the manifests for the target models.
+      def update_manifests_on_upload
+        cache = []
+
+        params[:relationships].keys.each do |index|
+          relationship_params = params[:relationships][index]
+
+          relationship = Relationship.find_by(
+            primary_record_id: relationship_params[:primary_record_id],
+            primary_record_type: relationship_params[:primary_record_type],
+            related_record_id: relationship_params[:related_record_id],
+            related_record_type: relationship_params[:related_record_type]
+          )
+
+          next if relationship.nil?
+
+          record = record_to_update(relationship)
+          next if record.nil? || cache.include?(record)
+
+          cache << record
+
+          service = Iiif::Manifest.new
+          service.reset_manifests_by_type(record.class, {
+            id: record.id,
+            project_model_relationship_id: relationship.project_model_relationship_id,
+            limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/mergeable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/mergeable_controller.rb
@@ -1,0 +1,71 @@
+module CoreDataConnector
+  module MergeableController
+    extend ActiveSupport::Concern
+
+    included do
+      # Search methods
+      search_methods :search_merged_uuid
+
+      def merge
+        render json: { errors: [I18n.t('errors.mergeable.ids')] }, status: :bad_request and return unless params[:ids].present?
+
+        item = item_class.new(prepare_params)
+        authorize_create item
+
+        items = item_class
+                  .preload(ImportAnalyze::Helper::PRELOADS)
+                  .where(id: params[:ids])
+
+        authorize_destroy items
+
+        begin
+          service = Merge::Merger.new
+          service.merge(item, items)
+
+          errors = item.errors
+        rescue StandardError => exception
+          errors = [exception]
+        end
+
+        if errors.nil? || errors.empty?
+          render json: build_show_response(item), status: :ok
+        else
+          render json: { errors: errors }, status: :bad_request
+        end
+      end
+
+      private
+
+      def authorize_create(item)
+        policy = Pundit.policy!(current_user, item)
+        policy.create?
+      end
+
+      def authorize_destroy(items)
+        items.each do |item|
+          policy = Pundit.policy!(current_user, item)
+          policy.destroy?
+        end
+      end
+
+      def search_merged_uuid(query)
+        return query unless params[:search].present?
+
+        uuid_query = item_class.where(
+          RecordMerge
+            .where(RecordMerge.arel_table[:mergeable_id].eq(item_class.arel_table[:id]))
+            .where(mergeable_type: item_class.to_s)
+            .where(merged_uuid: params[:search])
+            .arel
+            .exists
+        )
+
+        if query == item_class.all
+          query.merge(uuid_query)
+        else
+          query.or(uuid_query)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/nameable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/nameable_controller.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  module NameableController
+    extend ActiveSupport::Concern
+
+    included do
+      # Left joins
+      left_joins :primary_name
+
+      # Preloads
+      preloads :primary_name
+
+      def resolve_search_attribute(attr)
+        name_class = "CoreDataConnector::#{item_class.get_names_table.to_s.classify}".constantize
+
+        return super unless name_class.column_names.include?(attr.to_s)
+
+        "#{name_class.table_name}.#{attr.to_s}"
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/ownable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/ownable_controller.rb
@@ -1,0 +1,51 @@
+module CoreDataConnector
+  module OwnableController
+    extend ActiveSupport::Concern
+
+    VIEW_ALL = 'all'
+    VIEW_OWNED = 'owned'
+    VIEW_SHARED = 'shared'
+
+    included do
+      search_methods :search_uuid
+
+      protected
+
+      def base_query
+        query = super
+
+        # For a single record, we don't need project_model_id. We'll let the policy handle authorization.
+        return query if params[:id].present?
+
+        # Return an empty set if the project_model_id is not present
+        return item_class.none unless params[:project_model_id].present?
+
+        # For an index view, we'll filter the records based on the "view" parameter, defaulting to the records
+        # owned by the passed "project_model_id" parameter.
+        if params[:view] == VIEW_ALL
+          query.merge(item_class.all_records_by_project_model(params[:project_model_id]))
+        elsif params[:view] == VIEW_OWNED
+          query.merge(item_class.owned_records_by_project_model(params[:project_model_id]))
+        elsif params[:view] == VIEW_SHARED
+          query.merge(item_class.shared_records_by_project_model(params[:project_model_id]))
+        else
+          query.merge(item_class.owned_records_by_project_model(params[:project_model_id]))
+        end
+      end
+
+      private
+
+      def search_uuid(query)
+        return query unless params[:search].present?
+
+        uuid_query = item_class.where(uuid: params[:search])
+
+        if query == item_class.all
+          query.merge(uuid_query)
+        else
+          query.or(uuid_query)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/public/v0/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v0/nestable_controller.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module NestableController
+        extend ActiveSupport::Concern
+
+        included do
+          # Member attributes
+          attr_reader :current_record
+
+          # Actions
+          before_action :set_current_record
+
+          private
+
+          def set_current_record
+            if params[:event_id].present?
+              @current_record = Event.find_by_uuid(params[:event_id])
+            elsif params[:instance_id].present?
+              @current_record = Instance.find_by_uuid(params[:instance_id])
+            elsif params[:item_id].present?
+              @current_record = Item.find_by_uuid(params[:item_id])
+            elsif params[:place_id].present?
+              @current_record = Place.find_by_uuid(params[:place_id])
+            elsif params[:work_id].present?
+              @current_record = Work.find_by_uuid(params[:work_id])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/public/v0/unauthenticateable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v0/unauthenticateable_controller.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module UnauthenticateableController
+        extend ActiveSupport::Concern
+
+        included do
+          # No user authentication
+          skip_before_action :handle_authentication
+
+          # No Pundit authorization
+          before_action :bypass_authorization
+
+          protected
+
+          def find_record(query)
+            query.find_by_uuid(params[:id])
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -1,0 +1,43 @@
+module CoreDataConnector
+  module Public
+    module V1
+      module NestableController
+        extend ActiveSupport::Concern
+
+        NESTABLE_PARAMS = %i(event_id instance_id item_id organization_id person_id place_id work_id)
+
+        included do
+          # Member attributes
+          attr_reader :current_record
+
+          # Actions
+          before_action :set_current_record
+
+          def nested_resource?
+            NESTABLE_PARAMS.any? { |p| params[p].present? }
+          end
+
+          private
+
+          def set_current_record
+            if params[:event_id].present?
+              @current_record = Event.find_by_uuid(params[:event_id])
+            elsif params[:instance_id].present?
+              @current_record = Instance.find_by_uuid(params[:instance_id])
+            elsif params[:item_id].present?
+              @current_record = Item.find_by_uuid(params[:item_id])
+            elsif params[:organization_id].present?
+              @current_record = Organization.find_by_uuid(params[:organization_id])
+            elsif params[:person_id].present?
+              @current_record = Person.find_by_uuid(params[:person_id])
+            elsif params[:place_id].present?
+              @current_record = Place.find_by_uuid(params[:place_id])
+            elsif params[:work_id].present?
+              @current_record = Work.find_by_uuid(params[:work_id])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/public/v1/unauthenticateable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/unauthenticateable_controller.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Public
+    module V1
+      module UnauthenticateableController
+        extend ActiveSupport::Concern
+
+        included do
+          # No user authentication
+          skip_before_action :handle_authentication
+        end
+
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/public/v1/unauthorizeable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/unauthorizeable_controller.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module Public
+    module V1
+      module UnauthorizeableController
+        extend ActiveSupport::Concern
+
+        included do
+
+          # Authorization errors
+          rescue_from ActiveRecord::RecordNotFound, with: :unauthorized
+
+          def unauthorized
+            render json: { errors: [{ base: I18n.t('errors.general.not_found') }] }, status: :not_found
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/core_data_connector/related_columnable.rb
+++ b/app/controllers/concerns/core_data_connector/related_columnable.rb
@@ -1,0 +1,47 @@
+module CoreDataConnector
+  module RelatedColumnable
+    extend ActiveSupport::Concern
+
+    protected
+
+    def prepare_items(items)
+      cols = permitted_related_columns
+      return items if cols.empty? || items.empty?
+
+      ids = items.map(&:id)
+      prepared = CoreDataConnector::RecordTableQuery.new(
+        source_model:    item_class,
+        related_columns: cols
+      ).call(item_class.where(id: ids)).index_by(&:id)
+
+      # Preserve the order pagy gave us (which respects apply_sort)
+      ids.map { |id| prepared[id] }.compact
+    end
+
+    def permitted_related_columns
+      @permitted_related_columns ||= begin
+                                       raw = params[:join_columns]
+
+                                       base_columns = Array(raw).map do |c|
+                                         split = c.split('_')
+                                         next unless split.length == 3
+
+                                         { pmr_id: split[1].to_i, field: split[2] }
+                                       end
+
+                                       base_columns.map { |c| c.respond_to?(:permit) ? c.permit(:pmr_id, :field) : c }
+                                                   .reject { |c| c[:pmr_id].zero? || c[:field].empty? }
+                                     end
+    end
+
+    def related_column_aliases
+      permitted_related_columns.map do |c|
+        "rel_#{c[:pmr_id]}_#{c[:field].gsub(/\W/, '_')}"
+      end
+    end
+
+    def load_records(items)
+      super.merge(related_column_aliases: related_column_aliases)
+    end
+  end
+end

--- a/app/controllers/core_data_connector/application_controller.rb
+++ b/app/controllers/core_data_connector/application_controller.rb
@@ -1,0 +1,50 @@
+module CoreDataConnector
+  class ApplicationController < Api::ResourceController
+    # Includes
+    include JwtAuth::Authenticateable
+    include ClerkAuthenticatable
+
+    # Errors
+    rescue_from ArgumentError, with: :render_bad_request
+
+    # Actions
+    skip_before_action :authenticate_request
+    before_action :handle_authentication, :set_paper_trail_whodunnit
+
+    def item_class
+      "CoreDataConnector::#{controller_name.singularize.classify}".constantize
+    end
+
+    def serializer_class
+      "CoreDataConnector::#{"#{controller_name}_serializer".classify}".constantize
+    end
+
+    protected
+
+    def user_for_paper_trail
+      current_user&.id
+    end
+
+    def info_for_paper_trail
+      { request_uuid: request.uuid }
+    end
+
+    private
+
+    def handle_authentication
+      if is_clerk?
+        authenticate_clerk_request
+      else
+        authenticate_request
+      end
+    end
+
+    def log_error(error)
+      Rails.logger.error (["#{self.class} - #{error.class}: #{error.message}", error.backtrace]).join("\n")
+    end
+
+    def render_bad_request(error)
+      render json: { errors: [{ base: error.message }] }, status: :bad_request
+    end
+  end
+end

--- a/app/controllers/core_data_connector/direct_uploads_controller.rb
+++ b/app/controllers/core_data_connector/direct_uploads_controller.rb
@@ -1,0 +1,18 @@
+module CoreDataConnector
+  class DirectUploadsController < ApplicationController
+    # Actions
+    before_action :check_policy, only: :create
+
+    private
+
+    def check_policy
+      # If no storage key is present, assume the user can upload to the shared storage
+      return unless request.headers['X-STORAGE-KEY'].present?
+
+      project = Project.find_by(uuid: request.headers['X-STORAGE-KEY'])
+      raise Pundit::NotAuthorizedError if project.nil?
+
+      authorize project, :create?, policy_class: DirectUploadPolicy
+    end
+  end
+end

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  class EventsController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :start_date, :end_date
+
+    # Joins
+    joins Event.start_date_join, Event.end_date_join
+
+    # Search attributes
+    search_attributes :name, :description
+  end
+end

--- a/app/controllers/core_data_connector/instances_controller.rb
+++ b/app/controllers/core_data_connector/instances_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  class InstancesController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include NameableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :source_names, only: :show
+
+    # Search attributes
+    search_attributes :name
+  end
+end

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -1,0 +1,73 @@
+module CoreDataConnector
+  class ItemsController < ApplicationController
+    # Includes
+    include Http::Requestable
+    include ManifestableController
+    include MergeableController
+    include NameableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :source_names, only: :show
+
+    # Search attributes
+    search_attributes :name
+
+    def analyze_import
+      item = find_record(item_class)
+      authorize item
+
+      errors = nil
+      data = nil
+
+      service = ImportAnalyze::Helper.new
+
+      begin
+        # Download the zip file from FairCopy.cloud
+        send_request(item.faircopy_cloud_url, followlocation: true) do |contents|
+          # Write the contents to a temporary file
+          file = Tempfile.new
+          file.binmode
+          file.write(contents)
+          file.rewind
+
+          data = service.analyze(file, current_user)
+        end
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error(error)
+      end
+
+      if errors.nil? || errors.empty?
+        render json: data, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
+
+    def import
+      item = find_record(item_class)
+      authorize item
+
+      begin
+        service = ImportAnalyze::Helper.new
+        errors = service.import(params[:files], current_user, item.project_model.project_id)
+      rescue StandardError => error
+        errors = [error]
+      end
+
+      # Log any errors
+      errors.each { |e| log_error(e) } if errors.present?
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/jobs_controller.rb
+++ b/app/controllers/core_data_connector/jobs_controller.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class JobsController < ApplicationController
+    # Search attributes
+    search_attributes 'core_data_connector_users.name', 'core_data_connector_projects.name', :job_type
+
+    # Joins
+    joins :project, :user
+
+    # Preloads
+    preloads file_attachment: :blob
+    preloads :project, :user
+
+    protected
+
+    def apply_filters(query)
+      query = super
+
+      query = filter_project(query)
+
+      query
+    end
+
+    private
+
+    def filter_project(query)
+      return query unless params[:project_id].present?
+
+      query.where(project_id: params[:project_id])
+    end
+  end
+end

--- a/app/controllers/core_data_connector/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/media_contents_controller.rb
@@ -1,0 +1,38 @@
+module CoreDataConnector
+  class MediaContentsController < ApplicationController
+    # Includes
+    include Api::Uploadable
+    include Http::Requestable
+    include ManifestableController
+    include MergeableController
+    include OwnableController
+    include RelatedColumnable
+    include TripleEyeEffable::ResourceableController
+    include UserDefinedFields::Queryable
+
+    # Search attributes
+    search_attributes :name
+
+    # Actions
+    before_action :set_content, only: :merge
+
+    protected
+
+    def set_content
+      send_request(params[:media_content][:content_url], followlocation: true) do |content|
+        tempfile = Tempfile.new
+        tempfile.binmode
+        tempfile.write(content)
+        tempfile.rewind
+
+        file = ActionDispatch::Http::UploadedFile.new(
+          tempfile: tempfile,
+          type: params[:media_content][:content_type],
+          filename: params[:media_content][:name]
+        )
+
+        params[:media_content][:content] = file
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/organizations_controller.rb
+++ b/app/controllers/core_data_connector/organizations_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  class OrganizationsController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include NameableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :organization_names, only: :show
+
+    # Search attributes
+    search_attributes :name
+  end
+end

--- a/app/controllers/core_data_connector/people_controller.rb
+++ b/app/controllers/core_data_connector/people_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  class PeopleController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include NameableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :person_names, only: :show
+
+    # Search attributes
+    search_attributes :first_name, :middle_name, :last_name
+  end
+end

--- a/app/controllers/core_data_connector/places_controller.rb
+++ b/app/controllers/core_data_connector/places_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  class PlacesController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include NameableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :place_names, :place_geometry, :place_layers, only: :show
+
+    # Search attributes
+    search_attributes :name
+  end
+end

--- a/app/controllers/core_data_connector/project_model_accesses_controller.rb
+++ b/app/controllers/core_data_connector/project_model_accesses_controller.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  class ProjectModelAccessesController < ApplicationController
+    # Search attributes
+    search_attributes 'core_data_connector_projects.name'
+
+    # Joins
+    joins project_model: :project
+
+    # Preloads
+    preloads project_model: :project
+
+    protected
+
+    def base_query
+      query = super
+
+      return ProjectModelAccess.none unless params[:project_id].present? && params[:model_class].present?
+
+      query
+        .where(project_id: params[:project_id])
+        .where(core_data_connector_project_models: {
+          model_class: params[:model_class]
+        })
+    end
+  end
+end

--- a/app/controllers/core_data_connector/project_models_controller.rb
+++ b/app/controllers/core_data_connector/project_models_controller.rb
@@ -1,0 +1,46 @@
+module CoreDataConnector
+  class ProjectModelsController < ApplicationController
+    # Search attributes
+    search_attributes :name
+
+    # Preloads
+    preloads :project, only: :index
+    preloads :project_model_shares, only: :index
+    preloads project_model_relationships: :related_model, only: :show
+    preloads inverse_project_model_relationships: :primary_model, only: :show
+    preloads project_model_accesses: :project, only: :show
+    preloads project_model_shares: [project_model_access: :project_model], only: :show
+
+    # Returns a list of valid model classes
+    def model_classes
+      classes = ProjectModel
+                  .model_classes
+                  .map(&:model_name)
+                  .map{ |mn| { label: mn.human, value: mn.name } }
+                  .sort_by{ |mn| mn[:label] }
+
+      render json: { model_classes: classes }, status: :ok
+    end
+
+    protected
+
+    # Project settings cannot be viewed outside the context of a project
+    def base_query
+      query = super
+
+      if params[:id].present?
+        query = query.where(id: params[:id])
+      elsif params[:project_id].present?
+        query = query.where(project_id: params[:project_id])
+      else
+        query = ProjectModel.none
+      end
+
+      if params[:model_class].present?
+        query = query.where(model_class: params[:model_class])
+      end
+
+      query
+    end
+  end
+end

--- a/app/controllers/core_data_connector/projects_controller.rb
+++ b/app/controllers/core_data_connector/projects_controller.rb
@@ -1,0 +1,206 @@
+module CoreDataConnector
+  class ProjectsController < ApplicationController
+    # Search attributes
+    search_attributes :name
+
+    def analyze_import
+      render json: { errors: [I18n.t('errors.projects.import_data')] }, status: :bad_request and return unless params[:file].present?
+
+      project = Project.find(params[:id])
+      authorize project
+
+      service = ImportAnalyze::Helper.new
+
+      begin
+        data = service.analyze(params[:file], current_user)
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error(error)
+      end
+
+      if errors.nil? || errors.empty?
+        render json: data, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
+
+    def clear
+      project = Project.find(params[:id])
+      authorize project
+
+      # Query for models that are not shared with other projects
+      project_models = ProjectModel
+                         .unshared
+                         .where(project_id: project.id)
+
+      begin
+        project_models.map(&:clear)
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error error
+      end
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
+
+    def export_configuration
+      project = Project.find(params[:id])
+      authorize project
+
+      options = load_records(project)
+      serializer = ProjectConfigurationsSerializer.new(current_user, options)
+
+      json = { param_name.to_sym => serializer.render_show(project) }
+      render json: json, status: :ok
+    end
+
+    def export_data
+      project = Project.find(params[:id])
+      authorize project
+
+      begin
+        job = Job.create(
+          job_type: Job::JOB_TYPE_EXPORT,
+          project_id: project.id,
+          user: current_user
+        )
+
+        errors = job&.errors
+      rescue StandardError => error
+        errors = [error]
+
+        log_error error
+      end
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
+
+    def export_variables
+      project = Project.find(params[:id])
+      authorize project
+
+      serializer = ProjectVariablesSerializer.new(current_user)
+
+      json = { param_name.to_sym => serializer.render_show(project) }
+      render json: json, status: :ok
+    end
+
+    def import_analyze
+      project = Project.find(params[:id])
+      authorize project
+
+      begin
+        service = ImportAnalyze::Helper.new
+        errors = service.import(params[:files], current_user, project.id)
+      rescue StandardError => error
+        errors = [error]
+      end
+
+      # Log any errors
+      errors.each { |e| log_error(e) }
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
+
+    def import_configuration
+      render json: { errors: [I18n.t('errors.projects.import_configuration')] }, status: :bad_request and return unless params[:file].present?
+
+      project = Project.find(params[:id])
+      authorize project
+
+      begin
+        service = Configuration.new(project, params[:file])
+        service.import_configuration
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error(error)
+      end
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
+
+    def import_data
+      render json: { errors: [I18n.t('errors.projects.import_data')] }, status: :bad_request and return unless params[:file].present?
+
+      project = Project.find(params[:id])
+      authorize project
+
+      begin
+        job = Job.create(
+          file: params[:file],
+          job_type: Job::JOB_TYPE_IMPORT,
+          user: current_user,
+          project:
+        )
+
+        errors = job&.errors
+      rescue StandardError => error
+        errors = [error]
+
+        log_error(error)
+      end
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :unprocessable_entity
+      end
+    end
+
+    def map_library
+      project = Project.find(params[:id])
+      authorize project
+
+      library = MapLibrary.new(project.map_library_url)
+      json = library.fetch_library || []
+
+      render json: json, status: :ok
+    end
+
+    protected
+
+    # If we're not looking for "discoverable" projects, use base query defined by the policy. Otherwise, return
+    # a query to find all discoverable projects not matching the current project.
+    def base_query
+      return super unless params[:discoverable].to_s.to_bool && params[:project_id].present?
+
+      Project
+        .where(discoverable: true)
+        .where.not(id: params[:project_id])
+    end
+
+    # Automatically add the user who created the project as the owner, if they are not an admin.
+    def after_create(project)
+      return if current_user.admin?
+
+      UserProject.create(
+        project_id: project.id,
+        user_id: current_user.id,
+        role: UserProject::ROLE_OWNER
+      )
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/instances_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/instances_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class InstancesController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :source_names
+        preloads web_identifiers: :web_authority, only: :show
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/items_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/items_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class ItemsController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :source_names
+        preloads web_identifiers: :web_authority, only: :show
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/instances_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/instances_controller.rb
@@ -1,0 +1,18 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class InstancesController < LinkedPlacesController
+          # Includes
+          include NameableController
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Preloads
+          preloads project_model: :user_defined_fields
+          preloads :source_names, only: :show
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/items_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/items_controller.rb
@@ -1,0 +1,18 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class ItemsController < LinkedPlacesController
+          # Includes
+          include NameableController
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Preloads
+          preloads project_model: :user_defined_fields
+          preloads :source_names, only: :show
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/linked_places_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/linked_places_controller.rb
@@ -1,0 +1,44 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class LinkedPlacesController < PublicController
+
+          protected
+
+          def build_index_response(items, metadata)
+            options = load_records(items).merge({ count: metadata[:count], page: metadata[:page], pages: metadata[:pages] })
+            serializer = serializer_class.new(current_user, options)
+
+            # For nested resources, we'll render the annotation attributes. Otherwise, we'll render the index attributes.
+            if nested_resource?
+              serializer.render_annotation(items)
+            else
+              serializer.render_index(items)
+            end
+          end
+
+          def build_show_response(item)
+            options = load_records(item)
+            serializer = serializer_class.new(current_user, options)
+            serializer.render_show(item)
+          end
+
+          # Sets the additional attributes that are needed in the serializer
+          def load_records(items)
+            opts = super
+
+            opts.merge({
+                         target: current_record,
+                         url: request.url
+                       })
+          end
+
+          def serializer_class
+            "CoreDataConnector::Public::V0::LinkedPlaces::#{"#{controller_name}_serializer".classify}".constantize
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/media_contents_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class MediaContentsController < LinkedPlacesController
+          # Includes
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Preloads
+          preloads project_model: :user_defined_fields
+
+          # Search attributes
+          search_attributes :name
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/organizations_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/organizations_controller.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class OrganizationsController < LinkedPlacesController
+          # Includes
+          include NameableController
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Joins
+          joins :primary_name
+
+          # Preloads
+          preloads :organization_names
+          preloads :primary_name
+          preloads project_model: :user_defined_fields
+
+          # Search attributes
+          search_attributes :name, :description
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/people_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/people_controller.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class PeopleController < LinkedPlacesController
+          # Includes
+          include NameableController
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Joins
+          joins :primary_name
+
+          # Preloads
+          preloads :person_names
+          preloads :primary_name
+          preloads project_model: :user_defined_fields
+
+          # Search attributes
+          search_attributes :first_name, :middle_name, :last_name
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/places_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/places_controller.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class PlacesController < LinkedPlacesController
+          # Includes
+          include NameableController
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Joins
+          joins :primary_name
+
+          # Preloads
+          preloads :primary_name
+          preloads :place_names, :place_geometry
+          preloads project_model: :user_defined_fields
+          preloads :place_layers, only: :show
+          preloads web_identifiers: :web_authority, only: :show
+
+          # Search attributes
+          search_attributes :name
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/taxonomies_controller.rb
@@ -1,0 +1,18 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class TaxonomiesController < LinkedPlacesController
+          # Includes
+          include UnauthenticateableController
+
+          # Preloads
+          preloads project_model: :user_defined_fields
+
+          # Search attributes
+          search_attributes :name
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/linked_places/works_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/linked_places/works_controller.rb
@@ -1,0 +1,18 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class WorksController < LinkedPlacesController
+          # Includes
+          include NameableController
+          include UnauthenticateableController
+          include UserDefinedFields::Queryable
+
+          # Preloads
+          preloads project_model: :user_defined_fields
+          preloads :source_names, only: :show
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/manifests_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/manifests_controller.rb
@@ -1,0 +1,106 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class ManifestsController < ApplicationController
+        # Includes
+        include NestableController
+        include UnauthenticateableController
+
+        # Disable pagination
+        per_page 0
+
+        protected
+
+        def base_query
+          # Manifests can only be retrieved for nested routes
+          return Manifest.none unless current_record.present?
+
+          # If not retrieving a single manifest, the project_ids parameter is required
+          return Manifest.none unless params[:project_ids].present? || params[:id].present?
+
+          query = Manifest
+                    .joins(project_model_relationship: [:primary_model, :related_model])
+                    .where(
+                      manifestable_id: current_record.id,
+                      manifestable_type: current_record.class.to_s
+                    )
+
+          if params[:project_ids].present?
+            query = query.where(
+              primary_model: {
+                project_id: params[:project_ids]
+              }
+            ).or(
+              query.where(related_model: {
+                project_id: params[:project_ids]
+              })
+            )
+          end
+
+          query
+        end
+
+        def build_index_response(items, metadata)
+          return {} if items.empty?
+
+          service = TripleEyeEffable::Presentation.new
+
+          service.create_collection(
+            id: identifier,
+            label: label,
+            items: items.map{ |i| to_collection_item(i) }
+          )
+        end
+
+        def build_show_response(item)
+          item&.content
+        end
+
+        def find_record(query)
+          puts query.to_sql
+
+          query
+            .joins(:project_model_relationship)
+            .where(project_model_relationship: {
+              uuid: params[:id]
+            })
+            .take
+        end
+
+        private
+
+        def identifier
+          url = [
+            ENV['HOSTNAME'],
+            'core_data',
+            'public',
+            current_record.class.model_name.route_key,
+            current_record.uuid,
+            'manifests'
+          ].join('/')
+
+          parameters = {
+            project_ids: params[:project_ids]
+          }
+
+          "#{url}?#{parameters.to_query}"
+        end
+
+        def label
+          service = Iiif::Manifest.new
+          service.find_label(current_record)
+        end
+
+        def to_collection_item(manifest)
+          {
+            id: "#{ENV['HOSTNAME']}/#{manifest.identifier}",
+            type: 'Manifest',
+            label: manifest.label,
+            item_count: manifest.item_count,
+            thumbnail: manifest.thumbnail
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/media_contents_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class MediaContentsController < PublicController
+        # Includes
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/organizations_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/organizations_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class OrganizationsController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads :organization_names, only: :show
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/people_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/people_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class PeopleController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads :person_names, only: :show
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :first_name, :middle_name, :last_name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/places_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/places_controller.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class PlacesController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads :place_names, only: :show
+        preloads :place_geometry
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/projects_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/projects_controller.rb
@@ -1,0 +1,73 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class ProjectsController < ApplicationController
+        include UnauthenticateableController
+
+        def descriptors
+          descriptors = []
+          descriptors += load_project_models
+          descriptors += load_project_model_relationships
+
+          render json: { descriptors: descriptors}, status: :ok
+        end
+
+        private
+
+        def load_project_model_relationships
+          descriptors = []
+
+          query = ProjectModelRelationship
+                    .preload(:user_defined_fields, :primary_model)
+                    .joins(:primary_model)
+                    .where(primary_model: {
+                      project_id: params[:id]
+                    })
+
+          query.find_each do |project_model_relationship|
+            descriptors << {
+              identifier: project_model_relationship.uuid,
+              label: project_model_relationship.name,
+              context: project_model_relationship.primary_model.name
+            }
+
+            project_model_relationship.user_defined_fields.each do |user_defined_field|
+              descriptors << {
+                identifier: user_defined_field.uuid,
+                label: user_defined_field.column_name,
+                context: project_model_relationship.name
+              }
+            end
+          end
+
+          descriptors
+        end
+
+        def load_project_models
+          descriptors = []
+
+          query = ProjectModel
+                    .preload(:user_defined_fields)
+                    .where(project_id: params[:id])
+
+          query.find_each do |project_model|
+            descriptors << {
+              identifier: project_model.uuid,
+              label: project_model.name
+            }
+
+            project_model.user_defined_fields.each do |user_defined_field|
+              descriptors << {
+                identifier: user_defined_field.uuid,
+                label: user_defined_field.column_name,
+                context: project_model.name
+              }
+            end
+          end
+
+          descriptors
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/public_controller.rb
@@ -1,0 +1,155 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class PublicController < ApplicationController
+        # Includes
+        include NestableController
+
+        protected
+
+        def base_query
+          if nested_resource? && current_record.present?
+            item_class.where(build_base_sql)
+          elsif nested_resource?
+            item_class.none
+          elsif params[:project_ids].present?
+            item_class.all_records_by_project(params[:project_ids])
+          else
+            item_class.none
+          end
+        end
+
+        def load_records(item)
+          { nested_resource: nested_resource? }
+        end
+
+        def nested_resource?
+          return true if current_record.present? && params[:project_ids].present?
+
+          false
+        end
+
+        # Preloads the relationships records scoped to the passed project_ids
+        def preloads(query)
+          super
+
+          return unless nested_resource?
+
+          primary_scope = Relationship
+                            .joins(project_model_relationship: :related_model)
+                            .where(
+                              primary_record_type: item_class.to_s,
+                              related_record_id: current_record.id,
+                              related_record_type: current_record.class.to_s,
+                              related_model: {
+                                project_id: params[:project_ids]
+                              },
+                              project_model_relationship: {
+                                allow_inverse: true
+                              }
+                            )
+
+          if params[:project_model_relationship_uuid].present?
+            primary_scope = primary_scope.where(project_model_relationship: {
+              uuid: params[:project_model_relationship_uuid]
+            })
+          end
+
+          Preloader.new(
+            records: query,
+            associations: [
+              relationships: [
+                project_model_relationship: :user_defined_fields
+              ]
+            ],
+            scope: primary_scope
+          ).call
+
+          related_scope = Relationship
+                            .joins(project_model_relationship: :primary_model)
+                            .where(
+                              related_record_type: item_class.to_s,
+                              primary_record_id: current_record.id,
+                              primary_record_type: current_record.class.to_s,
+                              primary_model: {
+                                project_id: params[:project_ids]
+                              }
+                            )
+
+          if params[:project_model_relationship_uuid].present?
+            related_scope = related_scope.where(project_model_relationship: {
+              uuid: params[:project_model_relationship_uuid]
+            })
+          end
+
+          Preloader.new(
+            records: query,
+            associations: [
+              related_relationships: [project_model_relationship: :user_defined_fields]
+            ],
+            scope: related_scope
+          ).call
+        end
+
+        def serializer_class
+          "CoreDataConnector::Public::V0::#{"#{controller_name}_serializer".classify}".constantize
+        end
+
+        private
+
+        def build_base_sql
+          primary_query = Relationship
+                            .select(1)
+                            .joins(project_model_relationship: :primary_model)
+                            .where(Relationship.arel_table[:related_record_id].eq(item_class.arel_table[:id]))
+                            .where(
+                              related_record_type: item_class.to_s,
+                              primary_record_id: current_record.id,
+                              primary_record_type: current_record.class.to_s,
+                              primary_model: {
+                                project_id: params[:project_ids]
+                              }
+                            )
+
+          if params[:project_model_relationship_uuid].present?
+            primary_query = primary_query
+                              .where(project_model_relationship: {
+                                uuid: params[:project_model_relationship_uuid]
+                              })
+          end
+
+          related_query = Relationship
+                            .select(1)
+                            .joins(project_model_relationship: :related_model)
+                            .where(Relationship.arel_table[:primary_record_id].eq(item_class.arel_table[:id]))
+                            .where(
+                              primary_record_type: item_class.to_s,
+                              related_record_id: current_record.id,
+                              related_record_type: current_record.class.to_s,
+                              related_model: {
+                                project_id: params[:project_ids]
+                              },
+                              project_model_relationship: {
+                                allow_inverse: true
+                              }
+                            )
+
+          if params[:project_model_relationship_uuid].present?
+            related_query = related_query
+                              .where(project_model_relationship: {
+                                uuid: params[:project_model_relationship_uuid]
+                              })
+          end
+
+          <<-SQL.squish
+            EXISTS (
+              #{primary_query.to_sql}
+              UNION
+              #{related_query.to_sql}
+            )
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/taxonomies_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class TaxonomiesController < PublicController
+        # Includes
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v0/works_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/works_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class WorksController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :source_names
+        preloads web_identifiers: :web_authority, only: :show
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/events_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/events_controller.rb
@@ -1,0 +1,51 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class EventsController < PublicController
+        # Includes
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :start_date, :end_date
+
+        # Joins
+        joins Event.start_date_join, Event.end_date_join
+
+        # Search attributes
+        search_attributes :name, :description
+
+        protected
+
+        def apply_filters(query)
+          query = super
+
+          query = filter_min_year(query)
+
+          query = filter_max_year(query)
+
+          query
+        end
+
+        private
+
+        def filter_max_year(query)
+          return query unless params[:max_year].present?
+
+          date = Date.new(params[:max_year].to_i, 12, 31)
+
+          query.where('( start_date.start_date <= ? OR end_date.start_date <= ? )', date, date)
+        end
+
+        def filter_min_year(query)
+          return query unless params[:min_year].present?
+
+          date = Date.new(params[:min_year].to_i, 1, 1)
+
+          query.where('( start_date.end_date >= ? OR end_date.end_date >= ? )', date, date)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/instances_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/instances_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class InstancesController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :source_names
+        preloads web_identifiers: :web_authority, only: :show
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/items_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/items_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class ItemsController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :source_names
+        preloads web_identifiers: :web_authority, only: :show
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/manifests_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/manifests_controller.rb
@@ -1,0 +1,107 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class ManifestsController < ApplicationController
+        # Includes
+        include NestableController
+        include UnauthenticateableController
+        include UnauthorizeableController
+
+        # Disable pagination
+        per_page 0
+
+        protected
+
+        def base_query
+          # Manifests can only be retrieved for nested routes
+          return Manifest.none unless current_record.present?
+
+          # If not retrieving a single manifest, the project_ids parameter is required
+          return Manifest.none unless params[:project_ids].present? || params[:id].present?
+
+          query = super
+
+          query = query
+                    .joins(project_model_relationship: [:primary_model, :related_model])
+                    .where(
+                      manifestable_id: current_record.id,
+                      manifestable_type: current_record.class.to_s
+                    )
+
+          if params[:project_ids].present?
+            query = query.where(
+              primary_model: {
+                project_id: params[:project_ids]
+              }
+            ).or(
+              query.where(related_model: {
+                project_id: params[:project_ids]
+              })
+            )
+          end
+
+          query
+        end
+
+        def build_index_response(items, metadata)
+          return {} if items.empty?
+
+          parameters = {
+            project_ids: params[:project_ids]
+          }
+
+          id = Iiif::Manifest.generate_identifier(
+            model_class: current_record.class,
+            uuid: current_record.uuid
+          )
+
+          service = TripleEyeEffable::Presentation.new
+
+          service.create_collection(
+            id: "#{ENV['HOSTNAME']}/#{id}/#{parameters.to_query}",
+            label: label,
+            items: items.map{ |i| to_collection_item(i) }
+          )
+        end
+
+        def build_show_response(item)
+          item&.content
+        end
+
+        def find_record(query)
+          query
+            .joins(:project_model_relationship)
+            .where(project_model_relationship: {
+              uuid: params[:id]
+            })
+            .take!
+        end
+
+        def policy_class
+          CoreDataConnector::Public::V1::ManifestPolicy
+        end
+
+        private
+
+        def label
+          service = Iiif::Manifest.new
+          service.find_label(current_record)
+        end
+
+        def to_collection_item(manifest)
+          parameters = {
+            project_ids: params[:project_ids]
+          }
+
+          {
+            id: "#{ENV['HOSTNAME']}/#{manifest.identifier}?#{parameters.to_query}",
+            type: 'Manifest',
+            label: manifest.label,
+            item_count: manifest.item_count,
+            thumbnail: manifest.thumbnail
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/media_contents_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class MediaContentsController < PublicController
+        # Includes
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/organizations_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/organizations_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class OrganizationsController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads :organization_names, only: :show
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/people_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/people_controller.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PeopleController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads :person_names, only: :show
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :first_name, :middle_name, :last_name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/places_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/places_controller.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PlacesController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Joins
+        joins :primary_name
+
+        # Preloads
+        preloads :primary_name
+        preloads :place_names, :place_geometry
+        preloads project_model: :user_defined_fields
+        preloads :place_layers, only: :show
+        preloads web_identifiers: :web_authority, only: :show
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/projects_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/projects_controller.rb
@@ -1,0 +1,79 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class ProjectsController < ApplicationController
+        include UnauthenticateableController
+
+        def descriptors
+          descriptors = []
+          descriptors += load_project_models
+          descriptors += load_project_model_relationships
+
+          render json: { descriptors: descriptors}, status: :ok
+        end
+
+        private
+
+        def load_project_model_relationships
+          descriptors = []
+
+          query = ProjectModelRelationship
+                    .preload(:user_defined_fields, :primary_model)
+                    .joins(:primary_model)
+                    .where(primary_model: {
+                      project_id: params[:id]
+                    })
+
+          query.find_each do |project_model_relationship|
+            descriptor = {
+              identifier: project_model_relationship.uuid,
+              label: project_model_relationship.name,
+              context: project_model_relationship.primary_model.name
+            }
+
+            if project_model_relationship.allow_inverse?
+              descriptor[:inverse_label] = project_model_relationship.inverse_name
+            end
+
+            descriptors << descriptor
+
+              project_model_relationship.user_defined_fields.each do |user_defined_field|
+              descriptors << {
+                identifier: user_defined_field.uuid,
+                label: user_defined_field.column_name,
+                context: project_model_relationship.name
+              }
+            end
+          end
+
+          descriptors
+        end
+
+        def load_project_models
+          descriptors = []
+
+          query = ProjectModel
+                    .preload(:user_defined_fields)
+                    .where(project_id: params[:id])
+
+          query.find_each do |project_model|
+            descriptors << {
+              identifier: project_model.uuid,
+              label: project_model.name
+            }
+
+            project_model.user_defined_fields.each do |user_defined_field|
+              descriptors << {
+                identifier: user_defined_field.uuid,
+                label: user_defined_field.column_name,
+                context: project_model.name
+              }
+            end
+          end
+
+          descriptors
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/public_controller.rb
@@ -1,0 +1,162 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PublicController < ApplicationController
+        # Includes
+        include NestableController
+        include UnauthorizeableController
+
+        protected
+
+        def base_query
+          return item_class.none unless params[:project_ids].present?
+
+          query = super
+
+          if nested_resource? && current_record.present?
+            query = query.joins(build_base_sql).order('record.order')
+          elsif nested_resource?
+            query = item_class.none
+          elsif params[:id].present?
+            query = query.where(uuid: params[:id])
+          elsif params[:project_ids].present?
+            query = query.merge(item_class.all_records_by_project(params[:project_ids]))
+          else
+            query = item_class.none
+          end
+
+          query
+        end
+
+        def find_record(query)
+          query.find_by!(uuid: params[:id])
+        end
+
+        def policy_class
+          CoreDataConnector::Public::V1::PublicPolicy
+        end
+
+        # Preloads the relationships records scoped to the passed project_ids
+        def preloads(query)
+          super
+
+          return unless nested_resource? && current_record.present?
+
+          primary_scope = Relationship
+                            .joins(project_model_relationship: :related_model)
+                            .where(
+                              primary_record_type: item_class.to_s,
+                              related_record_id: current_record.id,
+                              related_record_type: current_record.class.to_s,
+                              related_model: {
+                                project_id: params[:project_ids]
+                              },
+                              project_model_relationship: {
+                                allow_inverse: true
+                              }
+                            )
+
+          if params[:project_model_relationship_uuid].present?
+            primary_scope = primary_scope.where(project_model_relationship: {
+              uuid: params[:project_model_relationship_uuid]
+            })
+          end
+
+          Preloader.new(
+            records: query,
+            associations: [
+              relationships: [
+                project_model_relationship: :user_defined_fields
+              ]
+            ],
+            scope: primary_scope
+          ).call
+
+          related_scope = Relationship
+                            .joins(project_model_relationship: :primary_model)
+                            .where(
+                              related_record_type: item_class.to_s,
+                              primary_record_id: current_record.id,
+                              primary_record_type: current_record.class.to_s,
+                              primary_model: {
+                                project_id: params[:project_ids]
+                              }
+                            )
+
+          if params[:project_model_relationship_uuid].present?
+            related_scope = related_scope.where(project_model_relationship: {
+              uuid: params[:project_model_relationship_uuid]
+            })
+          end
+
+          Preloader.new(
+            records: query,
+            associations: [
+              related_relationships: [project_model_relationship: :user_defined_fields]
+            ],
+            scope: related_scope
+          ).call
+        end
+
+        def serializer_class
+          "CoreDataConnector::Public::V1::#{"#{controller_name}_serializer".classify}".constantize
+        end
+
+        private
+
+        def build_base_sql
+          primary_query = Relationship
+                            .joins(project_model_relationship: :primary_model)
+                            .where(
+                              related_record_type: item_class.to_s,
+                              primary_record_id: current_record.id,
+                              primary_record_type: current_record.class.to_s,
+                              primary_model: {
+                                project_id: params[:project_ids]
+                              }
+                            )
+                            .select(Relationship.arel_table[:related_record_id].as('id'))
+                            .select(Relationship.arel_table[:order].as('order'))
+
+          if params[:project_model_relationship_uuid].present?
+            primary_query = primary_query
+                              .where(project_model_relationship: {
+                                uuid: params[:project_model_relationship_uuid]
+                              })
+          end
+
+          related_query = Relationship
+                            .joins(project_model_relationship: :related_model)
+                            .where(
+                              primary_record_type: item_class.to_s,
+                              related_record_id: current_record.id,
+                              related_record_type: current_record.class.to_s,
+                              related_model: {
+                                project_id: params[:project_ids]
+                              },
+                              project_model_relationship: {
+                                allow_inverse: true
+                              }
+                            )
+                            .select(Relationship.arel_table[:primary_record_id].as('id'))
+                            .select(Relationship.arel_table[:order].as('order'))
+
+          if params[:project_model_relationship_uuid].present?
+            related_query = related_query
+                              .where(project_model_relationship: {
+                                uuid: params[:project_model_relationship_uuid]
+                              })
+          end
+
+          <<-SQL.squish
+            INNER JOIN (
+              #{primary_query.to_sql}
+              UNION ALL
+              #{related_query.to_sql}
+            ) record ON record.id = "#{item_class.table_name}"."id"
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/taxonomies_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class TaxonomiesController < PublicController
+        # Includes
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+
+        # Search attributes
+        search_attributes :name
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/public/v1/works_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/works_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class WorksController < PublicController
+        # Includes
+        include NameableController
+        include UnauthenticateableController
+        include UserDefinedFields::Queryable
+
+        # Preloads
+        preloads project_model: :user_defined_fields
+        preloads :source_names
+        preloads web_identifiers: :web_authority, only: :show
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/reconcile/projects_controller.rb
+++ b/app/controllers/core_data_connector/reconcile/projects_controller.rb
@@ -1,0 +1,70 @@
+module CoreDataConnector
+  module Reconcile
+    class ProjectsController < ActionController::API
+
+      def show
+        # Validate that the requested project contains the necessary credentials to call the API
+        project = Project.find(params[:id])
+        credentials = project.reconciliation_credentials&.symbolize_keys
+
+        render json: { }, status: :not_found and return unless valid_credentials? credentials
+
+        serializer = ProjectsSerializer.new
+
+        # Per the spec, a request to the API without any parameters should return the service manifest
+        render json: serializer.render_manifest(project), status: :ok and return unless params[:queries].present?
+
+        # Allow request body to be sent as application/json or x-www-form-urlencoded
+        if params[:queries].is_a?(String)
+          queries = JSON.parse(params[:queries]).deep_symbolize_keys
+        else
+          queries = params[:queries]
+        end
+
+        manager = Reconcile::Manager.new
+        items = manager.send_request(queries, credentials)
+
+        render json: serializer.render_multiple(items), status: :ok
+      end
+
+      def view
+        # "view" endpoint for redirection to record's edit page
+
+        # Validate that the requested project contains the necessary credentials to call the API
+        project = Project.find(params[:id])
+        credentials = project.reconciliation_credentials&.symbolize_keys
+
+        render plain: 'Invalid credentials', status: :forbidden and return unless valid_credentials? credentials
+
+        # attempt to connect to and get the record from typesense
+        record_uuid = params[:record_id]
+        client = Typesense.create_client(**credentials.except(:collection_name))
+        collection = credentials[:collection_name]
+
+        begin
+          # build and redirect to the core-data-cloud redirect URL
+          record = client.collections[collection].documents[record_uuid].retrieve
+          project_model_id = record['project_model_id']
+          record_id = record['record_id']
+          redirect_url = "#{ENV['HOSTNAME']}/projects/#{project.id}/#{project_model_id}/#{record_id}"
+
+          redirect_to redirect_url, allow_other_host: true
+        rescue ::Typesense::Error::ObjectNotFound
+          render plain: 'Record not found', status: :not_found
+        end
+      end
+
+      private
+
+      def valid_credentials?(credentials)
+        return false unless credentials.present?
+
+        parameters = %i(host protocol port api_key collection_name)
+        return false unless parameters.all? { |parameter| credentials[parameter].present? }
+
+        true
+      end
+
+    end
+  end
+end

--- a/app/controllers/core_data_connector/record_merges_controller.rb
+++ b/app/controllers/core_data_connector/record_merges_controller.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  class RecordMergesController < ApplicationController
+    # Search attributes
+    search_attributes :merged_uuid
+
+    # Actions
+    before_action :bypass_authorization, only: :index
+    before_action :authorize_index, only: :index
+
+    protected
+
+    def base_query
+      return RecordMerge.none unless params[:mergeable_id].present? && params[:mergeable_type].present?
+
+      RecordMerge.where(
+        mergeable_id: params[:mergeable_id],
+        mergeable_type: params[:mergeable_type]
+      )
+    end
+
+    private
+
+    def authorize_index
+      return unless params[:mergeable_id].present? && params[:mergeable_type].present?
+
+      klass = params[:mergeable_type].constantize
+      item = klass.find(params[:mergeable_id])
+
+      policy_class = "#{item.class.to_s}Policy".constantize
+      authorize item, :show?, policy_class: policy_class
+    end
+  end
+end

--- a/app/controllers/core_data_connector/relationships_controller.rb
+++ b/app/controllers/core_data_connector/relationships_controller.rb
@@ -1,0 +1,173 @@
+module CoreDataConnector
+  class RelationshipsController < ApplicationController
+    # Includes
+    include Api::Uploadable
+    include ManifestsController
+    include UserDefinedFields::Queryable
+
+    # Actions
+    before_action :set_project_model_relationship, only: :index
+
+    # Search methods
+    search_methods :search_related_records
+
+    protected
+
+    def base_query
+      # If we're accessing a single record, do not apply any additional filtering. We'll assume the policy is set up
+      # such that the correct access is granted.
+      return super if params[:id].present?
+
+      # For an index view, scope the list of relationships to those owned by the project_model_relationship,
+      # for the given record type.
+      return Relationship.none unless params[:project_model_relationship_id].present? && params[:record_id].present? && params[:record_type].present?
+
+      # Relationships should always to scoped to a project model relationship. For inverse relationships, we'll
+      # use the related record.
+      if params[:inverse]
+        query = Relationship
+          .where(
+            project_model_relationship_id: params[:project_model_relationship_id],
+            related_record_id: params[:record_id],
+            related_record_type: params[:record_type]
+          )
+      else
+        query = Relationship
+          .where(
+            project_model_relationship_id: params[:project_model_relationship_id],
+            primary_record_id: params[:record_id],
+            primary_record_type: params[:record_type]
+          )
+      end
+
+      # Include preloads for the different model types
+      case model_class
+      when Event.to_s
+        query = query.preload(params[:inverse] ? { primary_record: [:start_date, :end_date] } : { related_record: [:start_date, :end_date] })
+      when Instance.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Item.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when MediaContent.to_s
+        query = query.preload(params[:inverse] ? :primary_record : :related_record)
+      when Organization.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Person.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Place.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      when Taxonomy.to_s
+        query = query.preload(params[:inverse] ? :primary_record : :related_record)
+      when Work.to_s
+        query = query.preload(params[:inverse] ? { primary_record: :primary_name } : { related_record: :primary_name })
+      end
+
+      # For sorting, left join the polymorphic model we're currently looking at.
+      case model_class
+      when Event.to_s
+        query = query.joins(params[:inverse] ? :inverse_related_event : :related_event).joins(Event.start_date_join, Event.end_date_join)
+      when Instance.to_s
+        query = query.joins(params[:inverse] ? { inverse_related_instance: :primary_name } : { related_instance: :primary_name })
+      when Item.to_s
+        query = query.joins(params[:inverse] ? { inverse_related_item: :primary_name } : { related_item: :primary_name })
+      when MediaContent.to_s
+        query = query.joins(params[:inverse] ? :inverse_related_media_content : :related_media_content)
+      when Organization.to_s
+        query = query.joins(params[:inverse] ? { inverse_related_organization: :primary_name } : { related_organization: :primary_name })
+      when Person.to_s
+        query = query.joins(params[:inverse] ? { inverse_related_person: :primary_name } : { related_person: :primary_name })
+      when Place.to_s
+        query = query.joins(params[:inverse] ? { inverse_related_place: :primary_name } : { related_place: :primary_name })
+      when Taxonomy.to_s
+        query = query.joins(params[:inverse] ? :inverse_related_taxonomy : :related_taxonomy)
+      when Work.to_s
+        query = query.joins(params[:inverse] ? { inverse_related_work: :primary_name } : { related_work: :primary_name })
+      end
+
+      query
+    end
+
+    private
+
+    # Returns the related model class for filtering and sorting.
+    def model_class
+      if params[:inverse]
+        @project_model_relationship.primary_model.model_class
+      else
+        @project_model_relationship.related_model.model_class
+      end
+    end
+
+    def resolve_person_query
+      query = nil
+
+      table = PersonName.arel_table
+      table_name = table.name
+
+      attributes = [
+        "#{table_name}.#{table[:last_name].name}",
+        "#{table_name}.#{table[:first_name].name}",
+        "#{table_name}.#{table[:first_name].name} || ' ' || #{table_name}.#{table[:last_name].name}"
+      ]
+
+      attributes.each do |attr|
+        q = resolve_search_query(attr)
+
+        if query.nil?
+          query = q
+        else
+          query = query.or(q)
+        end
+      end
+
+      query
+    end
+
+    def search_related_records(query)
+      return query unless params[:search].present?
+
+      or_query = nil
+
+      case model_class
+      when Event.to_s
+        attribute = "#{Event.arel_table.name}.#{Event.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when Instance.to_s
+        attribute = "#{SourceName.arel_table.name}.#{SourceName.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when Item.to_s
+        attribute = "#{SourceName.arel_table.name}.#{SourceName.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when MediaContent.to_s
+        attribute = "#{MediaContent.arel_table.name}.#{MediaContent.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when Organization.to_s
+        attribute = "#{OrganizationName.arel_table.name}.#{OrganizationName.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when Person.to_s
+        or_query = resolve_person_query
+      when Place.to_s
+        attribute = "#{PlaceName.arel_table.name}.#{PlaceName.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when Taxonomy.to_s
+        attribute = "#{Taxonomy.arel_table.name}.#{Taxonomy.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      when Work.to_s
+        attribute = "#{SourceName.arel_table.name}.#{SourceName.arel_table[:name].name}"
+        or_query = resolve_search_query(attribute)
+      end
+
+      return query if or_query.nil?
+
+      if query == item_class.all
+        query.merge(or_query)
+      else
+        query.or(or_query)
+      end
+    end
+
+    def set_project_model_relationship
+      @project_model_relationship = ProjectModelRelationship.find(params[:project_model_relationship_id])
+    end
+  end
+end

--- a/app/controllers/core_data_connector/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/taxonomies_controller.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  class TaxonomiesController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Search attributes
+    search_attributes :name
+  end
+end

--- a/app/controllers/core_data_connector/user_projects_controller.rb
+++ b/app/controllers/core_data_connector/user_projects_controller.rb
@@ -1,0 +1,50 @@
+module CoreDataConnector
+  class UserProjectsController < ApplicationController
+    # Search attributes
+    search_attributes 'core_data_connector_users.name', 'core_data_connector_users.email', 'core_data_connector_projects.name', 'core_data_connector_projects.description'
+
+    # Joins
+    joins :user, :project
+
+    # Preloads
+    preloads :user, :project
+
+    def invite
+      user_project = UserProject.find(params[:id])
+      authorize user_project, :invite?
+
+      begin
+        service = Users::Invitations.new
+        service.send_invitation user_project
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error(error)
+      end
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
+
+    protected
+
+    def base_query
+      return super if params[:id].present?
+
+      query = super
+
+      # User projects are only visible in the context of a user or a project.
+      if params[:project_id].present?
+        query.where(project_id: params[:project_id])
+      elsif params[:user_id].present?
+        query.where(user_id: params[:user_id])
+      else
+        query.none
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/users_controller.rb
+++ b/app/controllers/core_data_connector/users_controller.rb
@@ -1,0 +1,93 @@
+module CoreDataConnector
+  class UsersController < ApplicationController
+    # Search attributes
+    search_attributes :name, :email
+
+    # Preloads
+    preloads user_projects: :project, only: :show
+
+    def invite
+      user = User.find(params[:id])
+      authorize user, :update?
+
+      begin
+        service = Users::Invitations.new
+        service.send_invitation user
+      rescue StandardError => error
+        errors = [error]
+
+        # Log the error
+        log_error(error)
+      end
+
+      if errors.nil? || errors.empty?
+        render json: { }, status: :ok
+      else
+        render json: { errors: errors }, status: :bad_request
+      end
+    end
+
+    def me
+      authenticate_clerk_request
+
+      return unless @current_user
+
+      puts "Attempting to authenticate user #{@current_user.id}"
+
+      clerk_user = get_clerk_data(@current_user.sso_id)
+
+      update_user_from_sso(@current_user, clerk_user)
+
+      serializer = UsersSerializer.new
+
+      render json: serializer.render_show(@current_user), status: :ok
+    end
+
+    def build_name(first, last)
+      if first.present? && last.present?
+        name = "#{first} #{last}"
+      elsif first.present?
+        name = first
+      elsif last.present?
+        name = last
+      end
+
+      name
+    end
+
+    def update_user_from_sso(local_user, sso_user)
+      # default to guest, which means users can't create projects
+      role = 'guest'
+
+      if sso_user.private_metadata['is_global_admin'] == true
+        # *we* should be CD admins (and no one else!)
+        role = 'admin'
+      else
+        org_memberships = clerk_client.users.get_organization_memberships(user_id: sso_user.id)
+        # org admins are Performant Studio customers who should be able to create projects,
+        # which means they get the member system role in Core Data
+        if org_memberships.organization_memberships.data.any? { |o| o.role == 'org:admin' }
+          role = 'member'
+        end
+      end
+
+      local_user.update(
+        sso_id: sso_user.id,
+        name: build_name(sso_user.first_name, sso_user.last_name),
+        avatar_url: sso_user.profile_image_url,
+        role: role
+      )
+    end
+
+    protected
+
+    def after_update(user)
+      super
+
+      # If the user is resetting their password, set the "require_password_change" prop to false
+      if current_user.id == user.id && user.saved_change_to_password_digest? && user.require_password_change?
+        user.update_column(:require_password_change, false)
+      end
+    end
+  end
+end

--- a/app/controllers/core_data_connector/versions_controller.rb
+++ b/app/controllers/core_data_connector/versions_controller.rb
@@ -1,0 +1,203 @@
+module CoreDataConnector
+  class VersionsController < ApplicationController
+    preloads :user
+
+    protected
+
+    def base_query
+      scope = super
+
+      if params[:project_id].present?
+        authorize project, :show?
+        scope = scope.where(project_id: project.id)
+      elsif is_valid?
+        authorize root_record, :show?
+        scope = scope.merge(Version.for_record(root_record))
+      else
+        return Version.none
+      end
+
+      params[:sort_by].present? ? scope :
+        scope.order(created_at: :desc, id: :desc)
+    end
+
+    def load_records(items)
+      versions = [items].flatten
+
+      preload_user_defined_fields versions
+      preload_roots versions
+
+      super.merge(
+        attribute_changes: method(:attribute_changes),
+        user_defined_changes: method(:user_defined_changes),
+        root_data: method(:root_data)
+      )
+    end
+
+    def root_data(root)
+      record = @roots[root_key(root)]
+      project_model_id = record&.project_model_id || root['project_model_id']
+
+      {
+        record_type: root['type']&.demodulize,
+        id: root['id'],
+        uuid: record&.uuid || root['uuid'],
+        display_name: record&.display_name || root['display_name'],
+        project_model_id: project_model_id,
+        project_model_name: @project_models[project_model_id]&.name,
+        deleted: record.nil?
+      }
+    end
+
+    def attribute_changes(version)
+      serialized = {}
+
+      extract_changes(version).each do |attribute, (from, to)|
+        next if attribute == 'user_defined'
+
+        serialized[attribute] = { from: from, to: to }
+      end
+
+      serialized
+    end
+
+    def user_defined_changes(version)
+      before, after = extract_changes(version)['user_defined']
+      before ||= {}
+      after ||= {}
+
+      (before.keys | after.keys).filter_map do |uuid|
+        from = before[uuid]
+        to = after[uuid]
+
+        next if from == to
+
+        field = @user_defined_fields[uuid]
+
+        {
+          uuid: uuid,
+          label: field&.column_name || uuid,
+          data_type: field&.data_type,
+          from: from,
+          to: to
+        }
+      end
+    end
+
+    private
+
+    def extract_changes(version)
+      if version.object_changes.present?
+        version.object_changes
+      elsif version.event == 'destroy' && version.object.present?
+        version.object.transform_values { |value| [value, nil] }
+      else
+        {}
+      end
+    end
+
+    def preload_user_defined_fields(versions)
+      uuids = versions.flat_map { |version| user_defined_uuids(version) }.uniq
+
+      @user_defined_fields = UserDefinedFields::UserDefinedField
+                               .where(uuid: uuids)
+                               .index_by(&:uuid)
+    end
+
+    def preload_roots(versions)
+      roots = versions.flat_map { |version| Array(version.roots) }
+
+      @roots = {}
+
+      roots.group_by { |root| root['type'] }.each do |type, group|
+        klass = root_class(type)
+        next if klass.nil?
+
+        scope = klass.where(id: group.map { |root| root['id'] }.uniq)
+
+        if klass.respond_to?(:get_names_table) && klass.get_names_table.present?
+          scope = scope.includes(:primary_name)
+        end
+
+        scope.each { |record| @roots[[type, record.id]] = record }
+      end
+
+      preload_project_models roots
+    end
+
+    def preload_project_models(roots)
+      ids = roots.filter_map do |root|
+        @roots[root_key(root)]&.project_model_id || root['project_model_id']
+      end.uniq
+
+      @project_models = ProjectModel.where(id: ids).index_by(&:id)
+    end
+
+    def root_key(root)
+      [root['type'], root['id']]
+    end
+
+    # Guards against types stored on older versions that have since been renamed
+    # or removed.
+    def root_class(type)
+      klass = type&.safe_constantize
+      klass if klass.is_a?(Class) && klass < ActiveRecord::Base
+    end
+
+    def user_defined_uuids(version)
+      uuids = []
+
+      if version.object_changes.present?
+        before, after = version.object_changes['user_defined']
+        uuids += (before || {}).keys + (after || {}).keys
+      end
+
+      if version.object.present?
+        uuids += (version.object['user_defined'] || {}).keys
+      end
+
+      uuids
+    end
+
+    def is_valid?
+      record_class.present?
+    end
+
+    def root_record
+      @root_record ||= record_class.find(params[parent_param])
+    end
+
+    def record_class
+      resolve_parent
+      @record_class
+    end
+
+    def parent_param
+      resolve_parent
+      @parent_param
+    end
+
+    def resolve_parent
+      return if defined?(@resolved_parent)
+      @resolved_parent = true
+
+      @parent_param = params.keys
+                            .map(&:to_sym)
+                            .select { |key| key.to_s.end_with?('_id') && params[key].present? }
+                            .find do |key|
+                              klass = audit_root_class(key)
+                              @record_class = klass if klass
+                              klass
+                            end
+    end
+
+    def audit_root_class(param)
+      klass = "CoreDataConnector::#{param.to_s.delete_suffix('_id').classify}".safe_constantize
+      klass if klass.is_a?(Class) && klass.respond_to?(:audit_root?) && klass.audit_root?
+    end
+
+    def project
+      @project ||= Project.find(params[:project_id])
+    end
+  end
+end

--- a/app/controllers/core_data_connector/web_authorities_controller.rb
+++ b/app/controllers/core_data_connector/web_authorities_controller.rb
@@ -1,0 +1,42 @@
+module CoreDataConnector
+  class WebAuthoritiesController < ApplicationController
+    # Search attributes
+    search_attributes :source_type
+
+    def find
+      render json: { errors: [I18n.t('errors.web_authorities_controller.find.identifier')] }, status: :bad_request and return unless params[:identifier].present?
+
+      authority = WebAuthority.find(params[:id])
+      authorize authority, :search?
+
+      instance = Authority::Base.create_service(authority)
+      json = instance.find(params[:identifier], authority.access&.symbolize_keys)
+
+      render json: json, status: :ok
+    end
+
+    def search
+      render json: { errors: [I18n.t('errors.web_authorities_controller.search.query')] }, status: :bad_request and return unless params[:query].present?
+
+      authority = WebAuthority.find(params[:id])
+      authorize authority, :find?
+
+      instance = Authority::Base.create_service(authority)
+      json = instance.search(params[:query], authority.access&.symbolize_keys)
+
+      render json: json, status: :ok
+    end
+
+    protected
+
+    def base_query
+      # For index routes, require the project_id to be provided
+      return WebAuthority.none unless params[:project_id].present? || params[:id].present?
+
+      query = super
+      query = query.where(project_id: params[:project_id]) if params[:project_id].present?
+
+      query
+    end
+  end
+end

--- a/app/controllers/core_data_connector/web_identifiers_controller.rb
+++ b/app/controllers/core_data_connector/web_identifiers_controller.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  class WebIdentifiersController < ApplicationController
+    # Search attributes
+    search_attributes :key
+
+    # Preloads
+    preloads :web_authority
+
+    # Joins
+    joins :web_authority
+
+    protected
+
+    def base_query
+      return WebIdentifier.none unless (params[:identifiable_id].present? && params[:identifiable_type].present?) || params[:id].present?
+
+      query = super
+
+      if params[:identifiable_id].present? && params[:identifiable_type].present?
+        query = query
+                  .where(identifiable_id: params[:identifiable_id])
+                  .where(identifiable_type: params[:identifiable_type])
+      end
+
+      query
+    end
+  end
+end

--- a/app/controllers/core_data_connector/works_controller.rb
+++ b/app/controllers/core_data_connector/works_controller.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  class WorksController < ApplicationController
+    # Includes
+    include ManifestableController
+    include MergeableController
+    include NameableController
+    include OwnableController
+    include RelatedColumnable
+    include UserDefinedFields::Queryable
+
+    # Preloads
+    preloads :source_names, only: :show
+
+    # Search attributes
+    search_attributes :name
+  end
+end

--- a/app/jobs/core_data_connector/application_job.rb
+++ b/app/jobs/core_data_connector/application_job.rb
@@ -1,0 +1,4 @@
+module CoreDataConnector
+  class ApplicationJob < ActiveJob::Base
+  end
+end

--- a/app/jobs/core_data_connector/export_csv_job.rb
+++ b/app/jobs/core_data_connector/export_csv_job.rb
@@ -1,0 +1,56 @@
+module CoreDataConnector
+  class ExportCsvJob < ApplicationJob
+
+    def perform(job_id)
+      job = Job.find(job_id)
+
+      # Update the job status
+      job.update(status: Job::JOB_STATUS_PROCESSING)
+
+      # Run the import for the uploaded file
+      success = nil
+      errors = []
+
+      begin
+        # Create the temporary directory
+        directory = FileSystem.create_directory
+        filename = "#{job.project.name.gsub(/\s+/, "")}.zip"
+
+        # Run the exporter to generate the CSV files
+        exporter = Export::Exporter.new(job.project_id)
+        exporter.run(directory)
+
+        # Create a zip file of the CSVs in the passed directory
+        FileSystem.create_zip directory, filename
+
+        # Attach the file to the job
+        zippath = File.join(directory, filename)
+        job.file.attach(io: File.open(zippath), filename: filename)
+
+        success = true
+      rescue StandardError => error
+        errors = [error]
+        success = false
+
+        log_error error
+      ensure
+        # Remove the temporary directory
+        FileSystem.remove_directory directory
+      end
+
+      # Update the job status
+      if success && errors.empty?
+        job.update(status: Job::JOB_STATUS_COMPLETED)
+      else
+        job.update(status: Job::JOB_STATUS_FAILED)
+      end
+    end
+
+    private
+
+    def log_error(error)
+      Rails.logger.error (["#{self.class} - #{error.class}: #{error.message}", error.backtrace]).join("\n")
+    end
+
+  end
+end

--- a/app/jobs/core_data_connector/import_csv_job.rb
+++ b/app/jobs/core_data_connector/import_csv_job.rb
@@ -1,0 +1,51 @@
+module CoreDataConnector
+  class ImportCsvJob < ApplicationJob
+
+    def perform(job_id)
+      job = Job.find(job_id)
+
+      # Update the job status
+      job.update(status: Job::JOB_STATUS_PROCESSING)
+
+      # Run the import for the uploaded file
+      success = nil
+      errors = []
+
+      job.file.open do |file|
+        begin
+          zip_importer = Import::ZipHelper.new
+          success, errors = zip_importer.import_zip(file)
+        rescue StandardError => error
+          errors = [error]
+        end
+      end
+
+      # Remove duplicate records, if specified
+      remove_duplicates job if success
+
+      # Update the job status
+      if success && errors.empty?
+        job.update(status: Job::JOB_STATUS_COMPLETED)
+      else
+        log_errors errors
+        job.update(status: Job::JOB_STATUS_FAILED)
+      end
+    end
+
+    private
+
+    def log_errors(errors)
+      errors.each do |error|
+        Rails.logger.error (["#{self.class} - #{error.class}: #{error.message}", error.backtrace]).join("\n")
+      end
+    end
+
+    def remove_duplicates(job)
+      return unless job.extra['filenames'].present?
+
+      service = ImportAnalyze::Import.new
+      service.remove_duplicates job.project_id, job.extra['filenames']
+    end
+
+  end
+end

--- a/app/mailers/core_data_connector/application_mailer.rb
+++ b/app/mailers/core_data_connector/application_mailer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class ApplicationMailer < ActionMailer::Base
+    default from: "from@example.com"
+    layout "mailer"
+  end
+end

--- a/app/mailers/core_data_connector/invitation_mailer.rb
+++ b/app/mailers/core_data_connector/invitation_mailer.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  class InvitationMailer < ApplicationMailer
+    # Includes
+    include PostmarkRails::TemplatedMailerMixin
+
+    def invite_user(user:, password:, project:)
+      # Setup template variables
+      self.template_model = {
+        product_url: ENV['HOSTNAME'],
+        product_name: I18n.t('app.name'),
+        name: user.name,
+        project_name: project&.name,
+        password: password,
+        action_url: ENV['HOSTNAME'],
+        company_name: I18n.t('app.company_name'),
+        company_address: I18n.t('app.company_address')
+      }
+
+      # Send the email
+      mail(
+        postmark_template_alias: 'user-invitation',
+        to: user.email,
+        from: ENV['POSTMARK_FROM']
+      )
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -1,0 +1,90 @@
+module CoreDataConnector
+  module Auditable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def track_changes(root: nil, roots: nil, **options)
+        has_paper_trail(
+          versions: { class_name: 'CoreDataConnector::Version' },
+          meta: {
+            roots: ->(record) { record.audit_roots_data },
+            project_id: ->(record) { record.audit_roots.first&.project_id },
+            meta: ->(record) { record.audit_metadata }
+          },
+          **options,
+          ignore: [
+            :id,
+            :created_at,
+            :updated_at,
+            :uuid,
+            :import_id,
+            :project_model_id,
+            :z_event_id,
+            :z_instance_id,
+            :z_item_id,
+            :z_media_content_id,
+            :z_organization_id,
+            :z_person_id,
+            :z_place_id,
+            :z_taxonomy_id,
+            :z_work_id
+          ].concat(options[:ignore] || []),
+        )
+
+        after_commit :backfill_audit_roots_data, on: :create
+
+        if roots
+          define_method(:audit_roots) { Array(roots.call(self)).compact }
+        elsif root
+          define_method(:audit_roots) { [root.call(self)].compact }
+        else
+          @audit_root = true
+        end
+      end
+
+      # Returns whether this model is a top-level trackable record
+      def audit_root?
+        @audit_root
+      end
+    end
+
+    def audit_roots
+      [self]
+    end
+
+    def audit_roots_data
+      audit_roots.map do |record|
+        {
+          type: record.class.name,
+          id: record.id,
+          display_name: record.display_name,
+          uuid: record.uuid,
+          project_model_id: record.project_model_id
+        }
+      end
+    end
+
+    # Additional model-specific data to store alongside each version
+    def audit_metadata
+      nil
+    end
+
+    private
+
+    # Fill in root data after record creation
+    def backfill_audit_roots_data
+      incomplete = versions.where(event: 'create').reject { |version| audit_roots_complete?(version) }
+      return if incomplete.blank?
+
+      data = self.class.find_by(id: id)&.audit_roots_data
+      return if data.blank?
+
+      versions.where(id: incomplete.map(&:id)).update_all(roots: data)
+    end
+
+    def audit_roots_complete?(version)
+      roots = Array(version.roots)
+      roots.present? && roots.all? { |root| root['uuid'].present? }
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/display_nameable.rb
+++ b/app/models/concerns/core_data_connector/display_nameable.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module DisplayNameable
+    extend ActiveSupport::Concern
+
+    def display_name
+      name_from_nameable.presence ||
+        name_from_attributes.presence
+    end
+
+    private
+
+    def name_from_nameable
+      return unless self.class.respond_to?(:get_names_table)
+      return if self.class.get_names_table.blank?
+
+      primary_name&.name.presence
+    end
+
+    def name_from_attributes
+      return self[:name].to_s if self[:name].present?
+
+      nil
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/fcc_importable.rb
+++ b/app/models/concerns/core_data_connector/fcc_importable.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module FccImportable
+    extend ActiveSupport::Concern
+
+    included do
+      # Generate the full URL for the record's CSV files in FairCopy.cloud
+      def faircopy_cloud_url
+        project = project_model.project
+        return nil unless project_model.id == project.faircopy_cloud_project_model_id
+
+        # We assume that if a project ID is configured, that means we should use it; in other words, use the FCC2 URL format
+        if project.faircopy_cloud_project_id?
+          return "#{project.faircopy_cloud_url}/#{project.faircopy_cloud_project_id}/tei_documents/#{faircopy_cloud_id}/csv"
+        end
+
+        "#{project.faircopy_cloud_url}/documents/#{faircopy_cloud_id}/csv"
+      end
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/identifiable.rb
+++ b/app/models/concerns/core_data_connector/identifiable.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Identifiable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :web_identifiers, as: :identifiable, class_name: WebIdentifier.to_s, dependent: :destroy
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/manifestable.rb
+++ b/app/models/concerns/core_data_connector/manifestable.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Manifestable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :manifests, as: :manifestable, class_name: Manifest.to_s, dependent: :destroy
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/mergeable.rb
+++ b/app/models/concerns/core_data_connector/mergeable.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Mergeable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :record_merges, as: :mergeable, dependent: :destroy
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/nameable.rb
+++ b/app/models/concerns/core_data_connector/nameable.rb
@@ -1,0 +1,58 @@
+module CoreDataConnector
+  module Nameable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def name_table(name, options = {})
+        # Relationships
+        if options && options[:as]
+          self.send(:has_many, name.to_sym, dependent: :destroy, as: options[:as])
+          has_one :primary_name, -> { where(primary: true) }, class_name: name.to_s.classify, as: options[:as]
+          has_many :ordered_names, -> { order(primary: :desc) }, class_name: name.to_s.classify, as: options[:as]
+        else
+          self.send(:has_many, name.to_sym, dependent: :destroy)
+          has_one :primary_name, -> { where(primary: true) }, class_name: name.to_s.classify
+          has_many :ordered_names, -> { order(primary: :desc) }, class_name: name.to_s.classify
+        end
+
+        # Nested attributes
+        self.send(:accepts_nested_attributes_for, name.to_sym, allow_destroy: true)
+
+        @names_table = name
+        @nameable_attribute = options[:as] if options && options[:as]
+      end
+
+      def get_names_table
+        @names_table
+      end
+
+      def name_column(table_alias = nil)
+        if table_alias
+          return "#{table_alias}.name"
+        end
+
+        "name"
+      end
+
+      def nameable_attribute
+        @nameable_attribute
+      end
+    end
+
+    included do
+      # Validations
+      validate :validate_names
+
+      private
+
+      def has_primary_name?
+        names = self.send(self.class.get_names_table)
+        names.select{ |n| n.primary? }.present?
+      end
+
+      def validate_names
+        errors.add(:names, I18n.t('errors.nameable.primary_name')) unless has_primary_name?
+      end
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/ownable.rb
+++ b/app/models/concerns/core_data_connector/ownable.rb
@@ -1,0 +1,62 @@
+module CoreDataConnector
+  module Ownable
+    extend ActiveSupport::Concern
+
+    included do
+      # Relationships
+      belongs_to :project_model
+
+      # Delegates
+      delegate :project, to: :project_model, allow_nil: true
+      delegate :project_id, to: :project_model, allow_nil: true
+
+      def self.all_records_by_project(project_id)
+        owned_query = owned_records_by_project(project_id)
+        shared_query = shared_records_by_project(project_id)
+
+        owned_query.or(shared_query)
+      end
+
+      # Returns a query to find all of the records owned by the passed project_model_id or shared with the
+      # passed project_model_id.
+      def self.all_records_by_project_model(project_model_id)
+        owned_query = owned_records_by_project_model(project_model_id)
+        shared_query = shared_records_by_project_model(project_model_id)
+
+        owned_query.or(shared_query)
+      end
+
+      def self.owned_records_by_project(project_id)
+        joins(:project_model).where(core_data_connector_project_models: { project_id: project_id })
+      end
+
+      # Returns a query to find all of the records owned by the passed project_model_id.
+      def self.owned_records_by_project_model(project_model_id)
+        where(project_model_id: project_model_id)
+      end
+
+      def self.shared_records_by_project(project_id)
+        where(
+          ProjectModelShare
+            .joins(project_model_access: :project_model)
+            .where(ProjectModelAccess.arel_table[:project_model_id].eq(self.arel_table[:project_model_id]))
+            .where(core_data_connector_project_models: { project_id: project_id })
+            .arel
+            .exists
+        )
+      end
+
+      # Returns a query to find all of the records shared with the passed project_model_id.
+      def self.shared_records_by_project_model(project_model_id)
+        where(
+          ProjectModelShare
+            .joins(:project_model_access)
+            .where(ProjectModelAccess.arel_table[:project_model_id].eq(self.arel_table[:project_model_id]))
+            .where(project_model_id: project_model_id)
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/relateable.rb
+++ b/app/models/concerns/core_data_connector/relateable.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  module Relateable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :relationships, as: :primary_record, dependent: :destroy
+      has_many :related_relationships, as: :related_record, dependent: :destroy, class_name: Relationship.to_s
+    end
+  end
+end

--- a/app/models/concerns/core_data_connector/sluggable.rb
+++ b/app/models/concerns/core_data_connector/sluggable.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  module Sluggable
+    extend ActiveSupport::Concern
+
+    included do
+      # Callbacks
+      before_validation :set_slug, on: :create
+
+      # Validations
+      validates :slug, presence: true
+
+      private
+
+      def set_slug
+        return unless new_record? || name_changed?
+
+        self.slug = name.parameterize(separator: '_')
+      end
+    end
+  end
+end

--- a/app/models/core_data_connector/application_record.rb
+++ b/app/models/core_data_connector/application_record.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+
+    # Includes
+    include Resourceable
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  class Event < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Event
+    include FuzzyDates::FuzzyDateable
+    include Identifiable
+    include ImportAnalyze::Event
+    include Manifestable
+    include Mergeable
+    include Ownable
+    include Reconcile::Event
+    include Relateable
+    include Search::Event
+    include Auditable
+    include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
+
+    # Fuzzy dates
+    has_fuzzy_dates :start_date, :end_date
+
+    # User defined fields parent
+    resolve_defineable -> (event) { event.project_model }
+  end
+end

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  class Instance < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Instance
+    include Identifiable
+    include ImportAnalyze::Instance
+    include Manifestable
+    include Mergeable
+    include Nameable
+    include Ownable
+    include Reconcile::Instance
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Instance
+    include Auditable
+
+    # Audit logging
+    track_changes
+
+    # Nameable table
+    name_table :source_names, as: :nameable
+
+    # Delegates
+    delegate :name, to: :primary_name, allow_nil: true
+
+    # User defined fields parent
+    resolve_defineable -> (instance) { instance.project_model }
+  end
+end

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class Item < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Item
+    include FccImportable
+    include Identifiable
+    include ImportAnalyze::Item
+    include Manifestable
+    include Mergeable
+    include Nameable
+    include Ownable
+    include Reconcile::Item
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Item
+    include Auditable
+
+    # Audit logging
+    track_changes
+
+    # Nameable table
+    name_table :source_names, as: :nameable
+
+    # Delegates
+    delegate :name, to: :primary_name, allow_nil: true
+
+    # User defined fields parent
+    resolve_defineable -> (item) { item.project_model }
+  end
+end

--- a/app/models/core_data_connector/job.rb
+++ b/app/models/core_data_connector/job.rb
@@ -1,0 +1,49 @@
+module CoreDataConnector
+  class Job < ApplicationRecord
+    JOB_STATUS_INITIALIZING = 'initializing'
+    JOB_STATUS_PROCESSING = 'processing'
+    JOB_STATUS_COMPLETED = 'completed'
+    JOB_STATUS_FAILED = 'failed'
+
+    JOB_TYPE_EXPORT = 'export'
+    JOB_TYPE_IMPORT = 'import'
+
+    # Includes
+    include Rails.application.routes.url_helpers
+
+    # Relationships
+    belongs_to :project
+    belongs_to :user
+
+    # Active storage
+    has_one_attached :file
+
+    # Callbacks
+    after_create_commit :queue_export_job, if: :export?
+    after_create_commit :queue_import_job, if: :import?
+
+    def download_url
+      return nil unless file.attached?
+
+      rails_blob_url file, disposition: 'attachment'
+    end
+
+    def export?
+      job_type == JOB_TYPE_EXPORT
+    end
+
+    def import?
+      job_type == JOB_TYPE_IMPORT
+    end
+
+    private
+
+    def queue_export_job
+      ExportCsvJob.perform_later(id)
+    end
+
+    def queue_import_job
+      ImportCsvJob.perform_later(id)
+    end
+  end
+end

--- a/app/models/core_data_connector/manifest.rb
+++ b/app/models/core_data_connector/manifest.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  class Manifest < ApplicationRecord
+    # Relationships
+    belongs_to :manifestable, polymorphic: true
+    belongs_to :project_model_relationship
+
+    # Delegations
+    delegate :project, to: :project_model_relationship
+
+    # Validations
+    validates :project_model_relationship_id, uniqueness: {
+      scope: [:manifestable_id, :manifestable_type], message: I18n.t('errors.manifest.unique')
+    }
+  end
+end

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -1,0 +1,78 @@
+module CoreDataConnector
+  class MediaContent < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::MediaContent
+    include Identifiable
+    include ImportAnalyze::MediaContent
+    include Manifestable
+    include Mergeable
+    include Ownable
+    include Relateable
+    include Search::MediaContent
+    include Auditable
+    include TripleEyeEffable::Resourceable
+    include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
+
+    # Delegates
+    delegate :storage_key, to: :project, allow_nil: true
+
+    # Callbacks
+    after_save :update_manifests
+
+    # User defined fields parent
+    resolve_defineable -> (media_content) { media_content.project_model }
+
+    def metadata
+      fields = [{
+        label: I18n.t('services.iiif.manifest.content_warning'),
+        value: self[:content_warning]
+      }]
+
+      if !self.user_defined || self.user_defined.keys.count == 0
+        return fields.to_json
+      end
+
+      udfs = UserDefinedFields::UserDefinedField
+        .where(uuid: self.user_defined.keys)
+        .order(:order)
+
+      udfs.each do |udf|
+        fields.push({
+          label: udf[:column_name],
+          value: self.user_defined[udf[:uuid]]
+        })
+      end
+
+      fields.to_json
+    end
+
+    private
+
+    def update_manifests
+      iiif_service = Iiif::Manifest.new
+
+      self.relationships.each { |r| update_relationship_manifests(r, iiif_service, true) }
+      self.related_relationships.each { |r| update_relationship_manifests(r, iiif_service, false) }
+    end
+
+    def update_relationship_manifests(relationship, service, is_primary)
+      if is_primary
+        related_model = relationship.related_record_type.constantize
+        related_record_id = relationship.related_record_id
+      else
+        related_model = relationship.primary_record_type.constantize
+        related_record_id = relationship.primary_record_id
+      end
+
+      service.reset_manifests_by_type(related_model, {
+        id: related_record_id,
+        project_model_relationship_id: relationship.project_model_relationship_id,
+        limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+      })
+    end
+  end
+end

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  class Organization < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Organization
+    include Identifiable
+    include ImportAnalyze::Organization
+    include Manifestable
+    include Mergeable
+    include Nameable
+    include Ownable
+    include Reconcile::Organization
+    include Relateable
+    include Search::Organization
+    include Auditable
+    include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
+
+    # Delegates
+    delegate :name, to: :primary_name, allow_nil: true
+
+    # Nameable table
+    name_table :organization_names
+
+    # User defined fields parent
+    resolve_defineable -> (organization) { organization.project_model }
+  end
+end

--- a/app/models/core_data_connector/organization_name.rb
+++ b/app/models/core_data_connector/organization_name.rb
@@ -1,0 +1,12 @@
+module CoreDataConnector
+  class OrganizationName < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(organization_name) { organization_name.organization }, ignore: [:organization_id]
+
+    # Relationships
+    belongs_to :organization
+  end
+end

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -1,0 +1,46 @@
+module CoreDataConnector
+  class Person < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Person
+    include Identifiable
+    include ImportAnalyze::Person
+    include Manifestable
+    include Mergeable
+    include Nameable
+    include Ownable
+    include Reconcile::Person
+    include Relateable
+    include Search::Person
+    include Auditable
+    include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
+
+    # Delegates
+    delegate :first_name, :middle_name, :last_name, to: :primary_name, allow_nil: true
+
+    # Nameable table
+    name_table :person_names
+
+    def self.name_column(table_alias = nil)
+      if table_alias
+        "CONCAT_WS(' ', #{table_alias}.first_name, #{table_alias}.middle_name, #{table_alias}.last_name)"
+      else
+        "CONCAT_WS(' ', first_name, middle_name, last_name)"
+      end
+    end
+
+    # User defined fields parent
+    resolve_defineable -> (person) { person.project_model }
+
+    def full_name
+      [first_name, middle_name, last_name].compact.join(' ')
+    end
+
+    def display_name
+      full_name
+    end
+  end
+end

--- a/app/models/core_data_connector/person_name.rb
+++ b/app/models/core_data_connector/person_name.rb
@@ -1,0 +1,12 @@
+module CoreDataConnector
+  class PersonName < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(person_name) { person_name.person }, ignore: [:person_id]
+
+    # Relationships
+    belongs_to :person
+  end
+end

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -1,0 +1,83 @@
+module CoreDataConnector
+  class Place < ApplicationRecord
+    self.primary_key = :id
+
+    # Includes
+    include DisplayNameable
+    include Export::Place
+    include Identifiable
+    include ImportAnalyze::Place
+    include Manifestable
+    include Mergeable
+    include Nameable
+    include Ownable
+    include Reconcile::Place
+    include Relateable
+    include Search::Place
+    include Auditable
+    include UserDefinedFields::Fieldable
+
+    # Audit logging
+    track_changes
+
+    # Relationships
+    has_one :place_geometry, dependent: :destroy
+    has_many :place_layers, dependent: :destroy
+
+    # Nested attributes
+    accepts_nested_attributes_for :place_geometry, allow_destroy: true
+    accepts_nested_attributes_for :place_layers, allow_destroy: true
+
+    # Nameable table
+    name_table :place_names
+
+    # Delegates
+    delegate :name, to: :primary_name, allow_nil: true
+
+    # User defined fields parent
+    resolve_defineable -> (place) { place.project_model }
+
+    def self.centroid_function
+      Arel::Nodes::NamedFunction.new(
+        'st_centroid',
+        [PlaceGeometry.arel_table[:geometry]]
+      ).as('geometry_center')
+    end
+
+    def self.with_centroid
+      left_joins(:place_geometry)
+        .select(arel_table[Arel.star], centroid_function)
+    end
+
+    def self.simplified_geometry_function(base_tolerance = 0.004)
+      geometry_column = PlaceGeometry.arel_table[:geometry]
+
+      tolerance = Arel::Nodes::NamedFunction.new(
+        'greatest',
+        [
+          Arel::Nodes.build_quoted(base_tolerance),
+          Arel::Nodes::Multiplication.new(
+            Arel::Nodes.build_quoted(base_tolerance),
+            Arel::Nodes::NamedFunction.new('sqrt', [
+              Arel::Nodes::NamedFunction.new('st_area', [geometry_column])
+            ])
+          )
+        ]
+      )
+
+      Arel::Nodes::NamedFunction.new(
+        'st_simplify',
+        [geometry_column, Arel::Nodes.build_quoted(tolerance)]
+      ).as('simplified_geometry')
+    end
+
+    def self.with_search_geometry
+      left_joins(:place_geometry)
+        .select(
+          arel_table[Arel.star],
+          centroid_function,
+          simplified_geometry_function
+        )
+    end
+  end
+end

--- a/app/models/core_data_connector/place_geometry.rb
+++ b/app/models/core_data_connector/place_geometry.rb
@@ -1,0 +1,37 @@
+module CoreDataConnector
+  class PlaceGeometry < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging. Geometries are too large to store in the audit log, but
+    # every geometry update destroys the existing place_geometry record
+    # and creates a new one, so that event should appear in the log.
+    track_changes root: ->(place_geometry) { place_geometry.place },
+                  ignore: [:place_id],
+                  skip: [:geometry]
+
+    # Relationships
+    belongs_to :place
+
+    # Transient attributes
+    attr_accessor :geometry_json
+
+    # Callbacks
+    before_save :set_geometry
+
+    # Returns the "geometry" as GeoJSON
+    def to_geojson
+      Geometry.to_geojson(self.geometry)
+    end
+
+    private
+
+    # Sets the geometry attribute if the geometry_json attribute is provided.
+    def set_geometry
+      return unless self.geometry_json.present?
+
+      json = JSON.parse(self.geometry_json)
+      self.geometry = Geometry.to_postgis(json)
+    end
+  end
+end

--- a/app/models/core_data_connector/place_layer.rb
+++ b/app/models/core_data_connector/place_layer.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  class PlaceLayer < ApplicationRecord
+    LAYER_TYPES = %w(geojson raster georeference)
+
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(place_layer) { place_layer.place }, ignore: [:place_id]
+
+    # Relationships
+    belongs_to :place
+
+    # Validations
+    validates :name, presence: true
+    validates :layer_type, inclusion: { in: LAYER_TYPES }
+    validates :content, presence: true, if: -> { url.blank? }
+    validates :url, presence: true, if: -> { content.blank? }
+  end
+end

--- a/app/models/core_data_connector/place_name.rb
+++ b/app/models/core_data_connector/place_name.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  class PlaceName < ApplicationRecord
+    self.primary_key = :id
+
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(place_name) { place_name.place }, ignore: [:place_id]
+
+    # Relationships
+    belongs_to :place
+  end
+end

--- a/app/models/core_data_connector/project.rb
+++ b/app/models/core_data_connector/project.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  class Project < ApplicationRecord
+    # Relationships
+    has_many :project_models, dependent: :destroy
+    has_many :user_projects, dependent: :destroy
+    has_many :web_authorities, dependent: :destroy
+
+    def storage_key
+      return nil unless use_storage_key?
+
+      uuid
+    end
+  end
+end

--- a/app/models/core_data_connector/project_model.rb
+++ b/app/models/core_data_connector/project_model.rb
@@ -1,0 +1,83 @@
+module CoreDataConnector
+  class ProjectModel < ApplicationRecord
+    # Includes
+    include Sluggable
+    include UserDefinedFields::Defineable
+
+    # Relationships
+    belongs_to :project
+
+    has_many :instances, dependent: :destroy
+    has_many :items, dependent: :destroy
+    has_many :organizations, dependent: :destroy
+    has_many :people, dependent: :destroy
+    has_many :places, dependent: :destroy
+    has_many :project_model_accesses, dependent: :destroy
+    has_many :project_model_shares, dependent: :destroy
+    has_many :taxonomies, dependent: :destroy
+    has_many :works, dependent: :destroy
+
+    has_many :project_model_relationships, dependent: :destroy, foreign_key: :primary_model_id
+    has_many :related_project_model_relationships, dependent: :destroy, class_name: ProjectModelRelationship.to_s, foreign_key: :related_model_id
+    has_many :inverse_project_model_relationships, -> { where(allow_inverse: true) }, dependent: :destroy, class_name: ProjectModelRelationship.to_s, foreign_key: :related_model_id
+
+    # Nested attributes
+    accepts_nested_attributes_for :project_model_relationships, allow_destroy: true
+    accepts_nested_attributes_for :inverse_project_model_relationships, allow_destroy: true
+    accepts_nested_attributes_for :project_model_accesses, allow_destroy: true
+    accepts_nested_attributes_for :project_model_shares, allow_destroy: true
+
+    # Validations
+    validates :name, presence: true
+    validates :model_class, inclusion: { in: :valid_model_classes }
+
+    # Destroys any records owned by the project_model
+    def clear
+      model_class
+        .constantize
+        .where(project_model_id: id)
+        .destroy_all
+    end
+
+    # Returns a list of models that include the Ownable concern.
+    def self.model_classes
+      # Eager load all of the models in development mode
+      Rails.application.eager_load! if Rails.env.development?
+
+      # Return the list of values
+      ApplicationRecord.descendants.select do |descendant|
+        descendant.included_modules&.include?(Ownable) && descendant.model_name.present?
+      end
+    end
+
+    # Returns a human readable model class name.
+    def model_class_view
+      model_class&.safe_constantize&.model_name&.human&.titleize
+    end
+
+    # Returns the singular version of the name.
+    def name_singular
+      name&.singularize
+    end
+
+    # Returns a query to find project_models records that are not shared with other projects.
+    def self.unshared
+      model_table = ProjectModel.arel_table
+      access_table = ProjectModelAccess.arel_table
+
+      where.not(
+        ProjectModelAccess
+          .where(access_table[:project_model_id].eq(model_table[:id]))
+          .arel
+          .exists
+      )
+    end
+
+    private
+
+    # Returns a list of valid model class names.
+    def valid_model_classes
+      self.class.model_classes.map(&:model_name).map(&:name)
+    end
+  end
+end

--- a/app/models/core_data_connector/project_model_access.rb
+++ b/app/models/core_data_connector/project_model_access.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class ProjectModelAccess < ApplicationRecord
+    # Relationships
+    belongs_to :project_model
+    belongs_to :project
+    has_many :project_model_shares, dependent: :destroy
+  end
+end

--- a/app/models/core_data_connector/project_model_relationship.rb
+++ b/app/models/core_data_connector/project_model_relationship.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  class ProjectModelRelationship < ApplicationRecord
+    # Includes
+    include Sluggable
+    include UserDefinedFields::Defineable
+
+    # Relationships
+    belongs_to :primary_model, class_name: ProjectModel.to_s
+    belongs_to :related_model, class_name: ProjectModel.to_s
+    has_many :relationships, dependent: :destroy
+    has_many :manifests, dependent: :destroy
+
+    # Delegates
+    delegate :project, to: :primary_model
+    delegate :project_id, to: :primary_model
+
+    # Validations
+    validates :name, presence: true
+    validates :inverse_name, presence: true, if: :allow_inverse?
+  end
+end

--- a/app/models/core_data_connector/project_model_share.rb
+++ b/app/models/core_data_connector/project_model_share.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class ProjectModelShare < ApplicationRecord
+    belongs_to :project_model_access
+    belongs_to :project_model
+  end
+end

--- a/app/models/core_data_connector/record_merge.rb
+++ b/app/models/core_data_connector/record_merge.rb
@@ -1,0 +1,5 @@
+module CoreDataConnector
+  class RecordMerge < ApplicationRecord
+    belongs_to :mergeable, polymorphic: true
+  end
+end

--- a/app/models/core_data_connector/relationship.rb
+++ b/app/models/core_data_connector/relationship.rb
@@ -1,0 +1,71 @@
+module CoreDataConnector
+  class Relationship < ApplicationRecord
+    # Includes
+    include Export::Relationship
+    include Auditable
+    include UserDefinedFields::Fieldable
+
+    track_changes roots: ->(relationship) { [relationship.primary_record, relationship.related_record] },
+                  only: [:user_defined]
+
+    # Relationships
+    belongs_to :project_model_relationship
+    belongs_to :primary_record, polymorphic: true
+    belongs_to :related_record, polymorphic: true
+
+    belongs_to :related_event, -> { where(Relationship.arel_table.name => { related_record_type: Event.to_s }) }, class_name: Event.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_instance, -> { where(Relationship.arel_table.name => { related_record_type: Instance.to_s }) }, class_name: Instance.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_item, -> { where(Relationship.arel_table.name => { related_record_type: Item.to_s }) }, class_name: Item.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_media_content, -> { where(Relationship.arel_table.name => { related_record_type: MediaContent.to_s }) }, class_name: MediaContent.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_organization, -> { where(Relationship.arel_table.name => { related_record_type: Organization.to_s }) }, class_name: Organization.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_person, -> { where(Relationship.arel_table.name => { related_record_type: Person.to_s }) }, class_name: Person.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_place, -> { where(Relationship.arel_table.name => { related_record_type: Place.to_s }) }, class_name: Place.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_taxonomy, -> { where(Relationship.arel_table.name => { related_record_type: Taxonomy.to_s }) }, class_name: Taxonomy.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :related_work, -> { where(Relationship.arel_table.name => { related_record_type: Work.to_s }) }, class_name: Work.to_s, foreign_key: :related_record_id, optional: true
+
+    belongs_to :inverse_related_event, -> { where(Relationship.arel_table.name => { primary_record_type: Event.to_s }) }, class_name: Event.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_instance, -> { where(Relationship.arel_table.name => { primary_record_type: Instance.to_s }) }, class_name: Instance.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_item, -> { where(Relationship.arel_table.name => { primary_record_type: Item.to_s }) }, class_name: Item.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_media_content, -> { where(Relationship.arel_table.name => { primary_record_type: MediaContent.to_s }) }, class_name: MediaContent.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_organization, -> { where(Relationship.arel_table.name => { primary_record_type: Organization.to_s }) }, class_name: Organization.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_person, -> { where(Relationship.arel_table.name => { primary_record_type: Person.to_s }) }, class_name: Person.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_place, -> { where(Relationship.arel_table.name => { primary_record_type: Place.to_s }) }, class_name: Place.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_taxonomy, -> { where(Relationship.arel_table.name => { primary_record_type: Taxonomy.to_s }) }, class_name: Taxonomy.to_s, foreign_key: :primary_record_id, optional: true
+    belongs_to :inverse_related_work, -> { where(Relationship.arel_table.name => { primary_record_type: Work.to_s }) }, class_name: Work.to_s, foreign_key: :primary_record_id, optional: true
+
+    # Place relationships
+    belongs_to :related_place_with_search_geometry, -> { merge(Place.with_search_geometry) }, class_name: Place.to_s, foreign_key: :related_record_id, optional: true
+    belongs_to :inverse_related_place_with_search_geometry, -> { merge(Place.with_search_geometry) }, class_name: Place.to_s, foreign_key: :primary_record_id, optional: true
+
+    # Delegates
+    delegate :project, to: :project_model_relationship
+    delegate :project_id, to: :project_model_relationship
+
+    # User defined fields parent
+    resolve_defineable -> (relationship) { relationship.project_model_relationship }
+
+    def self.all_records_by_project(project_id)
+      primary_query = Relationship
+                        .where(
+                          ProjectModelRelationship
+                            .joins(:primary_model)
+                            .where(ProjectModelRelationship.arel_table[:id].eq(Relationship.arel_table[:project_model_relationship_id]))
+                            .where(primary_model: { project_id: project_id })
+                            .arel
+                            .exists
+                        )
+
+      related_query = Relationship
+                        .where(
+                          ProjectModelRelationship
+                            .joins(:related_model)
+                            .where(ProjectModelRelationship.arel_table[:id].eq(Relationship.arel_table[:project_model_relationship_id]))
+                            .where(related_model: { project_id: project_id })
+                            .arel
+                            .exists
+                        )
+
+      primary_query.or(related_query)
+    end
+  end
+end

--- a/app/models/core_data_connector/source_name.rb
+++ b/app/models/core_data_connector/source_name.rb
@@ -1,0 +1,12 @@
+module CoreDataConnector
+  class SourceName < ApplicationRecord
+    # Includes
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(source_name) { source_name.nameable }, ignore: [:nameable_id, :nameable_type]
+
+    # Relationships
+    belongs_to :nameable, polymorphic: true
+  end
+end

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -1,0 +1,23 @@
+module CoreDataConnector
+  class Taxonomy < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Taxonomy
+    include Identifiable
+    include ImportAnalyze::Taxonomy
+    include Manifestable
+    include Mergeable
+    include Ownable
+    include Reconcile::Taxonomy
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Taxonomy
+    include Auditable
+
+    # Audit logging
+    track_changes
+
+    # User defined fields parent
+    resolve_defineable -> (taxonomy) { taxonomy.project_model }
+  end
+end

--- a/app/models/core_data_connector/user.rb
+++ b/app/models/core_data_connector/user.rb
@@ -1,0 +1,80 @@
+module CoreDataConnector
+  class User < ApplicationRecord
+    # Roles
+    ROLE_ADMIN = 'admin'
+    ROLE_MEMBER = 'member'
+    ROLE_GUEST = 'guest'
+
+    ALLOWED_ROLES = [
+      ROLE_ADMIN,
+      ROLE_MEMBER,
+      ROLE_GUEST
+    ]
+
+    # Relationships
+    has_many :user_projects, dependent: :destroy
+
+    # JWT
+    has_secure_password
+
+    # Transient attributes
+    attr_accessor :password_temporary, :skip_invitation
+
+    # Actions
+    before_validation :set_temp_password, on: :create
+    after_commit :send_invitation, on: :create
+
+    # Validations
+    validates :email, uniqueness: true
+    validates :password,
+              allow_nil: true,
+              length: { in: 8..128 },
+              format: { with: Users::Passwords::PASSWORD_FORMAT },
+              unless: :password_temporary
+    validates :role, inclusion:  { in: ALLOWED_ROLES, message: I18n.t('errors.users.roles') }
+
+    def admin?
+      role === ROLE_ADMIN
+    end
+
+    def authenticate(password)
+      success = super
+
+      # Update the user's last sign in at timestamp
+      update(last_sign_in_at: Time.now.utc) if success
+
+      success
+    end
+
+    def guest?
+      role === ROLE_GUEST
+    end
+
+    def member?
+      role === ROLE_MEMBER
+    end
+
+    def split_name
+      self.name&.split(' ', 2)
+    end
+
+    private
+
+    def set_temp_password
+      return if password.present?
+      temp = Users::Passwords.generate_user_password
+      self.assign_attributes(
+        password: temp,
+        password_confirmation: temp,
+        password_temporary: true,
+        require_password_change: true
+      )
+    end
+
+    def send_invitation
+      return false if ENV['VITE_AUTH_PROVIDER'] == 'clerk' || last_sign_in_at.present? || skip_invitation
+
+      Users::Invitations.new.send_invitation(self)
+    end
+  end
+end

--- a/app/models/core_data_connector/user_project.rb
+++ b/app/models/core_data_connector/user_project.rb
@@ -1,0 +1,74 @@
+module CoreDataConnector
+  class UserProject < ApplicationRecord
+    # Constants
+    ROLE_OWNER = 'owner'
+    ROLE_EDITOR = 'editor'
+    ALLOWED_ROLES = [
+      ROLE_OWNER,
+      ROLE_EDITOR
+    ]
+
+    # Relationships
+    belongs_to :user
+    belongs_to :project
+
+    # Transient attributes
+    attr_accessor :name, :email
+
+    # Validations
+    validate :validate_project_owner
+    validates :role, inclusion:  { in: ALLOWED_ROLES, message: I18n.t('errors.user_projects.roles') }
+    validates :user_id, uniqueness: { scope: :project_id, message: I18n.t('errors.user_projects.unique') }
+
+    # Callbacks
+    after_commit :send_invitation, on: :create
+    before_validation :find_or_create_user, on: :create
+
+    private
+
+    # Create the user record at the same time if the correct attributes are provided and no user_id is set. We'll
+    # only update the name and password if the user is a new record.
+    def find_or_create_user
+      return unless user_id.nil? && name.present? && email.present?
+
+      user = User.find_or_create_by(email: email) do |user|
+        next unless user.new_record?
+
+        # Generate a temporary password in order to create the user record. The password sent to the user
+        # will be generated after the record is saved.
+        temporary_password = Users::Passwords.generate_user_password
+
+        user.assign_attributes(
+          name: name,
+          password: temporary_password,
+          password_confirmation: temporary_password,
+          password_temporary: true,
+          role: User::ROLE_GUEST,
+          require_password_change: true,
+          skip_invitation: true  # prevent double invitation email from User callback
+        )
+      end
+
+      self.user_id = user.id
+    end
+
+    def send_invitation
+      return if ENV['VITE_AUTH_PROVIDER'] == 'clerk' || user.last_sign_in_at.present? || user.last_invited_at.present?
+
+      Users::Invitations.new.send_invitation(self)
+    end
+
+    # Validates that the project has at least one owner
+    def validate_project_owner
+      return unless role == ROLE_EDITOR
+
+      has_owner = project
+                    .user_projects
+                    .where(role: ROLE_OWNER)
+                    .where.not(id: id)
+                    .exists?
+
+      errors.add(:role, I18n.t('errors.user_projects.role_owner')) unless has_owner
+    end
+  end
+end

--- a/app/models/core_data_connector/version.rb
+++ b/app/models/core_data_connector/version.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  class Version < ApplicationRecord
+    include PaperTrail::VersionConcern
+    self.table_name = 'core_data_connector_versions'
+
+    # Relationships
+    has_one :user, foreign_key: :id, primary_key: :whodunnit
+
+    def self.for_record(record)
+      where('roots @> ?', [{ type: record.class.name, id: record.id }].to_json)
+    end
+  end
+end

--- a/app/models/core_data_connector/web_authority.rb
+++ b/app/models/core_data_connector/web_authority.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  class WebAuthority < ApplicationRecord
+    SOURCE_TYPES = %w(atom bnf dpla geonames jisc viaf wikidata)
+
+    # Relationships
+    belongs_to :project
+    has_many :web_identifiers, dependent: :destroy
+
+    # Validations
+    validates :source_type, inclusion: { in: SOURCE_TYPES }
+    validates :source_type, uniqueness: { scope: :project_id, message: I18n.t('errors.web_authority.source_type_unique') }
+  end
+end

--- a/app/models/core_data_connector/web_identifier.rb
+++ b/app/models/core_data_connector/web_identifier.rb
@@ -1,0 +1,34 @@
+module CoreDataConnector
+  class WebIdentifier < ApplicationRecord
+    # Includes
+    include Export::WebIdentifier
+    include Auditable
+
+    # Audit logging
+    track_changes root: ->(web_identifier) { web_identifier.identifiable }, ignore: [:identifiable_id]
+
+    # Relationships
+    belongs_to :identifiable, polymorphic: true
+    belongs_to :web_authority
+
+    # Callbacks
+    before_create :find_identifier
+
+    # Delegates
+    delegate :project, to: :web_authority, allow_nil: true
+    delegate :project_id, to: :web_authority, allow_nil: true
+
+    def self.all_records_by_project(project_id)
+      WebIdentifier
+        .joins(:web_authority)
+        .where(web_authority: { project_id: project_id })
+    end
+
+    private
+
+    def find_identifier
+      service = Authority::Base.create_service(web_authority)
+      service.before_create(self)
+    end
+  end
+end

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  class Work < ApplicationRecord
+    # Includes
+    include DisplayNameable
+    include Export::Work
+    include Identifiable
+    include ImportAnalyze::Work
+    include Manifestable
+    include Mergeable
+    include Nameable
+    include Ownable
+    include Reconcile::Work
+    include Relateable
+    include UserDefinedFields::Fieldable
+    include Search::Work
+    include Auditable
+
+    # Audit logging
+    track_changes
+
+    # Nameable table
+    name_table :source_names, as: :nameable
+
+    # Delegates
+    delegate :name, to: :primary_name, allow_nil: true
+
+    # User defined fields parent
+    resolve_defineable -> (work) { work.project_model }
+  end
+end

--- a/app/policies/concerns/core_data_connector/manifestable_policy.rb
+++ b/app/policies/concerns/core_data_connector/manifestable_policy.rb
@@ -1,0 +1,23 @@
+module CoreDataConnector
+  module ManifestablePolicy
+    extend ActiveSupport::Concern
+
+    included do
+      def create_manifests?
+        return true if current_user.admin?
+
+        !project.archived? && member?
+      end
+
+      private
+
+      # Returns true if the current user has a `user_projects` record for the project that owns the current record.
+      def member?
+        current_user
+          .user_projects
+          .where(project_id: project_id)
+          .exists?
+      end
+    end
+  end
+end

--- a/app/policies/concerns/core_data_connector/mergeable_policy.rb
+++ b/app/policies/concerns/core_data_connector/mergeable_policy.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  module MergeablePolicy
+    extend ActiveSupport::Concern
+
+    included do
+      def permitted_attributes_for_merge
+        [*permitted_attributes, :uuid]
+      end
+    end
+  end
+end

--- a/app/policies/concerns/core_data_connector/ownable_policy.rb
+++ b/app/policies/concerns/core_data_connector/ownable_policy.rb
@@ -1,0 +1,70 @@
+module CoreDataConnector
+  module OwnablePolicy
+    extend ActiveSupport::Concern
+
+    included do
+      # A user can create an owned record for projects of which they are a member.
+      def create?
+        return true if current_user.admin?
+
+        !project.archived? && member?
+      end
+
+      # A user can delete an owned record if they are a member of the owning project and the record has not been
+      # shared with other projects.
+      def destroy?
+        return true if current_user.admin?
+
+        !project.archived? && member? && !shared?
+      end
+
+      # A user can view an owned record if they are a member of the owning project or a member of a project
+      # with which the record has been shared.
+      def show?
+        return true if current_user.admin?
+
+        !project.archived? && (member? || access_member?)
+      end
+
+      # A user can update an owned record if they are a member of the owning project or a member of a project
+      # with which the record has been shared.
+      def update?
+        return true if current_user.admin?
+
+        !project.archived? && (member? || access_member?)
+      end
+
+      protected
+
+      # Returns true if the current has has a `user_projects` record for a project which shares data with the project
+      # that owns the current record.
+      def access_member?
+        ProjectModelShare
+          .joins(project_model_access: [project: :user_projects])
+          .joins(project_model_access: :project_model)
+          .where(core_data_connector_user_projects: { user_id: current_user.id })
+          .where(core_data_connector_project_models: { project_id: project_id })
+          .exists?
+      end
+
+      # Returns true if the current user has a `user_projects` record for the project that owns the current record.
+      def member?
+        current_user
+          .user_projects
+          .where(project_id: project_id)
+          .exists?
+      end
+
+      def ownable_attributes
+        [ :project_model_id ]
+      end
+
+      # Returns true if the current has belongs to a `project_model` that has been shared with other projects.
+      def shared?
+        ProjectModelAccess
+          .where(project_model_id: project_model_id)
+          .exists?
+      end
+    end
+  end
+end

--- a/app/policies/concerns/core_data_connector/ownable_scope.rb
+++ b/app/policies/concerns/core_data_connector/ownable_scope.rb
@@ -1,0 +1,32 @@
+module CoreDataConnector
+  module OwnableScope
+    extend ActiveSupport::Concern
+
+    included do
+      def resolve
+        return scope.all if current_user.admin?
+
+        if scope.is_a?(Class)
+          ownable_table = scope.arel_table
+        elsif scope.is_a?(ActiveRecord::Relation)
+          ownable_table = scope.klass.arel_table
+        end
+
+        owned_records_query = UserProject
+                                .joins(project: :project_models)
+                                .where(ProjectModel.arel_table[:id].eq(ownable_table[:project_model_id]))
+                                .where(user_id: current_user.id)
+                                .where.not(project: { archived: true })
+
+        shared_records_query = ProjectModelShare
+                                 .joins(project_model_access: [project: :user_projects])
+                                 .where(ProjectModelAccess.arel_table[:project_model_id].eq(ownable_table[:project_model_id]))
+                                 .where(core_data_connector_user_projects: { user_id: current_user.id })
+                                 .where.not(project: { archived: true })
+
+        scope.where(owned_records_query.arel.exists)
+             .or(scope.where(shared_records_query.arel.exists))
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/direct_upload_policy.rb
+++ b/app/policies/core_data_connector/direct_upload_policy.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  class DirectUploadPolicy < BasePolicy
+
+    attr_accessor :current_user, :project
+
+    def initialize(current_user, project)
+      @current_user = current_user
+      @project = project
+    end
+
+    # A user can direct upload to a project if they are an admin or a member of the non-archived project.
+    def create?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    private
+
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project.id)
+        .exists?
+    end
+  end
+end

--- a/app/policies/core_data_connector/event_policy.rb
+++ b/app/policies/core_data_connector/event_policy.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  class EventPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :event, :project_model_id, :project, :project_id
+
+    def initialize(current_user, event)
+      @current_user = current_user
+      @event = event
+
+      @project_model_id = event&.project_model_id
+      @project = event&.project
+      @project_id = event&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        *Event.permitted_params,
+        :name,
+        :description,
+        user_defined: {}
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/instance_policy.rb
+++ b/app/policies/core_data_connector/instance_policy.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class InstancePolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :instance, :project_model_id, :project, :project_id
+
+    def initialize(current_user, instance)
+      @current_user = current_user
+      @instance = instance
+
+      @project_model_id = instance&.project_model_id
+      @project = instance&.project
+      @project_id = instance&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        user_defined: {},
+        source_names_attributes: [:id, :name, :primary, :_destroy]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/item_policy.rb
+++ b/app/policies/core_data_connector/item_policy.rb
@@ -1,0 +1,46 @@
+module CoreDataConnector
+  class ItemPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :item, :project_model_id, :project, :project_id
+
+    def initialize(current_user, item)
+      @current_user = current_user
+      @item = item
+
+      @project_model_id = item&.project_model_id
+      @project = item&.project
+      @project_id = item&.project_id
+    end
+
+    # A user can analyze the import for an item if the user is an admin or has update permissions.
+    def analyze_import?
+      return true if current_user.admin?
+
+      update?
+    end
+
+    # A user can import for an item if the user is an admin or has update permissions.
+    def import?
+      return true if current_user.admin?
+
+      update?
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        :faircopy_cloud_id,
+        user_defined: {},
+        source_names_attributes: [:id, :name, :primary, :_destroy]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/job_policy.rb
+++ b/app/policies/core_data_connector/job_policy.rb
@@ -1,0 +1,39 @@
+module CoreDataConnector
+  class JobPolicy < BasePolicy
+    attr_reader :current_user, :job
+
+    def initialize(current_user, job)
+      @current_user = current_user
+      @job = job
+    end
+
+    # Jobs cannot be created via the API.
+    def create?
+      false
+    end
+
+    # Only admin users can delete a job.
+    def destroy?
+      current_user.admin?
+    end
+
+    # Jobs cannot be viewed via the API.
+    def show?
+      false
+    end
+
+    # Jobs cannot be updated via the API.
+    def update?
+      false
+    end
+
+    # Admin users can view all jobs, other users can view no jobs.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.none
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/media_content_policy.rb
+++ b/app/policies/core_data_connector/media_content_policy.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  class MediaContentPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :media_content, :project_model_id, :project, :project_id
+
+    def initialize(current_user, media_content)
+      @current_user = current_user
+      @media_content = media_content
+
+      @project_model_id = media_content&.project_model_id
+      @project = media_content&.project
+      @project_id = media_content&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        :name,
+        :content,
+        :content_warning,
+        user_defined: {}
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/organization_policy.rb
+++ b/app/policies/core_data_connector/organization_policy.rb
@@ -1,0 +1,32 @@
+module CoreDataConnector
+  class OrganizationPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :organization, :project_model_id, :project, :project_id
+
+    def initialize(current_user, organization)
+      @current_user = current_user
+      @organization = organization
+
+      @project_model_id = organization&.project_model_id
+      @project = organization&.project
+      @project_id = organization&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        :description,
+        user_defined: {},
+        organization_names_attributes: [:id, :name, :primary, :_destroy]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/person_policy.rb
+++ b/app/policies/core_data_connector/person_policy.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class PersonPolicy < BasePolicy
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :person, :project_model_id, :project, :project_id
+
+    def initialize(current_user, person)
+      @current_user = current_user
+      @person = person
+
+      @project_model_id = person&.project_model_id
+      @project = person&.project
+      @project_id = person&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        :biography,
+        user_defined: {},
+        person_names_attributes: [:id, :first_name, :middle_name, :last_name, :primary, :_destroy]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/place_policy.rb
+++ b/app/policies/core_data_connector/place_policy.rb
@@ -1,0 +1,34 @@
+module CoreDataConnector
+  class PlacePolicy < BasePolicy
+    # Includes
+    include ManifestablePolicy
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :place, :project_model_id, :project, :project_id
+
+    def initialize(current_user, place)
+      @current_user = current_user
+      @place = place
+
+      @project_model_id = place&.project_model_id
+      @project = place&.project
+      @project_id = place&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        user_defined: {},
+        place_names_attributes: [:id, :name, :primary, :_destroy],
+        place_geometry_attributes: [:id, :geometry_json, :_destroy, properties: {}],
+        place_layers_attributes: [:id, :name, :layer_type, :url, :content, :_destroy]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/project_model_access_policy.rb
+++ b/app/policies/core_data_connector/project_model_access_policy.rb
@@ -1,0 +1,49 @@
+module CoreDataConnector
+  class ProjectModelAccessPolicy < BasePolicy
+    attr_accessor :current_user, :project_model_access, :project
+
+    def initialize(current_user, project_model_access)
+      @current_user = current_user
+      @project_model_access = project_model_access
+      @project = project_model_access&.project_model&.project
+    end
+
+    # A user cannot create a project_model_access via the /project_model_accesses API
+    def create?
+      false
+    end
+
+    # A user cannot delete a project_model_access via the /project_model_accesses API
+    def destroy?
+      false
+    end
+
+    # A user cannot view a project_model_access via the /project_model_accesses API
+    def show?
+      false
+    end
+
+    # A user cannot update a project_model_access via the /project_model_accesses API
+    def update?
+      false
+    end
+
+    # Returns a query to find all of the project_model_access records for the projects the current user
+    # has access to.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .joins(:project)
+            .where(UserProject.arel_table[:project_id].eq(ProjectModelAccess.arel_table[:project_id]))
+            .where(user_id: current_user.id)
+            .where.not(project: { archived: true })
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/project_model_policy.rb
+++ b/app/policies/core_data_connector/project_model_policy.rb
@@ -1,0 +1,94 @@
+module CoreDataConnector
+  class ProjectModelPolicy < BasePolicy
+    attr_reader :current_user, :project_model, :project
+
+    def initialize(current_user, project_model)
+      @current_user = current_user
+      @project_model = project_model
+      @project = project_model&.project
+    end
+
+    # A user can create project models if they are the owner of the project.
+    def create?
+      return true if current_user.admin?
+
+      !project.archived? && owner?
+    end
+
+    # A user can delete project models if they are the owner of the project and the model is not shared with
+    # another project.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && owner? && !shared?
+    end
+
+    # A user can view project models if they are a member of the project.
+    def show?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can update project models if they are the owner of the project.
+    def update?
+      return true if current_user.admin?
+
+      !project.archived? && owner?
+    end
+
+    def permitted_attributes
+      [:project_id, :name, :model_class, :slug, :allow_identifiers, :order, *ProjectModel.permitted_params,
+       project_model_relationships_attributes: [:id, :primary_model_id, :related_model_id, :name, :multiple, :slug,
+                                                :allow_inverse, :inverse_name, :inverse_multiple, :order, :_destroy,
+                                                *ProjectModelRelationship.permitted_params],
+       inverse_project_model_relationships_attributes: [:id, :primary_model_id, :related_model_id, :name, :multiple, :slug,
+                                                :allow_inverse, :inverse_name, :inverse_multiple, :order, :_destroy,
+                                                *ProjectModelRelationship.permitted_params],
+       project_model_accesses_attributes: [:id, :project_id, :_destroy],
+       project_model_shares_attributes: [:id, :project_model_access_id, :_destroy]
+      ]
+    end
+
+    private
+
+    # Returns true if the current user has a `user_projects` record for the model's project.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_model.project_id)
+        .exists?
+    end
+
+    # Returns true if the current user has an owner `user_projects` record for the model's project.
+    def owner?
+      current_user
+        .user_projects
+        .where(project_id: project_model.project_id)
+        .where(role: UserProject::ROLE_OWNER)
+        .exists?
+    end
+
+    # Returns true if the current project_model is shared with other projects.
+    def shared?
+      project_model.project_model_accesses.any?
+    end
+
+    # A user can view project models for any project of which they are a member.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .joins(:project)
+            .where(UserProject.arel_table[:project_id].eq(ProjectModel.arel_table[:project_id]))
+            .where(user_id: current_user.id)
+            .where.not(project: { archived: true })
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -1,0 +1,153 @@
+module CoreDataConnector
+  class ProjectPolicy < BasePolicy
+    attr_reader :current_user, :project
+
+    def initialize(current_user, project)
+      @current_user = current_user
+      @project = project
+    end
+
+    # A user can analyze and import data into a project if they are an admin.
+    def analyze_import?
+      return true if current_user.admin?
+
+      false
+    end
+
+    # A user can clear data from a project if they are an admin or an owner of the project.
+    def clear?
+      return true if current_user.admin?
+
+      !project.archived? && project_owner?
+    end
+
+    # Users with an "admin" or "member" role can create projects.
+    def create?
+      current_user.admin? || current_user.member?
+    end
+
+    # A user can view any project for which they are a member.
+    def show?
+      return true if current_user.admin?
+
+      !project.archived? && project_member?
+    end
+
+    # A user can delete a project if they are an admin or an owner of the project.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && project_owner?
+    end
+
+    # A user can export a project's configuration if they are an admin or an owner of the project.
+    def export_configuration?
+      return true if current_user.admin?
+
+      !project.archived? && project_owner?
+    end
+
+    # A user can export data from a project if they are an admin.
+    def export_data?
+      return true if current_user.admin?
+
+      false
+    end
+
+    # A user can export a project's environment variables if they are an admin or an owner of the project.
+    def export_variables?
+      return true if current_user.admin?
+
+      !project.archived? && project_owner?
+    end
+
+    # A user can import data into a project if they are an admin.
+    def import_analyze?
+      return true if current_user.admin?
+
+      false
+    end
+
+    # A user can import a project's configuration if they are an admin or an owner of the project.
+    def import_configuration?
+      return true if current_user.admin?
+
+      !project.archived? && project_owner?
+    end
+
+    # A user can import data into a project if they are an admin.
+    def import_data?
+      return true if current_user.admin?
+
+      false
+    end
+
+    # A user can view any project's map library for which they are a member.
+    def map_library?
+      return true if current_user.admin?
+
+      !project.archived? && project_member?
+    end
+
+    # A user can update a project if they are an admin or an owner of the project.
+    def update?
+      return true if current_user.admin?
+
+      !project.archived? && project_owner?
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      attributes = [
+        :name,
+        :description,
+        :discoverable,
+        :faircopy_cloud_url,
+        :faircopy_cloud_project_id,
+        :faircopy_cloud_project_model_id,
+        :map_library_url,
+        reconciliation_credentials: {}
+      ]
+
+      attributes << :archived if current_user.admin?
+
+      attributes
+    end
+
+    private
+
+    # Returns a query to find user_projects records for the passed user_id and project_id.
+    def project_member?
+      user_projects.exists?
+    end
+
+    # Returns a query to find user_projects records with an owner role for the passed user_id and project_id.
+    def project_owner?
+      user_projects
+        .where(role: UserProject::ROLE_OWNER)
+        .exists?
+    end
+
+    # Returns a query to find user_projects records for the current user and project.
+    def user_projects
+      current_user
+        .user_projects
+        .where(project_id: project.id)
+    end
+
+    # Admin users can view all projects. Non-admin users can view projects for which they are members.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .where(user_id: current_user.id)
+            .where(UserProject.arel_table[:project_id].eq(Project.arel_table[:id]))
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/public/v1/manifest_policy.rb
+++ b/app/policies/core_data_connector/public/v1/manifest_policy.rb
@@ -1,0 +1,37 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class ManifestPolicy < BasePolicy
+        attr_reader :project
+
+        def initialize(current_user, record)
+          @project = record.project_model_relationship.project
+        end
+
+        def create?
+          false
+        end
+
+        def destroy?
+          false
+        end
+
+        def show?
+          !project.archived?
+        end
+
+        def update?
+          false
+        end
+
+        class Scope < BaseScope
+          def resolve
+            scope
+              .joins(project_model_relationship: [primary_model: :project])
+              .where.not(project: { archived: true })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/public/v1/public_policy.rb
+++ b/app/policies/core_data_connector/public/v1/public_policy.rb
@@ -1,0 +1,37 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PublicPolicy < BasePolicy
+        attr_reader :project
+
+        def initialize(current_user, record)
+          @project = record.project
+        end
+
+        def create?
+          false
+        end
+
+        def destroy?
+          false
+        end
+
+        def show?
+          !project.archived?
+        end
+
+        def update?
+          false
+        end
+
+        class Scope < BaseScope
+          def resolve
+            scope
+              .joins(project_model: :project)
+              .where.not(project: { archived: true })
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/record_merge_policy.rb
+++ b/app/policies/core_data_connector/record_merge_policy.rb
@@ -1,0 +1,46 @@
+module CoreDataConnector
+  class RecordMergePolicy < BasePolicy
+    attr_reader :current_user, :record_merge, :project, :project_id
+
+    def initialize(current_user, record_merge)
+      @current_user = current_user
+      @record_merge = record_merge
+      @project = record_merge&.mergeable&.project
+      @project_id = record_merge&.mergeable&.project_id
+    end
+
+    # A record_merge cannot be created via the API, only through the merge function.
+    def create?
+      false
+    end
+
+    # A user can delete a record_merge if they are an admin user or member of owning the project.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A record_merge cannot be viewed via the API.
+    def show?
+      false
+    end
+
+    # A record_merge cannot be updated via the API.
+    def update?
+      false
+    end
+
+    private
+
+    # Returns true if the current user has a `user_projects` record for the web identifier's project.
+    def member?
+      current_user
+        .user_projects
+        .joins(:project)
+        .where(project_id: project_id)
+        .where.not(project: { archived: true })
+        .exists?
+    end
+  end
+end

--- a/app/policies/core_data_connector/relationship_policy.rb
+++ b/app/policies/core_data_connector/relationship_policy.rb
@@ -1,0 +1,82 @@
+module CoreDataConnector
+  class RelationshipPolicy < BasePolicy
+    attr_reader :current_user, :relationship, :project, :project_id
+
+    def initialize(current_user, relationship)
+      @current_user = current_user
+      @relationship = relationship
+      @project = relationship&.project
+      @project_id = relationship&.project_id
+    end
+
+    # A user can create a relationship if they are an admin or a member of the owning project.
+    def create?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can create a relationship if they are an admin or a member of the owning project.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can view a relationship if they are an admin or a member of the owning project.
+    def show?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can update a relationship if they are an admin or a member of the owning project.
+    def update?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # Returns true if the current user has a `user_projects` record for the project that owns the current record.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .exists?
+    end
+
+    def permitted_attributes
+      [ :project_model_relationship_id,
+        :primary_record_id,
+        :primary_record_type,
+        :related_record_id,
+        :related_record_type,
+        :order,
+        user_defined: {}
+      ]
+    end
+
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        if scope.is_a?(Class)
+          ownable_table = scope.arel_table
+        elsif scope.is_a?(ActiveRecord::Relation)
+          ownable_table = scope.klass.arel_table
+        end
+
+        scope
+          .where(
+            UserProject
+              .joins(project: [project_models: :project_model_relationships])
+              .where(ProjectModelRelationship.arel_table[:id].eq(ownable_table[:project_model_relationship_id]))
+              .where(user_id: current_user.id)
+              .where.not(project: { archived: true })
+              .arel
+              .exists
+          )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/taxonomy_policy.rb
+++ b/app/policies/core_data_connector/taxonomy_policy.rb
@@ -1,0 +1,29 @@
+module CoreDataConnector
+  class TaxonomyPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :taxonomy, :project_model_id, :project, :project_id
+
+    def initialize(current_user, taxonomy)
+      @current_user = current_user
+      @taxonomy = taxonomy
+
+      @project_model_id = taxonomy&.project_model_id
+      @project = taxonomy&.project
+      @project_id = taxonomy&.project_id
+    end
+
+    def permitted_attributes
+      [ *ownable_attributes,
+        :name,
+        user_defined: {}
+      ]
+    end
+
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/policies/core_data_connector/user_policy.rb
+++ b/app/policies/core_data_connector/user_policy.rb
@@ -1,0 +1,61 @@
+module CoreDataConnector
+  class UserPolicy < BasePolicy
+    attr_reader :current_user, :user
+
+    def initialize(current_user, user)
+      @current_user = current_user
+      @user = user
+    end
+
+    # Only admin users can create users directly.
+    def create?
+      current_user.admin?
+    end
+
+    # Only admin users can delete a user.
+    def destroy?
+      # Users cannot delete themselves, not even an admin
+      return false if current_user.id == user.id
+
+      current_user.admin?
+    end
+
+    # Only admin users can view background jobs.
+    def jobs?
+      current_user.admin?
+    end
+
+    # Only admin users can view users outside the context of a project. Users can view
+    # themselves outside the context of a project.
+    def show?
+      return true if current_user.admin?
+
+      current_user.id == user.id
+    end
+
+    # Only admin users can update users outside the context of a project. Users can update
+    # themselves outside the context of a project.
+    def update?
+      return true if current_user.admin?
+
+      current_user.id == user.id
+    end
+
+    # Allowed create/update attributes. Non-admin users can only change their password.
+    def permitted_attributes
+      attributes = []
+      attributes += [:password, :password_confirmation] if current_user.admin? || current_user.sso_id.blank?
+      attributes += [:name, :email, :role, :require_password_change] if current_user.admin?
+      attributes
+    end
+
+    # Users can only view themselves outside of a project context.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        User.where(id: current_user.id)
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/user_project_policy.rb
+++ b/app/policies/core_data_connector/user_project_policy.rb
@@ -1,0 +1,116 @@
+module CoreDataConnector
+  class UserProjectPolicy < BasePolicy
+    attr_accessor :current_user, :user_project, :project
+
+    DEFAULT_INTERVAL = '24'
+    SECONDS_TO_HOURS = 60 * 60
+
+    def initialize(current_user, user_project)
+      @current_user = current_user
+      @user_project = user_project
+      @project = user_project&.project
+    end
+
+    # A "member" user can create user projects only for projects which they are an owner.
+    def create?
+      return true if current_user.admin?
+
+      !project.archived? && owner? && current_user.member?
+    end
+
+    # A "member" user can destroy user projects only for projects which they are an owner.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && owner? && current_user.member?
+    end
+
+    # An admin user can invite users. A project owner with a "member" user role can invite a user who has not already
+    # been invited within the last 24 hours if that user has not yet logged in.
+    def invite?
+      # Admin users can always invite a user
+      return true if current_user.admin?
+
+      # Only project owners with a "member" user role can invite users
+      return false unless owner? && current_user.member?
+
+      user = user_project.user
+
+      # Users cannot be invited if they have already logged in
+      return false unless user.last_sign_in_at.nil?
+
+      # Users cannot be invited if they have been invited within the last 24 hours
+      last_invited_at = user_project.user.last_invited_at
+      interval = ENV.fetch('POSTMARK_INTERVAL') { DEFAULT_INTERVAL }.to_i
+
+      last_invited_at.nil? || ((Time.now.utc - last_invited_at) / SECONDS_TO_HOURS > interval)
+    end
+
+    # A "member" user can view user projects for projects which they are a member.
+    def show?
+      return true if current_user.admin?
+
+      !project.archived? && owner? && current_user.member?
+    end
+
+    # A "member" user can update user projects only for projects which they are an owner.
+    def update?
+      return true if current_user.admin?
+
+      !project.archived? && owner? && current_user.member?
+    end
+
+    # Allowed attributes.
+    def permitted_attributes
+      [:user_id, :project_id, :role, :password, :password_confirmation]
+    end
+
+    # Allowed create attributes
+    def permitted_attributes_for_create
+      [:user_id, :project_id, :role, :name, :email, :password, :password_confirmation]
+    end
+
+    private
+
+    # Returns true if the current user is an owner of the current user project's project.
+    def owner?
+      user_projects
+        .where(role: UserProject::ROLE_OWNER)
+        .exists?
+    end
+
+    # Returns a query to find user_projects for the current user for current user_project's project.
+    def user_projects
+      current_user
+        .user_projects
+        .where(project_id: user_project.project_id)
+    end
+
+    # A user can view the user_projects for any project for which they are an owner.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        user_projects = UserProject.arel_table.alias('b')
+        users = User.arel_table
+        projects = Project.arel_table
+
+        UserProject.where(
+          UserProject
+            .arel_table
+            .project(1)
+            .from(user_projects)
+            .join(users).on(users[:id].eq(user_projects[:user_id]))
+            .join(projects).on(projects[:id].eq(user_projects[:project_id]))
+            .where(user_projects[:project_id].eq(UserProject.arel_table[:project_id]))
+            .where(user_projects[:user_id].eq(current_user.id))
+            .where(user_projects[:role].eq(UserProject::ROLE_OWNER))
+            .where(users[:role].eq(User::ROLE_MEMBER))
+            .where(projects[:archived].not_eq(true))
+            .exists
+            .to_sql
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/web_authority_policy.rb
+++ b/app/policies/core_data_connector/web_authority_policy.rb
@@ -1,0 +1,94 @@
+module CoreDataConnector
+  class WebAuthorityPolicy < BasePolicy
+    attr_reader :current_user, :web_authority, :project, :project_id
+
+    def initialize(current_user, web_authority)
+      @current_user = current_user
+      @web_authority = web_authority
+      @project = web_authority&.project
+      @project_id = web_authority&.project_id
+    end
+
+    # A user can create a web authority if they are an admin user or the owner of the project.
+    def create?
+      return true if current_user.admin?
+
+      !project.archived? && owner?
+    end
+
+    # A user can find a web authority entity if they are an admin user or a member of the project.
+    def find?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can delete a web authority if they are an admin user or the owner of the project.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && owner?
+    end
+
+    # A user can search a web authority if they are an admin user or a member of the project.
+    def search?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can view a web authority if they are an admin user or a member of the project.
+    def show?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can update a web authority if they are an admin user or the owner of the project.
+    def update?
+      return true if current_user.admin?
+
+      !project.archived? && owner?
+    end
+
+    def permitted_attributes
+      [:project_id, :source_type, access: {}]
+    end
+
+    private
+
+    # Returns true if the current user has a `user_projects` record for the web authority's project.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .exists?
+    end
+
+    # Returns true if the current user has an owner `user_projects` record for the web authority's project.
+    def owner?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .where(role: UserProject::ROLE_OWNER)
+        .exists?
+    end
+
+    # A user can view web authorities for any project for which they are a member.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .joins(:project)
+            .where(UserProject.arel_table[:project_id].eq(WebAuthority.arel_table[:project_id]))
+            .where(user_id: current_user.id)
+            .where.not(project: { archived: true })
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/web_identifier_policy.rb
+++ b/app/policies/core_data_connector/web_identifier_policy.rb
@@ -1,0 +1,72 @@
+module CoreDataConnector
+  class WebIdentifierPolicy < BasePolicy
+    attr_reader :current_user, :web_identifier, :project, :project_id
+
+    def initialize(current_user, web_identifier)
+      @current_user = current_user
+      @web_identifier = web_identifier
+      @project = web_identifier&.project
+      @project_id = web_identifier&.project_id
+    end
+
+    # A user can create a web identifier if they are an admin user or member of owning the project.
+    def create?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can delete a web identifier if they are an admin user or member of owning the project.
+    def destroy?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can view a web identifier if they are an admin user or member of owning the project.
+    def show?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # A user can update a web identifier if they are an admin user or member of owning the project.
+    def update?
+      return true if current_user.admin?
+
+      !project.archived? && member?
+    end
+
+    # Allowed create/update attributes
+    def permitted_attributes
+      [:web_authority_id, :identifiable_id, :identifiable_type, :identifier, extra: {}]
+    end
+
+    private
+
+    # Returns true if the current user has a `user_projects` record for the web identifier's project.
+    def member?
+      current_user
+        .user_projects
+        .where(project_id: project_id)
+        .exists?
+    end
+
+    # A user can view web identifiers for all projects of which they are a member.
+    class Scope < BaseScope
+      def resolve
+        return scope.all if current_user.admin?
+
+        scope.where(
+          UserProject
+            .joins(project: :web_authorities)
+            .where(WebAuthority.arel_table[:id].eq(WebIdentifier.arel_table[:web_authority_id]))
+            .where(user_id: current_user.id)
+            .where.not(project: { archived: true })
+            .arel
+            .exists
+        )
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/work_policy.rb
+++ b/app/policies/core_data_connector/work_policy.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class WorkPolicy < BasePolicy
+    # Includes
+    include MergeablePolicy
+    include OwnablePolicy
+
+    attr_reader :current_user, :work, :project_model_id, :project, :project_id
+
+    def initialize(current_user, work)
+      @current_user = current_user
+      @work = work
+
+      @project_model_id = work&.project_model_id
+      @project = work&.project
+      @project_id = work&.project_id
+    end
+
+    # Allowed create/update attributes.
+    def permitted_attributes
+      [ *ownable_attributes,
+        user_defined: {},
+        source_names_attributes: [:id, :name, :primary, :_destroy]
+      ]
+    end
+
+    # Include default ownable scope.
+    class Scope < BaseScope
+      include OwnableScope
+    end
+  end
+end

--- a/app/queries/core_data_connector/record_table_query.rb
+++ b/app/queries/core_data_connector/record_table_query.rb
@@ -1,0 +1,62 @@
+module CoreDataConnector
+  class RecordTableQuery
+    def initialize(source_model:, related_columns: [])
+      @source_model     = source_model
+      @related_columns  = related_columns
+    end
+
+    def call(base_scope = nil)
+      scope    = base_scope || @source_model.all
+      builders = build_builders
+
+      builders.each { |b| b.joins.each { |j| scope = scope.joins(j) } }
+
+      scope = apply_selects(scope, builders)
+      scope = apply_grouping(scope, builders) if builders.any?(&:requires_aggregation?)
+      scope
+    end
+
+    private
+
+    def build_builders
+      @related_columns.map do |col|
+        CoreDataConnector::RelatedColumnJoinBuilder.new(
+          source_model: @source_model,
+          project_model_relationship_id: col[:pmr_id],
+          field: col[:field]
+        )
+      end
+    end
+
+    def apply_selects(scope, builders)
+      selects = ["#{@source_model.table_name}.*"]
+      builders.each do |b|
+        if b.requires_aggregation?
+          expr = strip_alias(b.select_fragment)
+          selects << "array_to_string((array_agg(DISTINCT (#{expr})::text " \
+            "ORDER BY (#{expr})::text))[1:9], ', ') " \
+            "|| CASE WHEN count(DISTINCT (#{expr})::text) > 9 " \
+            "THEN ', ' || (count(DISTINCT (#{expr})::text) - 9) || ' more' ELSE '' END " \
+            "AS #{b.column_alias}"
+        else
+          selects << b.select_fragment
+        end
+      end
+      scope.select(selects.join(', '))
+    end
+
+    def apply_grouping(scope, builders)
+      # PG lets you GROUP BY the PK and select any other column from that table.
+      # But columns from non-aggregated joined tables must be in GROUP BY explicitly.
+      group_cols = ["#{@source_model.table_name}.id"]
+      builders.reject(&:requires_aggregation?).each do |b|
+        group_cols << strip_alias(b.select_fragment)
+      end
+      scope.group(group_cols.join(', '))
+    end
+
+    def strip_alias(fragment)
+      fragment.sub(/\s+AS\s+\S+\z/, '')
+    end
+  end
+end

--- a/app/queries/core_data_connector/related_column_join_builder.rb
+++ b/app/queries/core_data_connector/related_column_join_builder.rb
@@ -1,0 +1,132 @@
+module CoreDataConnector
+  class RelatedColumnJoinBuilder
+    def initialize(source_model:, project_model_relationship_id:, field:)
+      @source_model = source_model
+      @pmr_id       = project_model_relationship_id
+      @field        = field
+    end
+
+    def joins
+      j = [relationship_join, target_join]
+      j << name_join if @field == 'name' && target_model.respond_to?(:get_names_table)
+      j
+    end
+
+    def select_fragment
+      if @field == 'name'
+        if target_model.respond_to?(:name_column)
+          "#{target_model.name_column(name_alias)} AS #{column_alias}"
+        else
+          "#{target_alias}.name AS #{column_alias}"
+        end
+      elsif user_defined_field?
+        key = @field.sub('udf.', '')
+        "(#{target_alias}.user_defined ->> #{quote(key)}) AS #{column_alias}"
+      else
+        validate_column!
+        "#{target_alias}.#{@field} AS #{column_alias}"
+      end
+    end
+
+    def column_alias
+      @column_alias ||= "rel_#{@pmr_id}_#{@field.gsub(/\W/, '_')}"
+    end
+
+    def requires_aggregation?
+      direction == :forward ? pmr.multiple : pmr.inverse_multiple
+    end
+
+    private
+
+    def pmr
+      @pmr ||= ProjectModelRelationship
+                 .includes(:primary_model, :related_model)
+                 .find(@pmr_id)
+    end
+
+    def direction
+      @direction ||=
+        if pmr.primary_model.model_class == @source_model.name
+          :forward
+        elsif pmr.related_model.model_class == @source_model.name
+          :inverse
+        else
+          raise ArgumentError, "PMR #{@pmr_id} does not involve #{@source_model.name}"
+        end
+    end
+
+    def target_model
+      @target_model ||= (direction == :forward ? pmr.related_model.model_class
+                           : pmr.primary_model.model_class).constantize
+    end
+
+    def rel_alias    = "rel_#{@pmr_id}"
+    def target_alias = "tgt_#{@pmr_id}"
+    def name_alias   = "name_#{@pmr_id}"
+
+    def relationship_join
+      src_id, src_type =
+        direction == :forward ? %w[primary_record_id primary_record_type]
+          : %w[related_record_id related_record_type]
+
+      ActiveRecord::Base.sanitize_sql_array([
+                                              "LEFT JOIN core_data_connector_relationships #{rel_alias} " \
+                                                "ON #{rel_alias}.#{src_type} = ? " \
+                                                "AND #{rel_alias}.#{src_id} = #{@source_model.table_name}.id " \
+                                                "AND #{rel_alias}.project_model_relationship_id = ?",
+                                              @source_model.name, @pmr_id
+                                            ])
+    end
+
+    def target_join
+      tgt_id, tgt_type =
+        direction == :forward ? %w[related_record_id related_record_type]
+          : %w[primary_record_id primary_record_type]
+
+      ActiveRecord::Base.sanitize_sql_array([
+                                              "LEFT JOIN #{target_model.table_name} #{target_alias} " \
+                                                "ON #{target_alias}.id = #{rel_alias}.#{tgt_id} " \
+                                                "AND #{rel_alias}.#{tgt_type} = ?",
+                                              target_model.name
+                                            ])
+    end
+
+    def name_join
+      names_association = target_model.get_names_table
+      names_model = target_model.reflect_on_association(names_association)&.klass
+      names_table = names_model.table_name
+      nameable_attribute = target_model.nameable_attribute
+
+      if nameable_attribute
+        target_id_column = "#{nameable_attribute}_id"
+        target_type_column = "#{nameable_attribute}_type"
+      else
+        target_id_column = "#{target_model.name.demodulize.underscore}_id"
+        target_type_column = nil
+      end
+
+      sql = "LEFT JOIN #{names_table} #{name_alias} " \
+            "ON #{name_alias}.#{target_id_column} = #{target_alias}.id " \
+            "AND #{name_alias}.primary = #{ActiveRecord::Base.connection.quoted_true}"
+
+      if target_type_column
+        sql << ActiveRecord::Base.sanitize_sql_array([" AND #{name_alias}.#{target_type_column} = ?", target_model.name])
+      end
+
+      sql
+    end
+
+    def user_defined_field?
+      @field.start_with?('udf.')
+    end
+
+    def validate_column!
+      return if target_model.column_names.include?(@field)
+      raise ArgumentError, "Unknown column #{@field} on #{target_model.name}"
+    end
+
+    def quote(value)
+      ActiveRecord::Base.connection.quote(value)
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/ownable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/ownable_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  module OwnableSerializer
+    extend ActiveSupport::Concern
+
+    included do
+      index_attributes :project_model_id, :uuid
+      show_attributes :project_model_id, :uuid
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/public/v0/linked_places/typeable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/public/v0/linked_places/typeable_serializer.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        module TypeableSerializer
+          extend ActiveSupport::Concern
+
+          included do
+            include CoreDataConnector::Public::V0::TypeableSerializer
+
+            annotation_attributes(:relationship_type) { |item, current_user, options| relationship_type(item, options) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/public/v0/typeable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/public/v0/typeable_serializer.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module TypeableSerializer
+        extend ActiveSupport::Concern
+
+        included do
+          index_attributes(:relationship_type) { |item, current_user, options| relationship_type(item, options) }
+
+          protected
+
+          def self.relationship_type(item, options)
+            if options[:nested_resource].to_s.to_bool
+              if !item.relationships.empty?
+                item.relationships.map{ |r| r.project_model_relationship.inverse_name }.first
+              elsif !item.related_relationships.empty?
+                item.related_relationships.map { |r| r.project_model_relationship.name }.first
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/public/v0/user_defineable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/public/v0/user_defineable_serializer.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module UserDefineableSerializer
+        extend ActiveSupport::Concern
+
+        included do
+          index_attributes user_defined: UserDefinedSerializer
+          show_attributes user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/public/v1/typeable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/public/v1/typeable_serializer.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  module Public
+    module V1
+      module TypeableSerializer
+        extend ActiveSupport::Concern
+
+        included do
+          index_attributes(:project_model_relationship_uuid) { |item| relationship_uuid(item) }
+          index_attributes(:project_model_relationship_inverse) { |item| relationship_inverse(item) }
+
+          protected
+
+          def self.relationship_inverse(item)
+            !item.relationships.empty?
+          end
+
+          def self.relationship_uuid(item)
+            if !item.relationships.empty?
+              item.relationships.map{ |r| r.project_model_relationship.uuid }.first
+            elsif !item.related_relationships.empty?
+              item.related_relationships.map { |r| r.project_model_relationship.uuid }.first
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/public/v1/user_defineable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/public/v1/user_defineable_serializer.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  module Public
+    module V1
+      module UserDefineableSerializer
+        extend ActiveSupport::Concern
+
+        included do
+          index_attributes user_defined: UserDefinedSerializer
+          show_attributes user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/concerns/core_data_connector/related_columns_serializable.rb
+++ b/app/serializers/concerns/core_data_connector/related_columns_serializable.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module RelatedColumnsSerializable
+    def render_index(items)
+      serialized = super
+      return serialized if serialized.blank?
+
+      aliases = options[:related_column_aliases] || []
+      return serialized if aliases.empty?
+
+      [items].flatten.each_with_index do |item, i|
+        aliases.each do |alias_name|
+          serialized[i][alias_name.to_sym] = item[alias_name]
+        end
+      end
+
+      serialized
+    end
+  end
+end

--- a/app/serializers/core_data_connector/events_serializer.rb
+++ b/app/serializers/core_data_connector/events_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class EventsSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
+    show_attributes :id, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
+  end
+end

--- a/app/serializers/core_data_connector/factory_serializer.rb
+++ b/app/serializers/core_data_connector/factory_serializer.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  class FactorySerializer < BaseSerializer
+
+    def render_index(item)
+      serializer = resolve_serializer(item)
+      serializer.render_index(item) unless serializer.nil?
+    end
+
+    def render_show(item)
+      serializer = resolve_serializer(item)
+      serializer.render_show(item) unless serializer.nil?
+    end
+
+    private
+
+    def resolve_serializer(item)
+      serializer_class = "#{item.class.name.pluralize}Serializer".safe_constantize
+      serializer_class.new(current_user)
+    end
+  end
+end

--- a/app/serializers/core_data_connector/instances_serializer.rb
+++ b/app/serializers/core_data_connector/instances_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class InstancesSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name
+    show_attributes :id, :name, source_names: [:id, :name, :primary]
+  end
+end

--- a/app/serializers/core_data_connector/items_serializer.rb
+++ b/app/serializers/core_data_connector/items_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class ItemsSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name
+    show_attributes :id, :name, :faircopy_cloud_id, source_names: [:id, :name, :primary]
+  end
+end

--- a/app/serializers/core_data_connector/jobs_serializer.rb
+++ b/app/serializers/core_data_connector/jobs_serializer.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  class JobsSerializer < BaseSerializer
+    index_attributes :id, :project_id, :user_id, :job_type, :status, :download_url, :created_at, :extra,
+                     project: ProjectsSerializer, user: UsersSerializer
+
+    show_attributes :id, :project_id, :user_id, :job_type, :status, :download_url, :created_at, :extra,
+                    project: ProjectsSerializer, user: UsersSerializer
+  end
+end

--- a/app/serializers/core_data_connector/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/media_contents_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class MediaContentsSerializer < BaseSerializer
+    include OwnableSerializer
+    include TripleEyeEffable::ResourceableSerializer
+    include UserDefinedFields::FieldableSerializer
+
+    index_attributes :id, :name, :content_warning
+    show_attributes :id, :name, :content_warning
+  end
+end

--- a/app/serializers/core_data_connector/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/organizations_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class OrganizationsSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name
+    show_attributes :id, :name, :description, organization_names: [:id, :name, :primary]
+  end
+end

--- a/app/serializers/core_data_connector/people_serializer.rb
+++ b/app/serializers/core_data_connector/people_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class PeopleSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :first_name, :middle_name, :last_name
+    show_attributes :id, :first_name, :middle_name, :last_name, :biography, person_names: [:id, :first_name, :middle_name, :last_name, :primary]
+  end
+end

--- a/app/serializers/core_data_connector/place_geometries_serializer.rb
+++ b/app/serializers/core_data_connector/place_geometries_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class PlaceGeometriesSerializer < BaseSerializer
+    index_attributes :id, :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
+    show_attributes :id, :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
+  end
+end

--- a/app/serializers/core_data_connector/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/place_layers_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class PlaceLayersSerializer < BaseSerializer
+    index_attributes :id, :name, :layer_type, :content, :url
+    show_attributes :id, :name, :layer_type, :content, :url
+  end
+end

--- a/app/serializers/core_data_connector/places_serializer.rb
+++ b/app/serializers/core_data_connector/places_serializer.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  class PlacesSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name
+    show_attributes :id, :name, place_names: [:id, :name, :primary], place_geometry: PlaceGeometriesSerializer,
+                    place_layers: PlaceLayersSerializer
+  end
+end

--- a/app/serializers/core_data_connector/project_configurations_serializer.rb
+++ b/app/serializers/core_data_connector/project_configurations_serializer.rb
@@ -1,0 +1,11 @@
+module CoreDataConnector
+  class ProjectConfigurationsSerializer < BaseSerializer
+    show_attributes :name, project_models: [:id, :name, :model_class,
+                                            user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer,
+                                            project_model_relationships: [
+                                              :primary_model_id, :related_model_id, :name, :multiple, :allow_inverse,
+                                              :inverse_name, :inverse_multiple,
+                                              user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
+                                            ]]
+  end
+end

--- a/app/serializers/core_data_connector/project_model_accesses_serializer.rb
+++ b/app/serializers/core_data_connector/project_model_accesses_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class ProjectModelAccessesSerializer < BaseSerializer
+    index_attributes :id, :project_model_id, project_model: ProjectModelsSerializer
+    show_attributes :id, :project_model_id, project_model: ProjectModelsSerializer
+  end
+end

--- a/app/serializers/core_data_connector/project_models_serializer.rb
+++ b/app/serializers/core_data_connector/project_models_serializer.rb
@@ -1,0 +1,31 @@
+module CoreDataConnector
+  class ProjectModelsSerializer < BaseSerializer
+    # Includes
+    include UserDefinedFields::DefineableSerializer
+
+    index_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug, :order,
+                     project: ProjectsSerializer, user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
+
+    index_attributes(:has_shares) do |project_model|
+      !project_model.project_model_shares.empty?
+    end
+
+    show_attributes :id, :uuid, :project_id, :name, :name_singular, :model_class, :model_class_view, :slug,
+                    :allow_identifiers, :order, project: ProjectsSerializer,
+                    project_model_relationships: [:id, :uuid, :related_model_id, :name, :multiple, :slug,
+                                                  :allow_inverse, :inverse_name, :inverse_multiple, :order,
+                                                  related_model: ProjectModelsSerializer,
+                                                  user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
+                    inverse_project_model_relationships: [:id, :uuid, :primary_model_id, :name, :multiple, :slug,
+                                                          :allow_inverse, :inverse_name, :inverse_multiple, :order,
+                                                          primary_model: ProjectModelsSerializer,
+                                                          user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer],
+                    project_model_accesses: [:id, :project_id, project: ProjectsSerializer],
+                    project_model_shares: [:id, :project_model_access_id, project_model_access: ProjectModelAccessesSerializer],
+                    user_defined_fields: UserDefinedFields::UserDefinedFieldsSerializer
+
+    show_attributes(:has_shares) do |project_model|
+      !project_model.project_model_shares.empty?
+    end
+  end
+end

--- a/app/serializers/core_data_connector/project_variables_serializer.rb
+++ b/app/serializers/core_data_connector/project_variables_serializer.rb
@@ -1,0 +1,75 @@
+module CoreDataConnector
+  class ProjectVariablesSerializer < BaseSerializer
+    TYPE_MODEL = 'MODEL'
+    TYPE_RELATIONSHIP = 'RELATIONSHIP'
+    TYPE_FIELD = 'FIELD'
+
+    def render_show(project)
+      return {} if project.nil?
+
+      serialized = []
+
+      project_models = ProjectModel
+                         .preload(:user_defined_fields)
+                         .preload(project_model_relationships: :user_defined_fields)
+                         .preload(inverse_project_model_relationships: :user_defined_fields)
+                         .where(project_id: project.id)
+                         .order(:name)
+
+      project_models.each do |project_model|
+        serialized << transform_value(project_model.id, project_model.name, TYPE_MODEL)
+        serialized += transform_fields(project_model.user_defined_fields, project_model.name)
+        serialized += transform_relationships(project_model.project_model_relationships, :name, project_model.name)
+        serialized += transform_relationships(project_model.inverse_project_model_relationships, :inverse_name, project_model.name)
+      end
+
+      serialized
+    end
+
+    private
+
+    def transform_fields(user_defined_fields, *names)
+      serialized = []
+
+      user_defined_fields.each do |user_defined_field|
+        serialized << transform_value(
+          user_defined_field.uuid,
+          *names,
+          user_defined_field.column_name,
+          TYPE_FIELD
+        )
+      end
+
+      serialized
+    end
+
+    def transform_relationships(project_model_relationships, name_attribute, names)
+      serialized = []
+
+      project_model_relationships.each do |project_model_relationship|
+        relationship_name = project_model_relationship.send(name_attribute)
+
+        serialized << transform_value(
+          project_model_relationship.id,
+          *names,
+          relationship_name,
+          TYPE_RELATIONSHIP
+        )
+
+        serialized += transform_fields(
+          project_model_relationship.user_defined_fields,
+          *names,
+          relationship_name
+        )
+      end
+
+      serialized
+    end
+
+    def transform_value(value, *names)
+      name = names.map{ |n| n.upcase.gsub(' ', '_') }.join('_')
+
+      "#{name}=#{value}"
+    end
+  end
+end

--- a/app/serializers/core_data_connector/projects_serializer.rb
+++ b/app/serializers/core_data_connector/projects_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class ProjectsSerializer < BaseSerializer
+    index_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_id, :map_library_url,
+                     :faircopy_cloud_project_model_id, :archived
+
+    show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_id, :map_library_url,
+                    :faircopy_cloud_project_model_id, :archived, :reconciliation_credentials,
+                    :use_storage_key, :uuid
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/instances_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/instances_serializer.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class InstancesSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, primary_name: SourceNamesSerializer
+
+        index_attributes(:source_titles) do |instance|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(instance.source_names)
+        end
+
+        show_attributes :uuid, primary_name: SourceNamesSerializer, web_identifiers: WebIdentifiersSerializer
+
+        show_attributes(:source_titles) do |instance|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(instance.source_names)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/items_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/items_serializer.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class ItemsSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, primary_name: SourceNamesSerializer
+
+        index_attributes(:source_titles) do |item|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(item.source_names)
+        end
+
+        show_attributes :uuid, primary_name: SourceNamesSerializer, web_identifiers: WebIdentifiersSerializer
+
+        show_attributes(:source_titles) do |item|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(item.source_names)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/base.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/base.rb
@@ -1,0 +1,135 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class Base < BaseSerializer
+          DEFAULT_CONTEXT = 'https://raw.githubusercontent.com/LinkedPasts/linked-places/master/linkedplaces-context-v1.1.jsonld'
+
+          def self.annotation_attributes(*attrs, &block)
+            @annotation_attributes ||= []
+
+            if attrs.present?
+              if attrs.size == 1 && block.present?
+                @annotation_attributes << { attrs[0] => block }
+              else
+                @annotation_attributes += attrs
+              end
+            end
+
+            @annotation_attributes
+          end
+
+          def self.base_url
+            "#{ENV['HOSTNAME']}/core_data/public"
+          end
+
+          def self.target_attributes(*attrs, &block)
+            @target_attributes ||= []
+
+            if attrs.present?
+              if attrs.size == 1 && block.present?
+                @target_attributes << { attrs[0] => block }
+              else
+                @target_attributes += attrs
+              end
+            end
+
+            @target_attributes
+          end
+
+          def render_index(items)
+            return [] if items.nil?
+
+            serialized = []
+
+            [items].flatten.each do |item|
+              item_serialized = {}
+
+              self.class.index_attributes.each do |a|
+                extract_value item_serialized, item, a
+              end
+
+              serialized << item_serialized
+            end
+
+            {
+              type: 'FeatureCollection',
+              '@context': DEFAULT_CONTEXT,
+              metadata: {
+                count: options[:count],
+                page: options[:page],
+                pages: options[:pages]
+              },
+              features: serialized
+            }
+          end
+
+          def render_annotation(items)
+            return [] if items.nil?
+
+            serialized = []
+            target = resolve_target
+
+            [items].flatten.each_with_index do |item, index|
+              item_serialized = {}
+
+              self.class.annotation_attributes.each do |a|
+                extract_value item_serialized, item, a
+              end
+
+              serialized << {
+                type: 'Annotation',
+                id: index,
+                created: DateTime.now.to_s,
+                motivation: 'linking',
+                target: target,
+                body: item_serialized
+              }
+            end
+
+            {
+              '@context': 'http://www.w3.org/ns/anno.jsonld',
+              id: options[:url],
+              type: 'AnnotationPage',
+              partOf: {
+                id: options[:url],
+                label: I18n.t(
+                  'serialization.linked_open_data.annotation_page_label',
+                  klass: items.klass.to_s.demodulize.pluralize,
+                  target: target[:name]
+                ),
+                total: options[:count]
+              },
+              items: serialized
+            }
+          end
+
+          def render_target(item)
+            return {} if item.nil?
+
+            serialized = {}
+
+            # Set all of the base attributes
+            self.class.target_attributes&.each do |a|
+              extract_value serialized, item, a
+            end
+
+            serialized
+          end
+
+          private
+
+          def resolve_target
+            item = options[:target]
+            return {} if item.nil?
+
+            serializer_class = "CoreDataConnector::Public::V0::LinkedPlaces::#{item.class.to_s.demodulize.pluralize}Serializer".constantize
+            serializer = serializer_class.new(current_user)
+
+            serializer.render_target(item)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/instances_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/instances_serializer.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class InstancesSerializer < Base
+          include TypeableSerializer
+
+          annotation_attributes(:id) { |instance| "#{base_url}/instances/#{instance.uuid}" }
+          annotation_attributes(:record_id) { |instance| instance.id }
+          annotation_attributes(:title) { |instance| instance.name }
+          annotation_attributes(:type) { 'Instance' }
+          annotation_attributes :uuid, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/items_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/items_serializer.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class ItemsSerializer < Base
+          include TypeableSerializer
+
+          annotation_attributes(:id) { |item| "#{base_url}/items/#{item.uuid}" }
+          annotation_attributes(:record_id) { |item| item.id }
+          annotation_attributes(:title) { |item| item.name }
+          annotation_attributes(:type) { 'Item' }
+          annotation_attributes :uuid, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/media_contents_serializer.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class MediaContentsSerializer < Base
+          annotation_attributes(:id) { |media_content| "#{base_url}/media_contents/#{media_content.uuid}" }
+          annotation_attributes(:record_id) { |media_content| media_content.id }
+          annotation_attributes(:title) { |media_content| media_content.name }
+          annotation_attributes(:type) { 'MediaContent' }
+          annotation_attributes :uuid, :content_url, :content_download_url, :content_iiif_url, :content_preview_url,
+                                :content_thumbnail_url, :manifest_url, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/organizations_serializer.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class OrganizationsSerializer < Base
+          annotation_attributes(:id) { |organization| "#{base_url}/organizations/#{organization.uuid}" }
+          annotation_attributes(:record_id) { |organization| organization.id }
+          annotation_attributes(:title) { |organization| organization.name }
+          annotation_attributes(:type) { 'Organization' }
+          annotation_attributes :uuid, :description, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/people_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/people_serializer.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class PeopleSerializer < Base
+          annotation_attributes(:id) { |person| "#{base_url}/people/#{person.uuid}" }
+          annotation_attributes(:record_id) { |person| person.id }
+          annotation_attributes(:title) { |person| person.full_name }
+          annotation_attributes(:type){ 'Person' }
+          annotation_attributes :uuid, :biography, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/place_layers_serializer.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class PlaceLayersSerializer < BaseSerializer
+          index_attributes :id, :name, :layer_type, :content, :url
+          index_attributes(:geometry) { |layer| layer.content }
+
+          show_attributes :id, :name, :layer_type, :content, :url
+          show_attributes(:geometry) { |layer| layer.content }
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/places_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/places_serializer.rb
@@ -1,0 +1,40 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class PlacesSerializer < Base
+          annotation_attributes(:id) { |place| identifier place }
+          annotation_attributes(:record_id) { |place| place.id }
+          annotation_attributes(:uuid) { |place| place.uuid }
+          annotation_attributes(:title) { |place| place.name }
+          annotation_attributes(:type) { 'Place' }
+          annotation_attributes(:geometry) { |place| place.place_geometry&.to_geojson }
+          annotation_attributes user_defined: UserDefinedSerializer
+
+          index_attributes(:@id) { |place| identifier place }
+          index_attributes(:type) { 'Place' }
+          index_attributes(:properties) { |place| { ccode: [], title: place.name, record_id: place.id, uuid: place.uuid } }
+          index_attributes(:geometry) { |place| place.place_geometry&.to_geojson }
+          index_attributes(:names) { |place| place.place_names.map{ |name| { toponym: name.name } } }
+
+          show_attributes(:@id) { |place| identifier place }
+          show_attributes(:type) { 'Place' }
+          show_attributes(:properties) { |place| { ccode: [], title: place.name, record_id: place.id, uuid: place.uuid } }
+          show_attributes(:geometry) { |place| place.place_geometry&.to_geojson }
+          show_attributes(:names) { |place| place.place_names.map{ |name| { toponym: name.name } } }
+          show_attributes user_defined: UserDefinedSerializer, place_layers: PlaceLayersSerializer, web_identifiers: WebIdentifiersSerializer
+
+          target_attributes(:id) { |place| identifier place }
+          target_attributes(:record_id) { |place| place.id }
+          target_attributes(:name) { |place| place.primary_name&.name }
+          target_attributes(:type) { 'Place' }
+          target_attributes :uuid
+
+          def self.identifier(place)
+            "#{base_url}/places/#{place.uuid}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/taxonomies_serializer.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class TaxonomiesSerializer < Base
+          annotation_attributes(:id) { |taxonomy| "#{base_url}/taxonomies/#{taxonomy.uuid}" }
+          annotation_attributes(:record_id) { |taxonomy| taxonomy.id }
+          annotation_attributes(:title) { |taxonomy| taxonomy.name }
+          annotation_attributes(:type) { 'Taxonomy' }
+          annotation_attributes :uuid, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/linked_places/works_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/linked_places/works_serializer.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Public
+    module V0
+      module LinkedPlaces
+        class WorksSerializer < Base
+          include TypeableSerializer
+
+          annotation_attributes(:id) { |work| "#{base_url}/works/#{work.uuid}" }
+          annotation_attributes(:record_id) { |work| work.id }
+          annotation_attributes(:title) { |work| work.name }
+          annotation_attributes(:type) { 'Work' }
+          annotation_attributes :uuid, user_defined: UserDefinedSerializer
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/media_contents_serializer.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class MediaContentsSerializer < BaseSerializer
+        include TripleEyeEffable::ResourceableSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+        show_attributes :uuid, :name
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/organizations_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class OrganizationsSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+        show_attributes :uuid, :name, :description, organization_names: [:id, :name, :primary]
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/people_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/people_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class PeopleSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :first_name, :middle_name, :last_name
+        show_attributes :uuid, :first_name, :middle_name, :last_name, :biography, person_names: [:id, :first_name, :middle_name, :last_name, :primary]
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/place_geometries_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/place_geometries_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class PlaceGeometriesSerializer < BaseSerializer
+        index_attributes geometry_json: -> (pg, *rest) { pg.to_geojson }
+        show_attributes geometry_json: -> (pg, *rest) { pg.to_geojson }
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/places_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/places_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class PlacesSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name, place_geometry: PlaceGeometriesSerializer
+        show_attributes :uuid, :name, place_names: [:id, :name, :primary], place_geometry: PlaceGeometriesSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/source_names_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/source_names_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class SourceNamesSerializer < BaseSerializer
+        index_attributes :id, :primary
+        index_attributes(:name) { |source_name| { name: source_name.name } }
+
+        show_attributes :id, :primary
+        show_attributes(:name) { |source_name| { name: source_name.name } }
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/taxonomies_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class TaxonomiesSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+        show_attributes :uuid, :name
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/user_defined_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/user_defined_serializer.rb
@@ -1,0 +1,47 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class UserDefinedSerializer < BaseSerializer
+        def render_index(item)
+          serialized = {}
+
+          # Retrieve all of the user-defined fields on the passed item
+          render_user_defined item, item.project_model.user_defined_fields, serialized
+
+          # Only render relationships for an annotation route
+          return serialized unless options[:nested_resource].to_s.to_bool
+
+          # Retrieve all of the user-defined fields on the relationships for the passed item
+          item.relationships.each do |relationship|
+            user_defined_fields = relationship.project_model_relationship.user_defined_fields
+            render_user_defined relationship, user_defined_fields, serialized
+          end
+
+          # Retrieve all of the user-defined fields on the related relationships for the passed item
+          item.related_relationships.each do |relationship|
+            user_defined_fields = relationship.project_model_relationship.user_defined_fields
+            render_user_defined relationship, user_defined_fields, serialized
+          end
+
+          serialized
+        end
+
+        def render_user_defined(item, fields, hash)
+          return if fields.nil?
+
+          fields.each do |field|
+            next unless item.user_defined
+
+            value = item.user_defined[field.uuid]
+            next if value.nil?
+
+            hash[field.uuid] = {
+              label: field.column_name,
+              value: value
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/web_identifiers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/web_identifiers_serializer.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class WebIdentifiersSerializer < BaseSerializer
+        index_attributes :id, :identifier, :extra, :web_authority_id, web_authority: [:id, :source_type]
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v0/works_serializer.rb
+++ b/app/serializers/core_data_connector/public/v0/works_serializer.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Public
+    module V0
+      class WorksSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, primary_name: SourceNamesSerializer
+
+        index_attributes(:source_titles) do |work|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(work.source_names)
+        end
+
+        show_attributes :uuid, primary_name: SourceNamesSerializer, web_identifiers: WebIdentifiersSerializer
+
+        show_attributes(:source_titles) do |work|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(work.source_names)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/events_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/events_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class EventsSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer
+        show_attributes :uuid, :name, :description, start_date: FuzzyDates::FuzzyDateSerializer, end_date: FuzzyDates::FuzzyDateSerializer, web_identifiers: WebIdentifiersSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/instances_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/instances_serializer.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class InstancesSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+
+        # Legacy attributes
+        index_attributes primary_name: SourceNamesSerializer
+
+        index_attributes(:source_titles) do |instance|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(instance.source_names)
+        end
+
+        show_attributes :uuid, :name, source_names: [:name, :primary], web_identifiers: WebIdentifiersSerializer
+
+        # Legacy attributes
+        show_attributes primary_name: SourceNamesSerializer
+
+        show_attributes(:source_titles) do |instance|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(instance.source_names)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/items_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/items_serializer.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class ItemsSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+
+        # Legacy attributes
+        index_attributes primary_name: SourceNamesSerializer
+
+        index_attributes(:source_titles) do |item|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(item.source_names)
+        end
+
+        show_attributes :uuid, :name, source_names: [:name, :primary], web_identifiers: WebIdentifiersSerializer
+
+        # Legacy attributes
+        show_attributes primary_name: SourceNamesSerializer
+
+        show_attributes(:source_titles) do |item|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(item.source_names)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/media_contents_serializer.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class MediaContentsSerializer < BaseSerializer
+        include TripleEyeEffable::ResourceableSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+        show_attributes :uuid, :name
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/organizations_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class OrganizationsSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+        show_attributes :uuid, :name, :description, organization_names: [:id, :name, :primary], web_identifiers: WebIdentifiersSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/people_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/people_serializer.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PeopleSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :first_name, :middle_name, :last_name
+        show_attributes :uuid, :first_name, :middle_name, :last_name, :biography,
+                        person_names: [:id, :first_name, :middle_name, :last_name, :primary],
+                        web_identifiers: WebIdentifiersSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/place_geometries_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/place_geometries_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PlaceGeometriesSerializer < BaseSerializer
+        index_attributes :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
+        show_attributes :properties, geometry_json: -> (pg, *rest) { pg.to_geojson }
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/place_layers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/place_layers_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PlaceLayersSerializer < BaseSerializer
+        index_attributes :id, :name, :layer_type, :content, :url
+        index_attributes(:geometry) { |layer| layer.content }
+
+        show_attributes :id, :name, :layer_type, :content, :url
+        show_attributes(:geometry) { |layer| layer.content }
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/places_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/places_serializer.rb
@@ -1,0 +1,14 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PlacesSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name, place_geometry: PlaceGeometriesSerializer
+        show_attributes :uuid, :name, place_names: [:name, :primary], place_geometry: PlaceGeometriesSerializer,
+                        place_layers: PlaceLayersSerializer, web_identifiers: WebIdentifiersSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/public_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/public_serializer.rb
@@ -1,0 +1,66 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class PublicSerializer < BaseSerializer
+
+        def render_index(items)
+          return super unless options[:target].present?
+
+          serialized_items = super
+          return serialized_items unless options[:target].present?
+
+          serialized = []
+          target = resolve_target
+
+          serialized_items.each_with_index do |item, index|
+            serialized << {
+              type: 'Annotation',
+              id: index,
+              created: DateTime.now.to_s,
+              motivation: 'linking',
+              target: target,
+              body: item
+            }
+          end
+
+          {
+            '@context': 'http://www.w3.org/ns/anno.jsonld',
+            id: options[:url],
+            type: 'AnnotationPage',
+            partOf: {
+              id: options[:url],
+              label: I18n.t(
+                'serialization.linked_open_data.annotation_page_label',
+                klass: items.klass.to_s.demodulize.pluralize,
+                target: target[:name]
+              ),
+              total: options[:count],
+              page: options[:page],
+              pages: options[:pages]
+            },
+            items: serialized
+          }
+        end
+
+        def render_show(item)
+          serialized = super
+          serialized[:id] = options[:url]
+
+          serialized
+        end
+
+        private
+
+        def resolve_target
+          item = options[:target]
+          return {} if item.nil?
+
+          serializer_class = "CoreDataConnector::Public::V1::#{item.class.to_s.demodulize.pluralize}Serializer".constantize
+          serializer = serializer_class.new(current_user)
+
+          serializer.render_index(item)&.first
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/source_names_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/source_names_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class SourceNamesSerializer < BaseSerializer
+        index_attributes :id, :primary
+        index_attributes(:name) { |source_name| { name: source_name.name } }
+
+        show_attributes :id, :primary
+        show_attributes(:name) { |source_name| { name: source_name.name } }
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/taxonomies_serializer.rb
@@ -1,0 +1,13 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class TaxonomiesSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+        show_attributes :uuid, :name, web_identifiers: WebIdentifiersSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/user_defined_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/user_defined_serializer.rb
@@ -1,0 +1,48 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class UserDefinedSerializer < BaseSerializer
+        def render_index(item)
+          serialized = {}
+
+          # Retrieve all of the user-defined fields on the passed item
+          render_user_defined item, item.project_model.user_defined_fields, serialized
+
+          # Only render relationships for an annotation route
+          return serialized unless options[:nested_resource].to_s.to_bool
+
+          # Retrieve all of the user-defined fields on the relationships for the passed item
+          item.relationships.each do |relationship|
+            user_defined_fields = relationship.project_model_relationship.user_defined_fields
+            render_user_defined relationship, user_defined_fields, serialized
+          end
+
+          # Retrieve all of the user-defined fields on the related relationships for the passed item
+          item.related_relationships.each do |relationship|
+            user_defined_fields = relationship.project_model_relationship.user_defined_fields
+            render_user_defined relationship, user_defined_fields, serialized
+          end
+
+          serialized
+        end
+
+        def render_user_defined(item, fields, hash)
+          return if fields.nil?
+
+          fields.each do |field|
+            next unless item.user_defined
+
+            value = item.user_defined[field.uuid]
+            next if value.nil?
+
+            hash[field.uuid] = {
+              label: field.column_name,
+              type: field.data_type,
+              value: value
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/web_identifiers_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/web_identifiers_serializer.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class WebIdentifiersSerializer < BaseSerializer
+        index_attributes :identifier, :extra, :web_authority_id, web_authority: [:source_type]
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/public/v1/works_serializer.rb
+++ b/app/serializers/core_data_connector/public/v1/works_serializer.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Public
+    module V1
+      class WorksSerializer < BaseSerializer
+        include TypeableSerializer
+        include UserDefineableSerializer
+
+        index_attributes :uuid, :name
+
+        # Legacy attributes
+        index_attributes primary_name: SourceNamesSerializer
+
+        index_attributes(:source_titles) do |work|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(work.source_names)
+        end
+
+        show_attributes :uuid, :name, source_names: [:name, :primary], web_identifiers: WebIdentifiersSerializer
+
+        # Legacy attributes
+        show_attributes primary_name: SourceNamesSerializer
+
+        show_attributes(:source_titles) do |work|
+          serializer = SourceNamesSerializer.new
+          serializer.render_index(work.source_names)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/core_data_connector/reconcile/projects_serializer.rb
+++ b/app/serializers/core_data_connector/reconcile/projects_serializer.rb
@@ -1,0 +1,58 @@
+module CoreDataConnector
+  module Reconcile
+    class ProjectsSerializer < BaseSerializer
+
+      index_attributes :id, :name, :description, :score, :match, :type
+
+      def render_multiple(searches)
+        searches.keys.inject({}) do |hash, key|
+          hash[key] = {
+            result: render_index(searches[key])
+          }
+
+          hash
+        end
+      end
+
+      def render_manifest(project)
+        # construct default types for filtered queries based on project models
+        default_types = []
+        models_by_class = project.project_models
+          .group_by(&:model_class)
+          .sort_by do |model_class_name, models|
+            # sort by min :order of all models of this model_class, to match fairdata ui
+            min_order = models.filter_map(&:order).min || Float::INFINITY
+            [min_order, model_class_name]
+          end
+        models_by_class.each do |model_class_name, models|
+          # add "All" option if there's more than one model with this model_class
+          if models.size > 1
+            default_types << {
+              id: "type:#{model_class_name}",
+              name: "#{model_class_name.demodulize}: All #{model_class_name.demodulize.pluralize}"
+            }
+          end
+          # add each model on this project as an option
+          models.sort_by { |m| [m.order || Float::INFINITY, m.name.downcase] }.each do |pm|
+            default_types << {
+              id: "model:#{pm.id}",
+              name: "#{model_class_name.demodulize}: #{pm.name}"
+            }
+          end
+        end
+
+        {
+          defaultTypes: default_types,
+          identifierSpace: "#{ENV['HOSTNAME']}/core_data/public/v1",
+          name: I18n.t('services.reconcile.name'),
+          schemaSpace: "#{ENV['HOSTNAME']}/core_data/reconcile",
+          versions: %w(0.1 0.2),
+          view: {
+            url: "#{ENV['HOSTNAME']}/core_data/reconcile/projects/#{project.id}/view/{{id}}"
+          }
+        }
+      end
+
+    end
+  end
+end

--- a/app/serializers/core_data_connector/record_merges_serializer.rb
+++ b/app/serializers/core_data_connector/record_merges_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class RecordMergesSerializer < BaseSerializer
+    index_attributes :id, :merged_uuid, :merged_name, :created_at
+    show_attributes :id, :merged_uuid, :merged_name, :created_at
+  end
+end

--- a/app/serializers/core_data_connector/relationships_serializer.rb
+++ b/app/serializers/core_data_connector/relationships_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class RelationshipsSerializer < BaseSerializer
+    include UserDefinedFields::FieldableSerializer
+
+    index_attributes :id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type, :order,
+                     primary_record: FactorySerializer, related_record: FactorySerializer
+    show_attributes :id, :primary_record_id, :primary_record_type, :related_record_id, :related_record_type, :order,
+                    primary_record: FactorySerializer, related_record: FactorySerializer
+  end
+end

--- a/app/serializers/core_data_connector/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/taxonomies_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class TaxonomiesSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name
+    show_attributes :id, :name
+  end
+end

--- a/app/serializers/core_data_connector/user_projects_serializer.rb
+++ b/app/serializers/core_data_connector/user_projects_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class UserProjectsSerializer < BaseSerializer
+    index_attributes :id, :user_id, :project_id, :role, user: UsersSerializer, project: ProjectsSerializer
+    show_attributes :id, :user_id, :project_id, :role, user: UsersSerializer, project: ProjectsSerializer
+  end
+end

--- a/app/serializers/core_data_connector/users_serializer.rb
+++ b/app/serializers/core_data_connector/users_serializer.rb
@@ -1,0 +1,8 @@
+module CoreDataConnector
+  class UsersSerializer < BaseSerializer
+    index_attributes :id, :name, :email, :role, :require_password_change, :last_sign_in_at, :last_invited_at, :avatar_url
+
+    show_attributes :id, :name, :email, :role, :require_password_change, :last_sign_in_at, :last_invited_at, :avatar_url,
+                    user_projects: UserProjectsSerializer
+  end
+end

--- a/app/serializers/core_data_connector/versions_serializer.rb
+++ b/app/serializers/core_data_connector/versions_serializer.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  class VersionsSerializer < BaseSerializer
+    index_attributes :id, :uuid, :event, :item_id, :request_uuid, :created_at, user: UsersSerializer
+
+    index_attributes(:record_type) { |version| version.item_type.demodulize }
+
+    index_attributes(:roots) do |version, _current_user, options|
+      Array(version.roots).map { |root| options[:root_data].call(root) }
+    end
+    index_attributes(:attributes) { |version, _current_user, options| options[:attribute_changes].call(version) }
+    index_attributes(:user_defined) { |version, _current_user, options| options[:user_defined_changes].call(version) }
+    index_attributes(:metadata) { |version| version.meta }
+
+    show_attributes(*index_attributes)
+  end
+end

--- a/app/serializers/core_data_connector/web_authorities_serializer.rb
+++ b/app/serializers/core_data_connector/web_authorities_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class WebAuthoritiesSerializer < BaseSerializer
+    index_attributes :id, :source_type, :access
+    show_attributes :id, :source_type, :access
+  end
+end

--- a/app/serializers/core_data_connector/web_identifiers_serializer.rb
+++ b/app/serializers/core_data_connector/web_identifiers_serializer.rb
@@ -1,0 +1,6 @@
+module CoreDataConnector
+  class WebIdentifiersSerializer < BaseSerializer
+    index_attributes :id, :identifier, :extra, :web_authority_id, web_authority: WebAuthoritiesSerializer
+    show_attributes :id, :identifier, :extra, :web_authority_id, web_authority: WebAuthoritiesSerializer
+  end
+end

--- a/app/serializers/core_data_connector/works_serializer.rb
+++ b/app/serializers/core_data_connector/works_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  class WorksSerializer < BaseSerializer
+    include OwnableSerializer
+    include UserDefinedFields::FieldableSerializer
+    include RelatedColumnsSerializable
+
+    index_attributes :id, :name
+    show_attributes :id, :name, source_names: [:id, :name, :primary]
+  end
+end

--- a/app/services/concerns/core_data_connector/export/nameable.rb
+++ b/app/services/concerns/core_data_connector/export/nameable.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Export
+    module Nameable
+      extend ActiveSupport::Concern
+
+      NAME_DELIMITER = ';'
+
+      included do
+
+        def format_name(attr = :name)
+          ordered_names.map(&attr).join(NAME_DELIMITER)
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/concerns/core_data_connector/import/nameable.rb
+++ b/app/services/concerns/core_data_connector/import/nameable.rb
@@ -1,0 +1,32 @@
+module CoreDataConnector
+  module Import
+    module Nameable
+      extend ActiveSupport::Concern
+
+      NAME_DELIMITER = ';'
+
+      included do
+
+        def transform_names
+          execute <<-SQL.squish
+            WITH 
+  
+            record_names AS (
+  
+            SELECT id, ARRAY(SELECT trim(BOTH ' ' FROM unnest(string_to_array(name, '#{NAME_DELIMITER}')))) as names
+              FROM #{table_name}
+  
+            )
+  
+            UPDATE #{table_name} z_table
+               SET primary_name = record_names.names[1],
+                   additional_names = record_names.names[2:array_length(record_names.names, 1)]
+              FROM record_names
+             WHERE record_names.id = z_table.id
+          SQL
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/atom.rb
+++ b/app/services/core_data_connector/authority/atom.rb
@@ -1,0 +1,57 @@
+module CoreDataConnector
+  module Authority
+    class Atom < Base
+      include Http::Requestable
+
+      def before_create(web_identifier)
+        authority = web_identifier.web_authority
+        options = authority.access&.symbolize_keys
+
+        data = find(web_identifier.identifier, options)
+
+        web_identifier.extra ||= {}
+        web_identifier.extra['title'] = data['title']
+
+        parents = []
+
+        find_parents(data['parent'], options, parents)
+
+        web_identifier.extra['parents'] = parents.reverse
+      end
+
+      def find(id, options = {})
+        headers = {
+          'REST-API-Key': options[:api_key]
+        }
+
+        send_request("#{options[:url]}/api/informationobjects/#{id}", headers: headers) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          sq0: query
+        }
+
+        headers = {
+          'REST-API-Key': options[:api_key]
+        }
+
+        send_request("#{options[:url]}/api/informationobjects", headers: headers, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      private
+
+      def find_parents(identifier, options, arr)
+        data = find(identifier, options)
+
+        arr << data['title']
+
+        find_parents(data['parent'], options, arr) if data['parent'].present?
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/base.rb
+++ b/app/services/core_data_connector/authority/base.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Authority
+    class Base
+
+      def self.create_service(authority)
+        class_name = "CoreDataConnector::Authority::#{authority.source_type.capitalize}"
+        klass = class_name.constantize
+        klass.new
+      end
+
+      def before_create(web_identifier)
+        # Implemented in sub-classes
+      end
+
+      def find(id, options = {})
+        # Implemented in sub-classes
+      end
+
+      def search(query, options = {})
+        # Implemented in sub-classes
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/bnf.rb
+++ b/app/services/core_data_connector/authority/bnf.rb
@@ -1,0 +1,40 @@
+module CoreDataConnector
+  module Authority
+    class Bnf < Base
+      include Http::Requestable
+
+      BASE_URL = 'https://catalogue.bnf.fr/api/SRU'
+
+      DEFAULT_LIMIT = 20
+
+      BASE_PARAMS = {
+        operation: 'searchRetrieve',
+        startRecord: 1,
+        recordSchema: 'dublincore',
+        version: 1.2
+      }
+
+      def find(id, options = {})
+        params = {
+          query: "bib.ark+all+\"#{id}\"",
+          maximumRecords: options[:limit] || DEFAULT_LIMIT
+        }.merge(BASE_PARAMS)
+
+        send_request(BASE_URL, params: params) do |body|
+          Hash.from_xml(body).to_json
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          query: "bib.anywhere+all+\"#{query}\"",
+          maximumRecords: options[:limit] || DEFAULT_LIMIT
+        }.merge(BASE_PARAMS)
+
+        send_request(BASE_URL, params: params) do |body|
+          Hash.from_xml(body).to_json
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/dpla.rb
+++ b/app/services/core_data_connector/authority/dpla.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  module Authority
+    class Dpla < Base
+      include Http::Requestable
+
+      BASE_URL = 'https://api.dp.la/v2/items'
+
+      DEFAULT_LIMIT = 20
+
+      def find(id, options = {})
+        params = {
+          api_key: options[:api_key]
+        }
+
+        send_request("#{BASE_URL}/#{id}", method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          api_key: options[:api_key],
+          page_size: options[:limit] || DEFAULT_LIMIT,
+          q: query
+        }
+
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/geonames.rb
+++ b/app/services/core_data_connector/authority/geonames.rb
@@ -1,0 +1,29 @@
+module CoreDataConnector
+  module Authority
+    class Geonames < Base
+      include Http::Requestable
+
+      BASE_URL = 'http://api.geonames.org'
+
+      def find(id, options = {})
+        params = {
+          geonameId: id,
+          username: options[:username]
+        }
+        send_request("#{BASE_URL}/getJSON", method: :get, params:) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          q: query,
+          username: options[:username]
+        }
+        send_request("#{BASE_URL}/searchJSON?", method: :get, params:) do |body|
+          JSON.parse(body)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/jisc.rb
+++ b/app/services/core_data_connector/authority/jisc.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  module Authority
+    class Jisc < Base
+      include Http::Requestable
+
+      BASE_URL = 'https://discover.libraryhub.jisc.ac.uk/search'
+  
+      DEFAULT_LIMIT = 20
+
+      def find(id, options = {})
+        params = {
+          format: 'json',
+          id: id
+        }
+
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          format: 'json',
+          keyword: query
+        }
+
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/viaf.rb
+++ b/app/services/core_data_connector/authority/viaf.rb
@@ -1,0 +1,34 @@
+module CoreDataConnector
+  module Authority
+    class Viaf < Base
+      include Http::Requestable
+
+      BASE_URL = 'https://viaf.org'
+      DEFAULT_LIMIT = 20
+
+      def find(id, options = {})
+        headers = {
+          'Accept': 'application/json'
+        }
+
+        send_request("#{BASE_URL}/viaf/#{id}", method: :get, headers:) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      def search(query, options = {})
+        headers = {
+          'Accept': 'application/json'
+        }
+
+        params = {
+          query: query
+        }
+
+        send_request("#{BASE_URL}/viaf/AutoSuggest", method: :get, headers:, params:) do |body|
+          JSON.parse(body)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/authority/wikidata.rb
+++ b/app/services/core_data_connector/authority/wikidata.rb
@@ -1,0 +1,41 @@
+module CoreDataConnector
+  module Authority
+    class Wikidata < Base
+      include Http::Requestable
+
+      BASE_URL = 'https://www.wikidata.org/w/api.php'
+
+      DEFAULT_LIMIT = 20
+
+      def find(id, options = {})
+        params = {
+          action: 'wbgetentities',
+          format: 'json',
+          ids: id,
+          languages: 'en',
+          type: 'item',
+        }
+
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+
+      def search(query, options = {})
+        params = {
+          action: 'wbsearchentities',
+          format: 'json',
+          language: 'en',
+          limit: options[:limit] || DEFAULT_LIMIT,
+          search: query,
+          type: 'item',
+          uselang: 'en'
+        }
+
+        send_request(BASE_URL, method: :get, params: params) do |body|
+          JSON.parse(body)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/configuration.rb
+++ b/app/services/core_data_connector/configuration.rb
@@ -1,0 +1,88 @@
+module CoreDataConnector
+  class Configuration
+    attr_reader :project, :settings
+
+    def initialize(project, file)
+      @project = project
+      @settings = load_settings(file)
+    end
+
+    def import_configuration
+      project_models = settings[:project_models]
+      project_model_relationships = []
+
+      project_model_ids = {}
+
+      project_models.each do |project_model|
+        # Create the new project model
+        create_project_model project_model, project_model_ids
+
+        # All the relationships to the list of project_model_relationships
+        project_model_relationships += project_model[:project_model_relationships]
+      end
+
+      project_model_relationships.each do |project_model_relationship|
+        create_project_model_relationship project_model_relationship, project_model_ids
+      end
+    end
+
+    private
+
+    def create_project_model(item, project_model_ids)
+      item_attributes = item.slice(:name, :model_class)
+      attributes = item_attributes.merge({ project_id: project.id })
+
+      project_model = ProjectModel.create(attributes)
+      project_model_ids[item[:id]] = project_model.id
+
+      create_user_defined_fields item[:user_defined_fields], project_model
+
+      project_model
+    end
+
+    def create_project_model_relationship(item, project_model_ids)
+      primary_model_id = project_model_ids[item[:primary_model_id]]
+      related_model_id = project_model_ids[item[:related_model_id]]
+
+      item_attributes = item.slice(:name, :multiple, :allow_inverse, :inverse_name, :inverse_multiple)
+
+      attributes = item_attributes.merge({
+        primary_model_id: primary_model_id,
+        related_model_id: related_model_id
+      })
+
+      project_model_relationship = ProjectModelRelationship.create(attributes)
+
+      create_user_defined_fields item[:user_defined_fields], project_model_relationship
+
+      project_model_relationship
+    end
+
+    def create_user_defined_fields(fields, defineable)
+      fields.each do |field|
+        field_attributes = field.slice(
+          :table_name,
+          :column_name,
+          :data_type,
+          :required,
+          :searchable,
+          :allow_multiple,
+          :options,
+          :order
+        )
+
+        attributes = field_attributes.merge({
+          defineable_id: defineable.id,
+          defineable_type: defineable.class.to_s
+        })
+
+        UserDefinedFields::UserDefinedField.create(attributes)
+      end
+    end
+
+    def load_settings(file)
+      contents = File.read(file.path)
+      JSON.parse(contents)&.deep_symbolize_keys
+    end
+  end
+end

--- a/app/services/core_data_connector/export/base.rb
+++ b/app/services/core_data_connector/export/base.rb
@@ -1,0 +1,65 @@
+module CoreDataConnector
+  module Export
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_attribute(*attrs, &block)
+          name, options = attrs
+
+          @export_attrs ||= []
+          @export_attrs << { name: name, block: block }.merge(options || {})
+        end
+
+        def export_attributes
+          @export_attrs
+        end
+      end
+
+      included do
+        def to_export_csv(user_defined_fields)
+          hash = {}
+
+          # Add attributes defined by the concrete-class
+          self.class.export_attributes.each do |attr|
+            name = attr[:name]
+
+            # Extract the value for the attribute
+            if attr[:block].present?
+              value = instance_eval(&attr[:block])
+            else
+              value = self.send(attr[:name])
+            end
+
+            # Add the name/value pair to the CSV
+            hash[name] = value
+          end
+
+          # Add user-defined field values
+          add_user_defined_fields(hash, user_defined_fields)
+
+          hash
+        end
+
+        private
+
+        def add_user_defined_fields(hash, user_defined_fields)
+          return unless user_defined_fields.present? && self.respond_to?(:user_defined) && user_defined.present?
+
+          user_defined_fields.each do |user_defined_field|
+            key = ImportAnalyze::Helper.uuid_to_column_name(user_defined_field.uuid)
+            value = user_defined[user_defined_field.uuid]
+
+            if user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:fuzzy_date]
+              value = value.nil? ? '' : value.to_json
+            elsif user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:select] && user_defined_field.allow_multiple?
+              value = value&.to_json
+            end
+
+            hash[key] = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/event.rb
+++ b/app/services/core_data_connector/export/event.rb
@@ -1,0 +1,42 @@
+module CoreDataConnector
+  module Export
+    module Event
+      extend ActiveSupport::Concern
+
+      DATE_FORMAT = '%Y-%m-%d'
+
+      class_methods do
+        def export_preloads
+          [:start_date, :end_date]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+        export_attribute :description
+
+        export_attribute(:start_date) do
+          start_date&.start_date&.strftime(DATE_FORMAT)
+        end
+
+        export_attribute(:start_date_description) do
+          start_date&.description
+        end
+
+        export_attribute(:end_date) do
+          end_date&.start_date&.strftime(DATE_FORMAT)
+        end
+
+        export_attribute(:end_date_description) do
+          end_date&.description
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/exporter.rb
+++ b/app/services/core_data_connector/export/exporter.rb
@@ -1,0 +1,120 @@
+require 'csv'
+
+module CoreDataConnector
+  module Export
+    class Exporter
+
+      attr_reader :project_id
+
+      EXPORT_CLASSES = [{
+        class: CoreDataConnector::Event,
+        filename: 'events.csv'
+      }, {
+        class: CoreDataConnector::Item,
+        filename: 'items.csv'
+     }, {
+        class: CoreDataConnector::Instance,
+        filename: 'instances.csv'
+     }, {
+        class: CoreDataConnector::MediaContent,
+        filename: 'media_contents.csv'
+     }, {
+        class: CoreDataConnector::Organization,
+        filename: 'organizations.csv'
+      }, {
+        class: CoreDataConnector::Person,
+        filename: 'people.csv'
+      }, {
+        class: CoreDataConnector::Place,
+        filename: 'places.csv'
+      }, {
+        class: CoreDataConnector::Relationship,
+        filename: 'relationships.csv'
+      }, {
+        class: CoreDataConnector::Taxonomy,
+        filename: 'taxonomies.csv'
+      }, {
+        class: CoreDataConnector::WebIdentifier,
+        filename: 'web_identifiers.csv'
+      }, {
+        class: CoreDataConnector::Work,
+        filename: 'works.csv'
+      }]
+
+      def initialize(project_id)
+        @project_id = project_id
+      end
+
+      def run(directory)
+        user_defined_fields_by_table = build_user_defined_fields
+
+        EXPORT_CLASSES.each do |klass|
+          model_class = klass[:class]
+          filename = klass[:filename]
+
+          filepath = File.join(directory, filename)
+
+          # Query all of the records owned or shared with the passed project
+          query = model_class.all_records_by_project(project_id)
+          query = query.merge(model_class.export_query) if model_class.respond_to?(:export_query)
+
+          # Skip this model class if the project does not contain any relevant data
+          next unless query.count(Arel.star) > 0
+
+          user_defined_fields = user_defined_fields_by_table[model_class.to_s] || []
+          headers = find_headers(model_class, user_defined_fields)
+
+          CSV.open(filepath, 'w', headers: headers, write_headers: true) do |csv|
+            query.find_in_batches(batch_size: 1000) do |records|
+
+              # Apply any preloads for the current model/batch
+              apply_preloads model_class, records
+
+              # Iterate over each record and convert it to a CSV row
+              records.each do |record|
+                csv_row = record.to_export_csv(user_defined_fields)
+                csv << csv_row.values
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def apply_preloads(klass, records)
+        # Preload any associations from the concrete class
+        if klass.respond_to?(:export_preloads) && klass.export_preloads.present?
+          Preloader.new(
+            records: records,
+            associations: klass.export_preloads
+          ).call
+        end
+      end
+
+      def build_user_defined_fields
+        query = Queries
+                  .all_fields_by_project(project_id)
+                  .order(:uuid)
+
+        query.inject({}) do |hash, user_defined_field|
+          hash[user_defined_field.table_name] ||= []
+          hash[user_defined_field.table_name] << user_defined_field
+
+          hash
+        end
+      end
+
+      def find_headers(klass, user_defined_fields)
+        headers = klass.export_attributes.map{ |a| a[:name].to_s }
+
+        user_defined_fields.each do |user_defined_field|
+          headers << ImportAnalyze::Helper.uuid_to_column_name(user_defined_field.uuid)
+        end
+
+        headers
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/export/instance.rb
+++ b/app/services/core_data_connector/export/instance.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Export
+    module Instance
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:ordered_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+        include Nameable
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute(:name) { format_name }
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/item.rb
+++ b/app/services/core_data_connector/export/item.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Export
+    module Item
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:ordered_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+        include Nameable
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute(:name) { format_name }
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/media_content.rb
+++ b/app/services/core_data_connector/export/media_content.rb
@@ -1,0 +1,29 @@
+module CoreDataConnector
+  module Export
+    module MediaContent
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:resource_description]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+
+        export_attribute(:import_url) do
+          import_url || content_download_url
+        end
+
+        export_attribute :content_warning
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/organization.rb
+++ b/app/services/core_data_connector/export/organization.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Export
+    module Organization
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:ordered_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+        include Nameable
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute(:name) { format_name }
+        export_attribute :description
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/person.rb
+++ b/app/services/core_data_connector/export/person.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Export
+    module Person
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:ordered_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+        include Nameable
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute(:last_name) { format_name :last_name }
+        export_attribute(:first_name) { format_name :first_name }
+        export_attribute(:middle_name) { format_name :middle_name }
+        export_attribute :biography
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/place.rb
+++ b/app/services/core_data_connector/export/place.rb
@@ -1,0 +1,33 @@
+module CoreDataConnector
+  module Export
+    module Place
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_query
+          self.all.with_centroid
+        end
+
+        def export_preloads
+          [:ordered_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+        include Nameable
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute(:name) { format_name }
+        export_attribute(:latitude) { geometry_center&.y }
+        export_attribute(:longitude) { geometry_center&.x }
+        export_attribute(:properties) do
+          JSON.generate(place_geometry&.properties) if place_geometry&.properties
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/relationship.rb
+++ b/app/services/core_data_connector/export/relationship.rb
@@ -1,0 +1,34 @@
+module CoreDataConnector
+  module Export
+    module Relationship
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:primary_record, :related_record]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_relationship_id
+        export_attribute :uuid
+
+        export_attribute(:primary_record_uuid) do
+          primary_record&.uuid
+        end
+
+        export_attribute :primary_record_type
+
+        export_attribute(:related_record_uuid) do
+          related_record&.uuid
+        end
+
+        export_attribute :related_record_type
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/taxonomy.rb
+++ b/app/services/core_data_connector/export/taxonomy.rb
@@ -1,0 +1,17 @@
+module CoreDataConnector
+  module Export
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute :name
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/web_identifier.rb
+++ b/app/services/core_data_connector/export/web_identifier.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  module Export
+    module WebIdentifier
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:identifiable]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Export attributes
+        export_attribute :web_authority_id
+
+        export_attribute(:identifiable_uuid) do
+          identifiable&.uuid
+        end
+
+        export_attribute :identifiable_type
+        export_attribute :identifier
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/export/work.rb
+++ b/app/services/core_data_connector/export/work.rb
@@ -1,0 +1,24 @@
+module CoreDataConnector
+  module Export
+    module Work
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def export_preloads
+          [:ordered_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+        include Nameable
+
+        # Export attributes
+        export_attribute :project_model_id
+        export_attribute :uuid
+        export_attribute(:name) { format_name }
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/file_system.rb
+++ b/app/services/core_data_connector/file_system.rb
@@ -1,0 +1,51 @@
+require 'zip'
+
+IGNORE_PATTERN = /\.DS_Store|__MACOSX|(^|\/)\._/
+
+module CoreDataConnector
+  class FileSystem
+
+    # Creates a temporary directory in the Rails root/tmp folder
+    def self.create_directory
+      directory = "#{Rails.root}/tmp/#{SecureRandom.urlsafe_base64}"
+
+      FileUtils.mkdir_p(directory) unless File.exist? directory
+
+      directory
+    end
+
+    def self.create_zip(directory, zip_filename)
+      zip_filepath = File.join(directory, zip_filename)
+      file_pattern = File.join(directory, '*.csv')
+
+      Zip::File.open(zip_filepath, create: true) do |zipfile|
+        Dir.glob(file_pattern).each do |filepath|
+          filename = File.basename(filepath)
+          zipfile.add(filename, File.join(directory, filename))
+        end
+      end
+    end
+
+    # Extracts the passed zip file to the passed destination
+    def self.extract_zip(zip_file, destination)
+      Zip::File.open(zip_file) do |zipfile|
+        zipfile.each do |entry|
+          # Ignore directories
+          next unless entry.file?
+
+          # Ignore MacOS archive
+          next if entry.name =~ IGNORE_PATTERN
+
+          # Extract the file
+          zipfile.extract(entry, File.join(destination, entry.name))
+        end
+      end
+    end
+
+    # Removes the passed directory
+    def self.remove_directory(directory)
+      FileUtils.rm_rf directory
+    end
+
+  end
+end

--- a/app/services/core_data_connector/geometry.rb
+++ b/app/services/core_data_connector/geometry.rb
@@ -1,0 +1,21 @@
+require 'rgeo/geo_json'
+
+module CoreDataConnector
+  class Geometry
+    # Converts the passed PostGIS to GeoJSON
+    def self.to_geojson(geometry)
+      RGeo::GeoJSON.encode(geometry)
+    end
+
+    # Converts the passed GeoJSON to PostGIS
+    def self.to_postgis(geometry)
+      factory = RGeo::Geographic.spherical_factory(srid: 4326, buffer_resolution: 8)
+
+      decoded = RGeo::GeoJSON.decode(geometry, geo_factory: factory, json_parser: :json)
+      return decoded unless decoded.is_a?(RGeo::GeoJSON::FeatureCollection)
+
+      # For a FeatureCollection, we'll convert that to a PostGIS GeometryCollection type
+      factory.collection(decoded.instance_variable_get('@features').map(&:geometry))
+    end
+  end
+end

--- a/app/services/core_data_connector/http/request.rb
+++ b/app/services/core_data_connector/http/request.rb
@@ -1,0 +1,39 @@
+require 'typhoeus'
+
+module CoreDataConnector
+  module Http
+    class Request
+
+      DEFAULT_GET_OPTIONS = {
+        followlocation: true
+      }
+
+      def self.delete(url, options = {})
+        parse_response Typhoeus.delete(url, options)
+      end
+
+      def self.get(url, options = {})
+        parse_response Typhoeus.get(url, options.merge(DEFAULT_GET_OPTIONS))
+      end
+
+      def self.post(url, options = {})
+        parse_response Typhoeus.post(url, options)
+      end
+
+      def self.put(url, options = {})
+        parse_response Typhoeus.put(url, options)
+      end
+
+      private
+
+      def self.parse_response(response)
+        {
+          code: response.code,
+          data: response.body,
+          success: response.success?
+        }
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/http/requestable.rb
+++ b/app/services/core_data_connector/http/requestable.rb
@@ -1,0 +1,35 @@
+require 'typhoeus'
+
+module CoreDataConnector
+  module Http
+    module Requestable
+      extend ActiveSupport::Concern
+
+      CODE_NO_RESPONSE = 0
+
+      included do
+        def send_request(url, options)
+          request = Typhoeus::Request.new(url, options)
+
+          response = request.run
+
+          if response.success?
+            yield response.body
+          elsif response.timed_out?
+            render_errors I18n.t('errors.http.timeout')
+          elsif response.code == CODE_NO_RESPONSE
+            render_errors I18n.t('errors.http.no_response')
+          else
+            render_errors I18n.t('errors.http.general')
+          end
+        end
+
+        private
+
+        def render_errors(message)
+          { errors: [message] }
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -7,7 +7,7 @@ module CoreDataConnector
         manifest_key = project_model_relationship_uuid.present? ? 'manifest' : 'manifests'
         method_name = "public_v1_#{route_name}_#{manifest_key}_path"
 
-        router_helpers = Engine.routes.url_helpers
+        router_helpers = Rails.application.routes.url_helpers
         router_helpers.send(method_name.to_sym, uuid, project_model_relationship_uuid)
       end
 

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -1,0 +1,204 @@
+module CoreDataConnector
+  module Iiif
+    class Manifest
+      def self.generate_identifier(model_class:, uuid:, project_model_relationship_uuid: nil)
+        route_name = model_class.model_name.route_key.singularize
+
+        manifest_key = project_model_relationship_uuid.present? ? 'manifest' : 'manifests'
+        method_name = "public_v1_#{route_name}_#{manifest_key}_path"
+
+        router_helpers = Engine.routes.url_helpers
+        router_helpers.send(method_name.to_sym, uuid, project_model_relationship_uuid)
+      end
+
+      def find_label(record)
+        return record.full_name if record.is_a?(Person)
+
+        return record.name if record.respond_to?(:name)
+
+        nil
+      end
+
+      def reset_manifests
+        # Find all project models that have a relationship
+        ProjectModel.model_classes.each do |model_class|
+          next unless model_class.ancestors.include?(Manifestable)
+
+          options = {
+            limit: ENV['IIIF_MANIFEST_ITEM_LIMIT']
+          }
+
+          reset_manifests_by_type model_class, options
+        end
+      end
+
+      def reset_manifests_by_type(model_class, options = {})
+        service = TripleEyeEffable::Presentation.new
+
+        query = build_query(model_class, options)
+
+        query.in_batches do |batch|
+          apply_preloads batch, options
+
+          batch.each do |record|
+            # Build a mapping of all of the related resources indexed by project_model_relationship
+            hash = {}
+
+            # Generate the manifest label for the current record
+            label = find_label(record)
+
+            record.relationships.each do |relationship|
+              project_model_relationship = relationship.project_model_relationship
+              resource = relationship.related_record
+
+              add_resource hash, project_model_relationship, resource
+            end
+
+            record.related_relationships.each do |relationship|
+              project_model_relationship = relationship.project_model_relationship
+              resource = relationship.primary_record
+
+              add_resource hash, project_model_relationship, resource
+            end
+
+            # Iterate over all of the relationships and build a manifest for each
+            hash.keys.each do |project_model_relationship_uuid|
+              info = hash[project_model_relationship_uuid]
+
+              identifier = self.class.generate_identifier(
+                model_class: model_class,
+                uuid: record.uuid,
+                project_model_relationship_uuid: project_model_relationship_uuid
+              )
+
+              # Create or update the manifest records
+              project_model_relationship_id = info[:id]
+              manifest = find_manifest(record, project_model_relationship_id)
+
+              if manifest.nil?
+                manifest = CoreDataConnector::Manifest.new(
+                  manifestable: record,
+                  project_model_relationship_id: project_model_relationship_id,
+                  identifier: identifier
+                )
+              end
+
+              manifest.identifier = identifier
+
+              # Get the resources from the info object, limiting if required
+              resources = info[:resources]
+              resources = resources.take(options[:limit].to_i) if options[:limit].present?
+
+              # Set the thumbnail and label on the manifest
+              manifest.thumbnail = resources.first
+              manifest.label = info[:name]
+              manifest.item_count = resources.size
+
+              # Create the manifest
+              manifest.content = service.create_manifest(
+                id: "#{ENV['HOSTNAME']}/#{identifier}",
+                label: I18n.t('services.iiif.manifest.label', name: label, relationship: info[:name]),
+                resource_ids: resources
+              )
+
+              manifest.save
+            end
+          end
+        end
+      end
+
+      private
+
+      def add_resource(hash, project_model_relationship, resource)
+        key = project_model_relationship.uuid
+
+        hash[key] ||= {
+          id: project_model_relationship.id,
+          name: project_model_relationship.name,
+          resources: []
+        }
+
+        hash[key][:resources] << resource.resource_description.resource_id
+      end
+
+      def apply_preloads(query, options)
+        relationships_scope = Relationship
+                                .joins(:related_media_content)
+                                .order(
+                                  Relationship.arel_table[:order],
+                                  MediaContent.arel_table[:name],
+                                  MediaContent.arel_table[:id]
+                                )
+
+        if options[:project_model_relationship_id].present?
+          relationships_scope = relationships_scope.where(
+            project_model_relationship_id: options[:project_model_relationship_id]
+          )
+        end
+
+        Preloader.new(
+          records: query,
+          associations: [
+            relationships: [:project_model_relationship, :related_record]
+          ],
+          scope: relationships_scope
+        ).call
+
+        related_relationships_scope = Relationship
+                                        .joins(:project_model_relationship)
+                                        .joins(:inverse_related_media_content)
+                                        .where(project_model_relationship: { allow_inverse: true })
+                                        .order(
+                                          Relationship.arel_table[:order],
+                                          MediaContent.arel_table[:name],
+                                          MediaContent.arel_table[:id]
+                                        )
+
+        if options[:project_model_relationship_id].present?
+          related_relationships_scope = related_relationships_scope.where(
+            project_model_relationship_id: options[:project_model_relationship_id]
+          )
+        end
+
+        Preloader.new(
+          records: query,
+          associations: [
+            related_relationships: [:project_model_relationship, :primary_record]
+          ],
+          scope: related_relationships_scope
+        ).call
+      end
+
+      def build_query(model_class, options)
+        primary_model_table = Arel::Table.new('primary_model')
+        related_model_table = Arel::Table.new('related_model')
+
+        primary_query = ProjectModel
+                          .joins(project_model_relationships: [:primary_model, :related_model])
+                          .where(primary_model_table[:id].eq(model_class.arel_table[:project_model_id]))
+                          .where(related_model: { model_class: MediaContent.to_s })
+
+        related_query = ProjectModel
+                          .joins(project_model_relationships: [:primary_model, :related_model])
+                          .where(related_model_table[:id].eq(model_class.arel_table[:project_model_id]))
+                          .where(project_model_relationships: { allow_inverse: true })
+                          .where(primary_model: { model_class: MediaContent.to_s })
+
+        query = model_class
+                  .where(primary_query.or(related_query).arel.exists)
+
+
+        if options[:id].present?
+          query = query.where(id: options[:id])
+        end
+
+        query
+      end
+
+      def find_manifest(record, project_model_relationship_id)
+        record.manifests.select{ |m| m.project_model_relationship_id == project_model_relationship_id }.first
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -1,0 +1,155 @@
+require 'csv'
+
+module CoreDataConnector
+  module Import
+    class Base
+      attr_reader :filepath, :import_id, :table_name, :user_defined_columns
+
+      def initialize(filepath, import_id)
+        @filepath = filepath
+        @import_id = import_id
+
+        @connection = ActiveRecord::Base.connection
+        @csv_headers = CSV.foreach(filepath).first
+        @table_name = create_table_name
+        @user_defined_columns = load_user_defined_columns
+      end
+
+      def cleanup
+        execute <<-SQL.squish
+          DROP TABLE IF EXISTS #{table_name}
+        SQL
+      end
+
+      def extract
+        column_names = columns
+                         .select{ |c| c[:copy] == true }
+                         .map{ |column| column[:name] }.join(', ')
+
+        options = "FORMAT CSV, DELIMITER ','"
+        copy_command = "COPY #{table_name} (#{column_names}) FROM STDIN WITH (#{options})"
+
+        @connection.raw_connection.copy_data(copy_command)  do
+          CSV.foreach(filepath, headers: true) do |row|
+            @connection.raw_connection.put_copy_data(row.to_csv)
+          end
+        end
+      end
+
+      def load
+        # Implemented in sub-classes
+      end
+
+      def setup
+        column_names = columns
+                         .map{ |column| "#{column[:name]} #{column[:type]} #{column[:options]}" }
+                         .join(', ')
+
+        execute <<-SQL.squish
+          CREATE TABLE #{table_name} (
+            id SERIAL,
+            #{column_names}
+          )
+        SQL
+      end
+
+      def transform
+        # Set the uuid value for any NULL records
+        execute <<-SQL.squish
+          UPDATE #{table_name}
+             SET uuid = gen_random_uuid()
+           WHERE uuid IS NULL
+        SQL
+
+        # Set the import_id value for each record
+        execute <<-SQL.squish
+          UPDATE #{table_name}
+             SET import_id = '#{import_id}'
+        SQL
+
+        return unless user_defined_columns.present?
+
+        # Sets the user_defined column based on any included user-defined fields
+        all_udc_args = user_defined_columns
+                     .map{ |c| ["'#{c[:uuid]}'", c[:name]] }
+                     .flatten
+        # can't pass more than 100 arguments to a function, so build
+        # expression using multiple function calls, each <= 100 args
+        expressions = []
+        all_udc_args.each_slice(100) do |udc_arg_set|
+          args = udc_arg_set.join(', ')
+          expressions.push("jsonb_strip_nulls(jsonb_build_object(#{args}))")
+        end
+        expression = expressions.join(' || ')
+
+        execute <<-SQL.squish
+          UPDATE #{table_name}
+             SET user_defined = COALESCE(user_defined, '{}') || #{expression}
+        SQL
+
+        # Sets the "Select" and "FuzzyDate" user-defined types to JSONB
+        user_defined_columns.each do |column|
+          next unless column[:data_type] == UserDefinedFields::UserDefinedField::DATA_TYPES[:select] && column[:allow_multiple] ||
+            column[:data_type] == UserDefinedFields::UserDefinedField::DATA_TYPES[:fuzzy_date]
+
+          execute <<-SQL.squish
+            UPDATE #{table_name}
+               SET user_defined = jsonb_set(user_defined, '{#{column[:uuid]}}', (user_defined->>'#{column[:uuid]}')::jsonb)
+             WHERE user_defined->>'#{column[:uuid]}' IS NOT NULL
+               AND user_defined->>'#{column[:uuid]}' != ''
+          SQL
+        end
+      end
+
+      protected
+
+      def execute(sql)
+        @connection.execute sql
+      end
+
+      def table_name_prefix
+        # Implemented in sub-classes
+      end
+
+      private
+
+      def columns
+        [ *column_names, *user_defined_columns ]
+      end
+
+      def create_table_name
+        "#{table_name_prefix}_#{Random.rand(1000..9999)}"
+      end
+
+      def load_user_defined_columns
+        columns = []
+
+        @csv_headers.each do |header|
+          next unless ImportAnalyze::Helper.is_user_defined_column?(header)
+
+          uuid = ImportAnalyze::Helper.column_name_to_uuid(header)
+          user_defined_field = UserDefinedFields::UserDefinedField.find_by_uuid(uuid)
+
+          data_type = user_defined_field.data_type
+          allow_multiple = user_defined_field.allow_multiple
+
+          columns << {
+            name: header,
+            type: 'VARCHAR',
+            uuid: uuid,
+            data_type: data_type,
+            allow_multiple: allow_multiple,
+            copy: true
+          }
+        end
+
+        columns
+      end
+
+      # Converts the passed UUID value to a database-safe column name
+      def uuid_to_column_name(uuid)
+        "_#{uuid.gsub('-', '_')}"
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -1,0 +1,247 @@
+module CoreDataConnector
+  module Import
+    class Events < Base
+      DATE_FORMAT = 'YYYY-MM-DD'
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_events
+             SET z_event_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_events
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_events events
+             SET z_event_id = z_events.id,
+                 name = z_events.name,
+                 description = z_events.description,
+                 user_defined = z_events.user_defined,
+                 import_id = z_events.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_events
+           WHERE z_events.event_id = events.id
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE fuzzy_dates_fuzzy_dates fuzzy_dates
+             SET accuracy = #{FuzzyDates::FuzzyDate.accuracies['date']},
+                 range = FALSE,
+                 start_date = z_events.start_date_start_date,
+                 end_date = z_events.start_date_end_date,
+                 description = z_events.start_date_description,
+                 updated_at = CURRENT_TIMESTAMP
+            FROM #{table_name} z_events
+           WHERE fuzzy_dates.dateable_id = z_events.event_id
+             AND fuzzy_dates.dateable_type = 'CoreDataConnector::Event'
+             AND fuzzy_dates.attribute_name = 'start_date'
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE fuzzy_dates_fuzzy_dates fuzzy_dates
+             SET accuracy = #{FuzzyDates::FuzzyDate.accuracies['date']},
+                 range = FALSE,
+                 start_date = z_events.end_date_start_date,
+                 end_date = z_events.end_date_end_date,
+                 description = z_events.end_date_description,
+                 updated_at = CURRENT_TIMESTAMP
+            FROM #{table_name} z_events
+           WHERE fuzzy_dates.dateable_id = z_events.event_id
+             AND fuzzy_dates.dateable_type = 'CoreDataConnector::Event'
+             AND fuzzy_dates.attribute_name = 'end_date'
+        SQL
+
+        execute <<-SQL.squish
+          WITH 
+          
+          insert_events AS (
+
+          INSERT INTO core_data_connector_events (
+            project_model_id, 
+            uuid, 
+            z_event_id, 
+            name, 
+            description, 
+            user_defined,
+            import_id,
+            created_at, 
+            updated_at
+          )
+          SELECT z_events.project_model_id, 
+                 z_events.uuid, 
+                 z_events.id, 
+                 z_events.name, 
+                 z_events.description, 
+                 z_events.user_defined,
+                 z_events.import_id,
+                 current_timestamp, 
+                 current_timestamp
+            FROM #{table_name} z_events
+           WHERE z_events.event_id IS NULL
+          RETURNING id AS event_id, z_event_id
+
+          ),
+
+          insert_start_date AS (
+
+          INSERT INTO fuzzy_dates_fuzzy_dates (
+            dateable_id, 
+            dateable_type, 
+            attribute_name, 
+            accuracy, 
+            range, 
+            start_date, 
+            end_date, 
+            description, 
+            created_at, 
+            updated_at
+          )
+          SELECT insert_events.event_id,
+                 'CoreDataConnector::Event',
+                 'start_date',
+                  #{FuzzyDates::FuzzyDate::accuracies['date']},
+                  false,
+                  z_events.start_date_start_date,
+                  z_events.start_date_end_date,
+                  z_events.start_date_description,
+                  CURRENT_TIMESTAMP,
+                  CURRENT_TIMESTAMP
+            FROM insert_events
+            JOIN #{table_name} z_events ON z_events.id = insert_events.z_event_id
+
+          ),
+
+          insert_end_date AS (
+
+          INSERT INTO fuzzy_dates_fuzzy_dates (
+            dateable_id, 
+            dateable_type, 
+            attribute_name, 
+            accuracy, 
+            range, 
+            start_date, 
+            end_date, 
+            description, 
+            created_at, 
+            updated_at
+          )
+          SELECT insert_events.event_id,
+                 'CoreDataConnector::Event',
+                 'end_date',
+                  #{FuzzyDates::FuzzyDate::accuracies['date']},
+                  false,
+                  z_events.end_date_start_date,
+                  z_events.end_date_end_date,
+                  z_events.end_date_description,
+                  CURRENT_TIMESTAMP,
+                  CURRENT_TIMESTAMP
+            FROM insert_events
+            JOIN #{table_name} z_events ON z_events.id = insert_events.z_event_id
+
+          )
+
+          UPDATE #{table_name} z_events
+             SET event_id = insert_events.event_id
+            FROM insert_events
+           WHERE insert_events.z_event_id = z_events.id
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
+             SET event_id = events.id,
+                 user_defined = events.user_defined
+            FROM core_data_connector_events events
+           WHERE events.uuid = z_events.uuid
+             AND z_events.uuid IS NOT NULL
+        SQL
+
+        super
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
+             SET start_date_start_date = TO_DATE(z_events.start_date, '#{DATE_FORMAT}'),
+                 end_date_start_date = TO_DATE(z_events.end_date, '#{DATE_FORMAT}')
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_events
+             SET start_date_end_date = z_events.start_date_start_date + INTERVAL '1 day',
+                 end_date_end_date = z_events.end_date_start_date + INTERVAL '1 day'
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'description',
+           type: 'TEXT',
+           copy: true
+         }, {
+           name: 'start_date',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'start_date_description',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'end_date',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'end_date_description',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'event_id',
+           type: 'INTEGER'
+         }, {
+           name: 'user_defined',
+           type: 'JSONB'
+         }, {
+           name: 'start_date_start_date',
+           type: 'DATE'
+         }, {
+           name: 'start_date_end_date',
+           type: 'DATE'
+         }, {
+           name: 'end_date_start_date',
+           type: 'DATE'
+         }, {
+           name: 'end_date_end_date',
+           type: 'DATE'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
+         }]
+      end
+
+      def table_name_prefix
+        'z_events'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -1,0 +1,102 @@
+module CoreDataConnector
+  module Import
+    class Importer
+
+      attr_reader :importers, :import_id
+
+      IMPORTERS = [{
+        importer_class: Events,
+        filename: 'events.csv'
+      }, {
+        importer_class: Instances,
+        filename: 'instances.csv'
+      }, {
+        importer_class: Items,
+        filename: 'items.csv'
+      }, {
+        importer_class: MediaContent,
+        filename: 'media_contents.csv'
+      }, {
+        importer_class: Organizations,
+        filename: 'organizations.csv'
+      }, {
+        importer_class: People,
+        filename: 'people.csv'
+      }, {
+        importer_class: Places,
+        filename: 'places.csv'
+      }, {
+        importer_class: Taxonomies,
+        filename: 'taxonomies.csv'
+      }, {
+        importer_class: Works,
+        filename: 'works.csv'
+      }]
+
+      # Importers that reference any of the above models
+      RELATIONSHIP_IMPORTERS = [{
+        importer_class: Relationships,
+        filename: 'relationships.csv'
+      }, {
+        importer_class: WebIdentifiers,
+        filename: 'web_identifiers.csv'
+      }]
+
+      def initialize(directory)
+        @importers = []
+        @import_id = SecureRandom.uuid
+
+        IMPORTERS.each do |importer|
+          populate_importer(importer, directory)
+        end
+
+        RELATIONSHIP_IMPORTERS.each do |importer|
+          populate_importer(importer, directory)
+        end
+      end
+
+      def close
+        # Iterate over each importer and perform any cleanup
+        importers.each do |importer|
+          importer.cleanup
+        end
+      end
+
+      def run
+        importers.each do |importer|
+          # Setup necessary schema
+          importer.setup
+
+          # Extract the files from the CSV to the temp table
+          importer.extract
+
+          # Transform any values
+          importer.transform
+
+          # Load the data into the appropriate tables
+          importer.load
+        end
+
+        # Upload any attachments for media_contents
+        uploader = Uploader.new(import_id)
+        uploader.upload
+
+        # Return the import ID
+        import_id
+      end
+
+      private
+
+      def populate_importer(importer, directory)
+        filename = importer[:filename]
+        klass = importer[:importer_class]
+
+        filepath = "#{directory}/#{filename}"
+
+        if File.exist? filepath
+          @importers << klass.new(filepath, import_id)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -1,0 +1,186 @@
+module CoreDataConnector
+  module Import
+    class Instances < Base
+      # Includes
+      include Nameable
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_instances
+             SET z_instance_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_instances, core_data_connector_source_names
+        SQL
+      end
+
+      def load
+        super
+
+        # Update existing instances
+        execute <<-SQL.squish
+          UPDATE core_data_connector_instances instances
+             SET z_instance_id = z_instances.id,
+                 user_defined = z_instances.user_defined,
+                 import_id = z_instances.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_instances
+           WHERE z_instances.instance_id = instances.id
+        SQL
+
+        # Insert new instances
+        execute <<-SQL.squish
+          WITH
+  
+          insert_instances AS (
+  
+          INSERT INTO core_data_connector_instances (
+            project_model_id,
+            uuid,
+            z_instance_id,
+            user_defined,
+            import_id,
+            created_at,
+            updated_at
+          )
+          SELECT z_instances.project_model_id,
+                 z_instances.uuid,
+                 z_instances.id,
+                 z_instances.user_defined,
+                 z_instances.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_instances
+           WHERE z_instances.instance_id IS NULL
+          RETURNING id AS instance_id, z_instance_id
+  
+          )
+  
+          UPDATE #{table_name} z_instances
+             SET instance_id = insert_instances.instance_id
+            FROM insert_instances
+           WHERE insert_instances.z_instance_id = z_instances.id
+        SQL
+
+        # Insert new source_names
+        execute <<-SQL.squish
+          WITH 
+  
+          all_instance_names AS (
+            
+          SELECT z_instances.instance_id AS instance_id, z_instances.primary_name AS name
+            FROM #{table_name} z_instances
+           UNION ALL
+          SELECT z_instances.instance_id AS instance_id, unnest(z_instances.additional_names) AS name
+            FROM #{table_name} z_instances
+          
+          )
+  
+          INSERT INTO core_data_connector_source_names (
+            nameable_id, 
+            nameable_type, 
+            name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_instance_names.instance_id, 
+                 'CoreDataConnector::Instance', 
+                 all_instance_names.name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_instance_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_source_names source_names
+                               WHERE source_names.nameable_id = all_instance_names.instance_id
+                                 AND source_names.nameable_type = 'CoreDataConnector::Instance'
+                                 AND source_names.name = all_instance_names.name )
+        SQL
+
+        # Reset "primary" indicator for all source_names to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_instances
+           WHERE z_instances.instance_id = source_names.nameable_id
+             AND source_names.nameable_type = 'CoreDataConnector::Instance'
+        SQL
+
+        # Set the "primary" indicator for source_names to TRUE
+        execute <<-SQL.squish
+          WITH 
+                
+          primary_instance_names AS (
+              
+          SELECT z_instances.instance_id AS instance_id, z_instances.primary_name AS name
+            FROM #{table_name} z_instances
+  
+          )
+  
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_instance_names
+           WHERE primary_instance_names.instance_id = source_names.nameable_id
+             AND primary_instance_names.name = source_names.name
+             AND source_names.nameable_type = 'CoreDataConnector::Instance'
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_instances
+             SET instance_id = instances.id,
+                 user_defined = instances.user_defined
+            FROM core_data_connector_instances instances
+           WHERE instances.uuid = z_instances.uuid
+             AND z_instances.uuid IS NOT NULL
+        SQL
+
+        transform_names
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'instance_id',
+          type: 'INTEGER'
+        }, {
+          name: 'primary_name',
+          type: 'VARCHAR'
+        }, {
+          name: 'additional_names',
+          type: 'TEXT[]'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }, {
+          name: 'import_id',
+          type: 'UUID'
+        }]
+      end
+
+      def table_name_prefix
+        'z_instances'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -1,0 +1,186 @@
+module CoreDataConnector
+  module Import
+    class Items < Base
+      # Includes
+      include Nameable
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_items
+             SET z_item_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_items, core_data_connector_source_names
+        SQL
+      end
+
+      def load
+        super
+
+        # Update existing items
+        execute <<-SQL.squish
+          UPDATE core_data_connector_items items
+             SET z_item_id = z_items.id,
+                 user_defined = z_items.user_defined,
+                 import_id = z_items.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_items
+           WHERE z_items.item_id = items.id
+        SQL
+
+        # Insert new items
+        execute <<-SQL.squish
+          WITH
+  
+          insert_items AS (
+  
+          INSERT INTO core_data_connector_items (
+            project_model_id,
+            uuid,
+            z_item_id,
+            user_defined,
+            import_id,
+            created_at,
+            updated_at
+          )
+          SELECT z_items.project_model_id,
+                 z_items.uuid,
+                 z_items.id,
+                 z_items.user_defined,
+                 z_items.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_items
+           WHERE z_items.item_id IS NULL
+          RETURNING id AS item_id, z_item_id
+  
+          )
+  
+          UPDATE #{table_name} z_items
+             SET item_id = insert_items.item_id
+            FROM insert_items
+           WHERE insert_items.z_item_id = z_items.id
+        SQL
+
+        # Insert new source_names
+        execute <<-SQL.squish
+          WITH 
+  
+          all_item_names AS (
+            
+          SELECT z_items.item_id AS item_id, z_items.primary_name AS name
+            FROM #{table_name} z_items
+           UNION ALL
+          SELECT z_items.item_id AS item_id, unnest(z_items.additional_names) AS name
+            FROM #{table_name} z_items
+          
+          )
+  
+          INSERT INTO core_data_connector_source_names (
+            nameable_id, 
+            nameable_type, 
+            name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_item_names.item_id, 
+                 'CoreDataConnector::Item', 
+                 all_item_names.name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_item_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_source_names source_names
+                               WHERE source_names.nameable_id = all_item_names.item_id
+                                 AND source_names.nameable_type = 'CoreDataConnector::Item'
+                                 AND source_names.name = all_item_names.name )
+        SQL
+
+        # Reset "primary" indicator for all source_names to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_items
+           WHERE z_items.item_id = source_names.nameable_id
+             AND source_names.nameable_type = 'CoreDataConnector::Item'
+        SQL
+
+        # Set the "primary" indicator for source_names to TRUE
+        execute <<-SQL.squish
+          WITH 
+                
+          primary_item_names AS (
+              
+          SELECT z_items.item_id AS item_id, z_items.primary_name AS name
+            FROM #{table_name} z_items
+  
+          )
+  
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_item_names
+           WHERE primary_item_names.item_id = source_names.nameable_id
+             AND primary_item_names.name = source_names.name
+             AND source_names.nameable_type = 'CoreDataConnector::Item'
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_items
+             SET item_id = items.id,
+                 user_defined = items.user_defined
+            FROM core_data_connector_items items
+           WHERE items.uuid = z_items.uuid
+             AND z_items.uuid IS NOT NULL
+        SQL
+
+        transform_names
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'item_id',
+          type: 'INTEGER'
+        }, {
+          name: 'primary_name',
+          type: 'VARCHAR'
+        }, {
+          name: 'additional_names',
+          type: 'TEXT[]'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }, {
+          name: 'import_id',
+          type: 'UUID'
+        }]
+      end
+
+      def table_name_prefix
+        'z_items'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/media_content.rb
+++ b/app/services/core_data_connector/import/media_content.rb
@@ -1,0 +1,141 @@
+module CoreDataConnector
+  module Import
+    class MediaContent < Base
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_media_contents
+             SET z_media_content_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_media_contents
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+         UPDATE core_data_connector_media_contents media_contents
+            SET z_media_content_id = z_media_contents.id,
+                name = z_media_contents.name,
+                import_url = z_media_contents.import_url,
+                content_warning = COALESCE(z_media_contents.content_warning, FALSE),
+                import_url_processed = z_media_contents.import_url_processed,
+                user_defined = z_media_contents.user_defined,
+                import_id = z_media_contents.import_id,
+                updated_at = current_timestamp
+           FROM #{table_name} z_media_contents
+          WHERE z_media_contents.media_content_id = media_contents.id
+        SQL
+
+        execute <<-SQL.squish
+          WITH
+
+          insert_media_contents AS (
+
+          INSERT INTO core_data_connector_media_contents (
+            project_model_id,
+            uuid,
+            z_media_content_id,
+            name,
+            import_url,
+            content_warning,
+            user_defined,
+            import_id,
+            created_at, 
+            updated_at
+          )
+          SELECT z_media_contents.project_model_id,
+                 z_media_contents.uuid,
+                 z_media_contents.id,
+                 z_media_contents.name,
+                 z_media_contents.import_url,
+                 COALESCE(z_media_contents.content_warning, FALSE),
+                 z_media_contents.user_defined,
+                 z_media_contents.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_media_contents
+           WHERE z_media_contents.media_content_id IS NULL
+          RETURNING id AS media_content_id, z_media_content_id
+
+          )
+
+          UPDATE #{table_name} z_media_contents
+             SET media_content_id = insert_media_contents.media_content_id
+            FROM insert_media_contents
+           WHERE insert_media_contents.z_media_content_id = z_media_contents.id
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_media_contents
+             SET media_content_id = media_contents.id,
+                 user_defined = media_contents.user_defined
+            FROM core_data_connector_media_contents media_contents
+           WHERE media_contents.uuid = z_media_contents.uuid
+             AND z_media_contents.uuid IS NOT NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_media_contents
+             SET import_url_processed = true
+            FROM core_data_connector_media_contents media_contents
+           WHERE media_contents.uuid = z_media_contents.uuid
+             AND media_contents.import_url = z_media_contents.import_url
+        SQL
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'import_url',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+          name: 'content_warning',
+          type: 'BOOLEAN',
+          copy: true
+         }, {
+           name: 'media_content_id',
+           type: 'INTEGER'
+         }, {
+           name: 'import_url_processed',
+           type: 'BOOLEAN',
+           options: 'NOT NULL DEFAULT FALSE'
+         }, {
+           name: 'user_defined',
+           type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
+         }]
+      end
+
+      def table_name_prefix
+        'z_media_contents'
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -1,0 +1,187 @@
+module CoreDataConnector
+  module Import
+    class Organizations < Base
+      # Includes
+      include Nameable
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_organizations
+             SET z_organization_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_organizations, core_data_connector_organization_names
+        SQL
+      end
+
+      def load
+        super
+
+        # Update existing organizations
+        execute <<-SQL.squish
+          UPDATE core_data_connector_organizations organizations
+             SET z_organization_id = z_organizations.id,
+                 description = z_organizations.description,
+                 user_defined = z_organizations.user_defined,
+                 import_id = z_organizations.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_organizations
+           WHERE z_organizations.organization_id = organizations.id
+        SQL
+
+        # Insert new organizations
+        execute <<-SQL.squish
+          WITH 
+          
+          insert_organizations AS (
+
+          INSERT INTO core_data_connector_organizations (
+            project_model_id, uuid, 
+            z_organization_id, 
+            description, 
+            user_defined,
+            import_id,
+            created_at, 
+            updated_at
+          )
+          SELECT z_organizations.project_model_id, 
+                 z_organizations.uuid, 
+                 z_organizations.id, 
+                 z_organizations.description, 
+                 z_organizations.user_defined, 
+                 z_organizations.import_id,
+                 current_timestamp, 
+                 current_timestamp
+            FROM #{table_name} z_organizations
+           WHERE z_organizations.organization_id IS NULL
+          RETURNING id AS organization_id, z_organization_id
+
+          )
+
+          UPDATE #{table_name} z_organizations
+             SET organization_id = insert_organizations.organization_id
+            FROM insert_organizations
+           WHERE insert_organizations.z_organization_id = z_organizations.id
+        SQL
+
+        # Insert new organization_names
+        execute <<-SQL.squish
+          WITH 
+ 
+          all_organization_names AS (
+            
+          SELECT z_organizations.organization_id AS organization_id, z_organizations.primary_name AS name
+            FROM #{table_name} z_organizations
+           UNION ALL
+          SELECT z_organizations.organization_id AS organization_id, unnest(z_organizations.additional_names) AS name
+            FROM #{table_name} z_organizations
+          
+          )
+
+          INSERT INTO core_data_connector_organization_names (
+            organization_id, 
+            name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_organization_names.organization_id, 
+                 all_organization_names.name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_organization_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_organization_names organization_names
+                               WHERE organization_names.organization_id = all_organization_names.organization_id
+                                 AND organization_names.name = all_organization_names.name )
+        SQL
+
+        # Reset all organization_names "primary" indicator to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_organization_names organization_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_organizations
+           WHERE z_organizations.organization_id = organization_names.organization_id
+        SQL
+
+        # Set organization_names "primary" indicator to TRUE
+        execute <<-SQL.squish
+          WITH 
+              
+          primary_organization_names AS (
+              
+          SELECT z_organizations.organization_id AS organization_id, z_organizations.primary_name AS name
+            FROM #{table_name} z_organizations
+
+          )
+
+          UPDATE core_data_connector_organization_names organization_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_organization_names
+           WHERE primary_organization_names.organization_id = organization_names.organization_id
+             AND primary_organization_names.name = organization_names.name
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_organizations
+             SET organization_id = organizations.id,
+                 user_defined = organizations.user_defined
+            FROM core_data_connector_organizations organizations
+           WHERE organizations.uuid = z_organizations.uuid
+             AND z_organizations.uuid IS NOT NULL
+        SQL
+
+        transform_names
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'description',
+           type: 'TEXT',
+           copy: true
+         }, {
+           name: 'organization_id',
+           type: 'INTEGER'
+         }, {
+           name: 'primary_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'additional_names',
+           type: 'TEXT[]'
+         }, {
+           name: 'user_defined',
+           type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
+         }]
+      end
+
+      def table_name_prefix
+        'z_organizations'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -1,0 +1,250 @@
+module CoreDataConnector
+  module Import
+    class People < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_people
+             SET z_person_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_people, core_data_connector_person_names
+        SQL
+      end
+
+      def load
+        super
+
+        # Update existing people
+        execute <<-SQL.squish
+          UPDATE core_data_connector_people people
+             SET z_person_id = z_people.id,
+                 biography = z_people.biography,
+                 user_defined = z_people.user_defined,
+                 import_id = z_people.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_people
+           WHERE z_people.person_id = people.id
+        SQL
+
+        # Insert new people
+        execute <<-SQL.squish
+          WITH 
+          
+          insert_people AS (
+
+          INSERT INTO core_data_connector_people (
+            project_model_id, 
+            uuid, 
+            z_person_id, 
+            biography, 
+            user_defined,
+            import_id,
+            created_at, 
+            updated_at
+          )
+          SELECT z_people.project_model_id, 
+                 z_people.uuid, 
+                 z_people.id, 
+                 z_people.biography, 
+                 z_people.user_defined,
+                 z_people.import_id,
+                 current_timestamp, 
+                 current_timestamp
+            FROM #{table_name} z_people
+           WHERE z_people.person_id IS NULL
+          RETURNING id AS person_id, z_person_id
+
+          )
+
+          UPDATE #{table_name} z_people
+             SET person_id = insert_people.person_id
+            FROM insert_people
+           WHERE insert_people.z_person_id = z_people.id
+        SQL
+
+        # Insert new person_names
+        execute <<-SQL.squish
+          WITH 
+ 
+          all_person_names AS (
+            
+          SELECT z_people.person_id AS person_id, 
+                 z_people.primary_last_name AS last_name,
+                 z_people.primary_first_name AS first_name,
+                 z_people.primary_middle_name AS middle_name
+            FROM #{table_name} z_people
+           UNION ALL
+          SELECT z_people.person_id AS person_id, 
+                 unnest(z_people.additional_last_names) AS last_name,
+                 unnest(z_people.additional_first_names) AS first_name,
+                 unnest(z_people.additional_middle_names) AS middle_name
+            FROM #{table_name} z_people
+          
+          )
+
+          INSERT INTO core_data_connector_person_names (
+            person_id, 
+            last_name,
+            first_name,
+            middle_name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_person_names.person_id, 
+                 all_person_names.last_name,
+                 all_person_names.first_name,
+                 all_person_names.middle_name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_person_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_person_names person_names
+                               WHERE person_names.person_id = all_person_names.person_id
+                                 AND ( person_names.last_name = all_person_names.last_name 
+                                  OR ( person_names.last_name IS NULL AND all_person_names.last_name IS NULL ))
+                                 AND ( person_names.first_name = all_person_names.first_name
+                                  OR ( person_names.first_name IS NULL AND all_person_names.first_name IS NULL ))
+                                 AND ( person_names.middle_name = all_person_names.middle_name 
+                                  OR ( person_names.middle_name IS NULL AND all_person_names.middle_name IS NULL )))
+        SQL
+
+        # Reset all person_names "primary" indicator to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_person_names person_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_people
+           WHERE z_people.person_id = person_names.person_id
+        SQL
+
+        # Set person_names "primary" indicator to TRUE
+        execute <<-SQL.squish
+          WITH 
+              
+          primary_person_names AS (
+              
+          SELECT z_people.person_id AS person_id, 
+                 z_people.primary_last_name AS last_name,
+                 z_people.primary_first_name AS first_name,
+                 z_people.primary_middle_name AS middle_name
+            FROM #{table_name} z_people
+
+          )
+
+          UPDATE core_data_connector_person_names person_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_person_names
+           WHERE primary_person_names.person_id = person_names.person_id
+             AND ( person_names.last_name = primary_person_names.last_name 
+              OR ( person_names.last_name IS NULL AND primary_person_names.last_name IS NULL ))
+             AND ( person_names.first_name = primary_person_names.first_name
+              OR ( person_names.first_name IS NULL AND primary_person_names.first_name IS NULL ))
+             AND ( person_names.middle_name = primary_person_names.middle_name 
+              OR ( person_names.middle_name IS NULL AND primary_person_names.middle_name IS NULL ))
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_people
+             SET person_id = people.id,
+                 user_defined = people.user_defined
+            FROM core_data_connector_people people
+           WHERE people.uuid = z_people.uuid
+             AND z_people.uuid IS NOT NULL
+        SQL
+
+        execute <<-SQL.squish
+          WITH 
+
+          record_names AS (
+
+          SELECT id, 
+                 ARRAY(SELECT nullif(trim(BOTH ' ' FROM unnest(string_to_array(last_name, '#{Nameable::NAME_DELIMITER}'))), '')) as last_names,
+                 ARRAY(SELECT nullif(trim(BOTH ' ' FROM unnest(string_to_array(first_name, '#{Nameable::NAME_DELIMITER}'))), '')) as first_names,
+                 ARRAY(SELECT nullif(trim(BOTH ' ' FROM unnest(string_to_array(middle_name, '#{Nameable::NAME_DELIMITER}'))), '')) as middle_names
+            FROM #{table_name}
+
+          )
+
+          UPDATE #{table_name} z_people
+             SET primary_last_name = record_names.last_names[1],
+                 primary_first_name = record_names.first_names[1],
+                 primary_middle_name = record_names.middle_names[1],
+                 additional_last_names = record_names.last_names[2:array_length(record_names.last_names, 1)],
+                 additional_first_names = record_names.first_names[2:array_length(record_names.first_names, 1)],
+                 additional_middle_names = record_names.middle_names[2:array_length(record_names.middle_names, 1)]
+            FROM record_names
+           WHERE record_names.id = z_people.id
+          SQL
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'last_name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'first_name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'middle_name',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'biography',
+           type: 'TEXT',
+           copy: true
+         }, {
+           name: 'person_id',
+           type: 'INTEGER'
+         }, {
+           name: 'primary_last_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'primary_first_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'primary_middle_name',
+           type: 'VARCHAR'
+         }, {
+           name: 'additional_last_names',
+           type: 'TEXT[]'
+         }, {
+           name: 'additional_first_names',
+           type: 'TEXT[]'
+         }, {
+           name: 'additional_middle_names',
+           type: 'TEXT[]'
+         }, {
+           name: 'user_defined',
+           type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
+         }]
+      end
+
+      def table_name_prefix
+        'z_people'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -1,0 +1,212 @@
+module CoreDataConnector
+  module Import
+    class Places < Base
+      # Includes
+      include Nameable
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_places
+             SET z_place_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_places, 
+                         core_data_connector_place_names, 
+                         core_data_connector_place_geometries
+        SQL
+      end
+
+      def load
+        super
+
+        # Update existing places
+        execute <<-SQL.squish
+          WITH
+              
+          update_places AS (
+          
+          UPDATE core_data_connector_places places
+             SET z_place_id = z_places.id,
+                 user_defined = z_places.user_defined,
+                 import_id = z_places.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_places
+           WHERE z_places.place_id = places.id
+              
+          )
+
+          UPDATE core_data_connector_place_geometries place_geometries
+             SET geometry = st_makepoint(z_places.longitude, z_places.latitude),
+                 properties = z_places.properties,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_places
+           WHERE z_places.place_id = place_geometries.place_id
+        SQL
+
+        # Insert new places
+        execute <<-SQL.squish
+          WITH 
+
+          insert_places AS (
+
+          INSERT INTO core_data_connector_places (
+            project_model_id,
+            uuid,
+            z_place_id, 
+            user_defined,
+            import_id,
+            created_at,
+            updated_at
+          )
+          SELECT z_places.project_model_id,
+                 z_places.uuid,
+                 z_places.id,
+                 z_places.user_defined,
+                 z_places.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_places
+           WHERE z_places.place_id IS NULL
+          RETURNING id AS place_id, z_place_id
+
+          ),
+
+          insert_place_geometries AS (
+
+          INSERT INTO core_data_connector_place_geometries (place_id, geometry, properties, created_at, updated_at)
+          SELECT insert_places.place_id, st_makepoint(z_places.longitude, z_places.latitude), z_places.properties, current_timestamp, current_timestamp
+            FROM insert_places
+            JOIN #{table_name} z_places ON z_places.id = insert_places.z_place_id
+          RETURNING id
+
+          )
+
+          UPDATE #{table_name} z_places
+             SET place_id = insert_places.place_id
+            FROM insert_places
+           WHERE insert_places.z_place_id = z_places.id
+        SQL
+
+        # Insert new place_names
+        execute <<-SQL.squish
+          WITH 
+ 
+          all_place_names AS (
+            
+          SELECT z_places.place_id AS place_id, z_places.primary_name AS name
+            FROM #{table_name} z_places
+           UNION ALL
+          SELECT z_places.place_id AS place_id, unnest(z_places.additional_names) AS name
+            FROM #{table_name} z_places
+          
+          )
+
+          INSERT INTO core_data_connector_place_names (place_id, name, created_at, updated_at)
+          SELECT all_place_names.place_id, all_place_names.name, current_timestamp, current_timestamp
+            FROM all_place_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_place_names place_names
+                               WHERE place_names.place_id = all_place_names.place_id
+                                 AND place_names.name = all_place_names.name )
+        SQL
+
+        # Reset all place_names "primary" indicator to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_place_names place_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_places
+           WHERE z_places.place_id = place_names.place_id
+        SQL
+
+        # Set place_names "primary" indicator to TRUE
+        execute <<-SQL.squish
+          WITH 
+              
+          primary_place_names AS (
+              
+          SELECT z_places.place_id AS place_id, z_places.primary_name AS name
+            FROM #{table_name} z_places
+
+          )
+
+          UPDATE core_data_connector_place_names place_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_place_names
+           WHERE primary_place_names.place_id = place_names.place_id
+             AND primary_place_names.name = place_names.name
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_places
+             SET place_id = places.id,
+                 user_defined = places.user_defined,
+                 properties = COALESCE(z_places.properties, place_geometries.properties, '{}'::jsonb)
+            FROM core_data_connector_places places
+            LEFT JOIN core_data_connector_place_geometries place_geometries ON place_geometries.place_id = places.id
+           WHERE places.uuid = z_places.uuid
+             AND z_places.uuid IS NOT NULL
+        SQL
+
+        transform_names
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'name',
+           type: 'VARCHAR',
+           copy: true
+        }, {
+           name: 'latitude',
+           type: 'DECIMAL',
+           copy: true
+         }, {
+           name: 'longitude',
+           type: 'DECIMAL',
+           copy: true
+         }, {
+          name: 'properties',
+          type: 'JSONB',
+          copy: @csv_headers.include?('properties')
+        }, {
+           name: 'place_id',
+           type: 'INTEGER'
+        }, {
+           name: 'primary_name',
+           type: 'VARCHAR'
+        }, {
+           name: 'additional_names',
+           type: 'TEXT[]'
+        }, {
+           name: 'user_defined',
+           type: 'JSONB'
+        }, {
+           name: 'import_id',
+           type: 'UUID'
+         }]
+      end
+
+      def table_name_prefix
+        'z_places'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -1,0 +1,206 @@
+module CoreDataConnector
+  module Import
+    class Relationships < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_relationships
+             SET z_relationship_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_relationships
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_relationships relationships
+             SET z_relationship_id = z_relationships.id,
+                 user_defined = z_relationships.user_defined,
+                 import_id = z_relationships.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_relationships
+           WHERE z_relationships.relationship_id = relationships.id
+        SQL
+
+        execute <<-SQL.squish
+          WITH
+
+          insert_relationships AS (
+
+          INSERT INTO core_data_connector_relationships (
+            project_model_relationship_id,
+            z_relationship_id,
+            uuid,
+            primary_record_id,
+            primary_record_type,
+            related_record_id,
+            related_record_type,
+            user_defined,
+            import_id,
+            created_at,
+            updated_at
+          )
+          SELECT z_relationships.project_model_relationship_id,
+                 z_relationships.id,
+                 z_relationships.uuid,
+                 z_relationships.primary_record_id,
+                 z_relationships.primary_record_type,
+                 z_relationships.related_record_id,
+                 z_relationships.related_record_type,
+                 z_relationships.user_defined,
+                 z_relationships.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_relationships
+           WHERE z_relationships.relationship_id IS NULL
+             AND z_relationships.primary_record_id IS NOT NULL
+             AND z_relationships.primary_record_type IS NOT NULL
+             AND z_relationships.related_record_id IS NOT NULL
+             AND z_relationships.related_record_type IS NOT NULL
+          RETURNING id as relationship_id, z_relationship_id
+
+          )
+
+          UPDATE #{table_name} z_relationships
+             SET relationship_id = insert_relationships.relationship_id
+            FROM insert_relationships
+           WHERE insert_relationships.z_relationship_id = z_relationships.id
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          WITH all_related_types AS (
+         
+          SELECT id, uuid, 'CoreDataConnector::Event' AS type
+            FROM core_data_connector_events events
+           WHERE events.z_event_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Instance' AS type
+            FROM core_data_connector_instances instances
+           WHERE instances.z_instance_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Item' AS type
+            FROM core_data_connector_items items
+           WHERE items.z_item_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::MediaContent' AS type
+            FROM core_data_connector_media_contents media_contents
+           WHERE media_contents.z_media_content_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Organization' AS type
+            FROM core_data_connector_organizations organizations
+           WHERE organizations.z_organization_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Person' AS type
+            FROM core_data_connector_people people
+           WHERE people.z_person_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Place' AS type
+            FROM core_data_connector_places places
+           WHERE places.z_place_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Taxonomy' AS type
+            FROM core_data_connector_taxonomies taxonomies
+           WHERE taxonomies.z_taxonomy_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Work' AS type
+            FROM core_data_connector_works works
+           WHERE works.z_work_id IS NOT NULL
+
+          )
+
+          UPDATE #{table_name} z_relationships
+             SET primary_record_id = primary_types.id,
+                 related_record_id = related_types.id
+            FROM all_related_types primary_types, all_related_types related_types
+           WHERE primary_types.uuid = z_relationships.primary_record_uuid
+             AND primary_types.type = z_relationships.primary_record_type
+             AND related_types.uuid = z_relationships.related_record_uuid
+             AND related_types.type = z_relationships.related_record_type
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_relationships
+             SET relationship_id = relationships.id,
+                 user_defined = relationships.user_defined
+            FROM core_data_connector_relationships relationships
+           WHERE relationships.uuid = z_relationships.uuid
+             AND z_relationships.relationship_id IS NULL
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_relationships
+             SET relationship_id = relationships.id,
+                 user_defined = relationships.user_defined
+            FROM core_data_connector_relationships relationships
+           WHERE relationships.primary_record_id = z_relationships.primary_record_id
+             AND relationships.primary_record_type = z_relationships.primary_record_type
+             AND relationships.related_record_id = z_relationships.related_record_id
+             AND relationships.related_record_type = z_relationships.related_record_type
+             AND (((relationships.user_defined IS NULL OR relationships.user_defined = '{}'::jsonb)
+             AND (z_relationships.user_defined IS NULL OR z_relationships.user_defined = '{}'::jsonb))
+              OR (relationships.user_defined @> z_relationships.user_defined
+             AND relationships.user_defined <@ z_relationships.user_defined))
+             AND z_relationships.relationship_id IS NULL
+        SQL
+      end
+
+      protected
+
+      def column_names
+        [{
+           name: 'project_model_relationship_id',
+           type: 'INTEGER',
+           copy: true
+         }, {
+           name: 'uuid',
+           type: 'UUID',
+           copy: true
+         },{
+           name: 'primary_record_uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'primary_record_type',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'related_record_uuid',
+           type: 'UUID',
+           copy: true
+         }, {
+           name: 'related_record_type',
+           type: 'VARCHAR',
+           copy: true
+         }, {
+           name: 'relationship_id',
+           type: 'INTEGER'
+         }, {
+           name: 'primary_record_id',
+           type: 'INTEGER'
+         }, {
+           name: 'related_record_id',
+           type: 'INTEGER'
+         }, {
+           name: 'user_defined',
+           type: 'JSONB'
+         }, {
+           name: 'import_id',
+           type: 'UUID'
+         }]
+      end
+
+      def table_name_prefix
+        'z_relationships'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -1,0 +1,112 @@
+module CoreDataConnector
+  module Import
+    class Taxonomies < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_taxonomies
+             SET z_taxonomy_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_taxonomies
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_taxonomies taxonomies
+            SET  z_taxonomy_id = z_taxonomies.id,
+                 name = z_taxonomies.name,
+                 user_defined = z_taxonomies.user_defined,
+                 import_id = z_taxonomies.import_id,
+                 updated_at = current_timestamp
+           FROM #{table_name} z_taxonomies
+          WHERE z_taxonomies.taxonomy_id = taxonomies.id
+        SQL
+
+        execute <<-SQL.squish
+          WITH
+
+          insert_taxonomies AS (
+
+          INSERT INTO core_data_connector_taxonomies (
+            project_model_id,
+            uuid,
+            z_taxonomy_id,
+            name,
+            user_defined,
+            import_id,
+            created_at, 
+            updated_at
+          )
+          SELECT z_taxonomies.project_model_id,
+                 z_taxonomies.uuid,
+                 z_taxonomies.id,
+                 z_taxonomies.name,
+                 z_taxonomies.user_defined,
+                 z_taxonomies.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_taxonomies
+           WHERE z_taxonomies.taxonomy_id IS NULL
+          RETURNING id AS taxonomy_id, z_taxonomy_id
+
+          )
+
+          UPDATE #{table_name} z_taxonomies
+              SET taxonomy_id = insert_taxonomies.taxonomy_id
+             FROM insert_taxonomies
+            WHERE insert_taxonomies.z_taxonomy_id = z_taxonomies.id
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_taxonomies
+             SET taxonomy_id = taxonomies.id,
+                 user_defined = taxonomies.user_defined
+            FROM core_data_connector_taxonomies taxonomies
+           WHERE taxonomies.uuid = z_taxonomies.uuid
+             AND z_taxonomies.uuid IS NOT NULL
+        SQL
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'taxonomy_id',
+          type: 'INTEGER'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }, {
+          name: 'import_id',
+          type: 'UUID'
+        }]
+      end
+
+      def table_name_prefix
+        'z_taxonomies'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/uploader.rb
+++ b/app/services/core_data_connector/import/uploader.rb
@@ -1,0 +1,56 @@
+module CoreDataConnector
+  module Import
+    class Uploader
+
+      attr_accessor :import_id
+
+      def initialize(import_id)
+        @import_id = import_id
+      end
+
+      def upload
+        query = CoreDataConnector::MediaContent
+                  .preload(project_model: :project)
+                  .where(import_id:)
+                  .where.not(import_url: nil)
+                  .where.not(import_url_processed: true)
+
+        query.find_each { |m| upload_attachment m }
+      end
+
+      def upload_attachment(media_content)
+        # Download the file contents from the "import_url" property
+        download_response = Http::Request.get(media_content.import_url)
+        download_response => { data: }
+
+        # Call the direct upload service to obtain a pre-signed URL
+        blob = {
+          byte_size: data.bytesize,
+          checksum: Digest::MD5.base64digest(data),
+          filename: media_content.name,
+          metadata: {
+            storage_key: media_content.storage_key
+          }
+        }
+
+        direct_upload_service = TripleEyeEffable::DirectUploads.new
+        response = direct_upload_service.direct_upload blob
+
+        # Upload the data to S3 using the pre-signed URL
+        url = response['direct_upload']['url']
+        headers = response['direct_upload']['headers']
+        signed_id = response['signed_id']
+
+        upload_response = Http::Request.put(url, body: data, headers:)
+        upload_response => { success: }
+
+        # Save the media_contents record if the upload is successful
+        if success
+          media_content.content = signed_id
+          media_content.import_url_processed = true
+          media_content.save
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/web_identifiers.rb
+++ b/app/services/core_data_connector/import/web_identifiers.rb
@@ -1,0 +1,155 @@
+module CoreDataConnector
+  module Import
+    class WebIdentifiers < Base
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_web_identifiers
+            SET z_web_identifier_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_web_identifiers
+        SQL
+      end
+
+      def load
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_web_identifiers web_identifiers
+             SET z_web_identifier_id = z_web_identifiers.id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_web_identifiers
+           WHERE z_web_identifiers.web_identifier_id = web_identifiers.id
+        SQL
+
+        execute <<-SQL.squish
+          WITH
+
+          insert_web_identifiers AS (
+
+          INSERT INTO core_data_connector_web_identifiers (
+            z_web_identifier_id,
+            identifiable_id,
+            identifiable_type,
+            web_authority_id,
+            identifier,
+            created_at,
+            updated_at
+            )
+          SELECT z_web_identifiers.id,
+                 z_web_identifiers.identifiable_id,
+                 z_web_identifiers.identifiable_type,
+                 z_web_identifiers.web_authority_id,
+                 z_web_identifiers.identifier,
+                 current_timestamp,
+                 current_timestamp
+          FROM   #{table_name} z_web_identifiers
+          WHERE  z_web_identifiers.web_identifier_id IS NULL
+          RETURNING id AS web_identifier_id, z_web_identifier_id
+
+          )
+
+          UPDATE #{table_name} z_web_identifiers
+             SET web_identifier_id = insert_web_identifiers.web_identifier_id
+            FROM insert_web_identifiers
+           WHERE insert_web_identifiers.z_web_identifier_id = z_web_identifiers.id
+        SQL
+      end
+
+      def transform
+        super
+
+        execute <<-SQL.squish
+          WITH
+          
+          related_types AS (
+          SELECT id, uuid, 'CoreDataConnector::Event' AS type
+            FROM core_data_connector_events events
+           WHERE events.z_event_id IS NOT NULL
+           UNION
+          SELECT id, uuid, 'CoreDataConnector::Instance' AS type
+            FROM core_data_connector_instances instances
+           WHERE instances.z_instance_id IS NOT NULL
+          UNION
+          SELECT id, uuid, 'CoreDataConnector::Item' AS type
+            FROM core_data_connector_items items
+           WHERE items.z_item_id IS NOT NULL
+          UNION
+          SELECT id, uuid, 'CoreDataConnector::Organization' AS type
+            FROM core_data_connector_organizations organizations
+           WHERE organizations.z_organization_id IS NOT NULL
+          UNION
+          SELECT id, uuid, 'CoreDataConnector::Person' AS type
+            FROM core_data_connector_people people
+           WHERE people.z_person_id IS NOT NULL
+          UNION
+          SELECT id, uuid, 'CoreDataConnector::Place' AS type
+            FROM core_data_connector_places places
+           WHERE places.z_place_id IS NOT NULL
+          UNION
+          SELECT id, uuid, 'CoreDataConnector::Taxonomy' AS type
+            FROM core_data_connector_taxonomies taxonomies
+           WHERE taxonomies.z_taxonomy_id IS NOT NULL
+          UNION
+          SELECT id, uuid, 'CoreDataConnector::Work' AS type
+            FROM core_data_connector_works works
+           WHERE works.z_work_id IS NOT NULL
+
+        )
+
+        UPDATE #{table_name} z_web_identifiers
+           SET identifiable_id = related_types.id
+          FROM related_types
+         WHERE related_types.uuid = z_web_identifiers.identifiable_uuid
+           AND related_types.type = z_web_identifiers.identifiable_type
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_web_identifiers
+             SET web_identifier_id = web_identifiers.id
+            FROM core_data_connector_web_identifiers web_identifiers
+           WHERE web_identifiers.identifiable_type = z_web_identifiers.identifiable_type
+             AND web_identifiers.identifier = z_web_identifiers.identifier
+             AND web_identifiers.web_authority_id = z_web_identifiers.web_authority_id
+             AND web_identifiers.identifiable_id = z_web_identifiers.identifiable_id
+        SQL
+
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'web_authority_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'identifiable_uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'identifiable_type',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'identifier',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'web_identifier_id',
+          type: 'INTEGER'
+        }, {
+          name: 'identifiable_id',
+          type: 'INTEGER',
+        }]
+      end
+
+      def table_name_prefix
+        'z_web_identifiers'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -1,0 +1,186 @@
+module CoreDataConnector
+  module Import
+    class Works < Base
+      # Includes
+      include Nameable
+
+      def cleanup
+        super
+
+        execute <<-SQL.squish
+          UPDATE core_data_connector_works
+             SET z_work_id = NULL
+        SQL
+
+        execute <<-SQL.squish
+          VACUUM ANALYZE core_data_connector_works, core_data_connector_source_names
+        SQL
+      end
+
+      def load
+        super
+
+        # Update existing works
+        execute <<-SQL.squish
+          UPDATE core_data_connector_works works
+             SET z_work_id = z_works.id,
+                 user_defined = z_works.user_defined,
+                 import_id = z_works.import_id,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_works
+           WHERE z_works.work_id = works.id
+        SQL
+
+        # Insert new works
+        execute <<-SQL.squish
+          WITH
+  
+          insert_works AS (
+  
+          INSERT INTO core_data_connector_works (
+            project_model_id,
+            uuid,
+            z_work_id,
+            user_defined,
+            import_id,
+            created_at,
+            updated_at
+          )
+          SELECT z_works.project_model_id,
+                 z_works.uuid,
+                 z_works.id,
+                 z_works.user_defined,
+                 z_works.import_id,
+                 current_timestamp,
+                 current_timestamp
+            FROM #{table_name} z_works
+           WHERE z_works.work_id IS NULL
+          RETURNING id AS work_id, z_work_id
+  
+          )
+  
+          UPDATE #{table_name} z_works
+             SET work_id = insert_works.work_id
+            FROM insert_works
+           WHERE insert_works.z_work_id = z_works.id
+        SQL
+
+        # Insert new source_names
+        execute <<-SQL.squish
+          WITH 
+  
+          all_work_names AS (
+            
+          SELECT z_works.work_id AS work_id, z_works.primary_name AS name
+            FROM #{table_name} z_works
+           UNION ALL
+          SELECT z_works.work_id AS work_id, unnest(z_works.additional_names) AS name
+            FROM #{table_name} z_works
+          
+          )
+  
+          INSERT INTO core_data_connector_source_names (
+            nameable_id, 
+            nameable_type, 
+            name, 
+            created_at, 
+            updated_at
+          )
+          SELECT all_work_names.work_id, 
+                 'CoreDataConnector::Work', 
+                 all_work_names.name, 
+                 current_timestamp, 
+                 current_timestamp
+            FROM all_work_names
+           WHERE NOT EXISTS ( SELECT 1
+                                FROM core_data_connector_source_names source_names
+                               WHERE source_names.nameable_id = all_work_names.work_id
+                                 AND source_names.nameable_type = 'CoreDataConnector::Work'
+                                 AND source_names.name = all_work_names.name )
+        SQL
+
+        # Reset "primary" indicator for all source_names to FALSE
+        execute <<-SQL.squish
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = FALSE,
+                 updated_at = current_timestamp
+            FROM #{table_name} z_works
+           WHERE z_works.work_id = source_names.nameable_id
+             AND source_names.nameable_type = 'CoreDataConnector::Work'
+        SQL
+
+        # Set the "primary" indicator for source_names to TRUE
+        execute <<-SQL.squish
+          WITH 
+                
+          primary_work_names AS (
+              
+          SELECT z_works.work_id AS work_id, z_works.primary_name AS name
+            FROM #{table_name} z_works
+  
+          )
+  
+          UPDATE core_data_connector_source_names source_names
+             SET "primary" = TRUE,
+                 updated_at = current_timestamp
+            FROM primary_work_names
+           WHERE primary_work_names.work_id = source_names.nameable_id
+             AND primary_work_names.name = source_names.name
+             AND source_names.nameable_type = 'CoreDataConnector::Work'
+        SQL
+      end
+
+      def transform
+        execute <<-SQL.squish
+          UPDATE #{table_name} z_works
+             SET work_id = works.id,
+                 user_defined = works.user_defined
+            FROM core_data_connector_works works
+           WHERE works.uuid = z_works.uuid
+             AND z_works.uuid IS NOT NULL
+        SQL
+
+        transform_names
+
+        super
+      end
+
+      protected
+
+      def column_names
+        [{
+          name: 'project_model_id',
+          type: 'INTEGER',
+          copy: true
+        }, {
+          name: 'uuid',
+          type: 'UUID',
+          copy: true
+        }, {
+          name: 'name',
+          type: 'VARCHAR',
+          copy: true
+        }, {
+          name: 'work_id',
+          type: 'INTEGER'
+        }, {
+          name: 'primary_name',
+          type: 'VARCHAR'
+        }, {
+          name: 'additional_names',
+          type: 'TEXT[]'
+        }, {
+          name: 'user_defined',
+          type: 'JSONB'
+        }, {
+          name: 'import_id',
+          type: 'UUID'
+        }]
+      end
+
+      def table_name_prefix
+        'z_works'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/zip_helper.rb
+++ b/app/services/core_data_connector/import/zip_helper.rb
@@ -1,0 +1,52 @@
+require 'zip'
+
+IGNORE_PATTERN = /\.DS_Store|__MACOSX|(^|\/)\._/
+
+module CoreDataConnector
+  module Import
+    class ZipHelper
+      def import_zip(temp_file)
+        begin
+          # Create the target directory
+          destination = "#{Rails.root}/tmp/#{SecureRandom.urlsafe_base64}"
+          FileUtils.mkdir_p(destination) unless File.exist? destination
+      
+          # Extract the zip file to the directory
+          Zip::File.open(temp_file) do |zipfile|
+            zipfile.each do |entry|
+              # Ignore directories
+              next unless entry.file?
+      
+              # Ignore MacOS archive
+              next if entry.name =~ IGNORE_PATTERN
+      
+              # Extract the file
+              zipfile.extract(entry, File.join(destination, entry.name))
+            end
+          end
+
+          import_id = nil
+
+          # Create a new importer with the temp directory and run it
+          importer = CoreDataConnector::Import::Importer.new(destination)
+
+          ActiveRecord::Base.transaction do
+            import_id = importer.run
+          end
+
+          # Perform any clean up operations and close the importer
+          importer.close
+      
+          # Remove the temporary directory
+          FileUtils.rm_rf(destination)
+      
+          return true, [], import_id
+        rescue ActiveRecord::RecordInvalid => exception
+          return false, [exception]
+        rescue StandardError => exception
+          return false, [exception]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/base.rb
+++ b/app/services/core_data_connector/import_analyze/base.rb
@@ -1,0 +1,40 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def base_query
+          all
+        end
+
+        def group_by_columns
+          # Implemented in sub-classes
+        end
+
+        def find_duplicates(project_id)
+          primary_key = "#{table_name}.id"
+
+          group_columns = [
+            :project_model_id,
+            *group_by_columns
+          ]
+
+          select_columns = [
+            *group_columns,
+            "MIN(#{primary_key}) AS primary_id",
+            "ARRAY_REMOVE(ARRAY_AGG(#{primary_key}), MIN(#{primary_key})) AS duplicate_ids"
+          ]
+
+          base_query
+            .select(select_columns)
+            .joins(:project_model)
+            .where(project_model: { project_id: project_id })
+            .group(group_columns)
+            .having('COUNT(*) > 1')
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/event.rb
+++ b/app/services/core_data_connector/import_analyze/event.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Event
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def group_by_columns
+          [CoreDataConnector::Event.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/helper.rb
+++ b/app/services/core_data_connector/import_analyze/helper.rb
@@ -1,0 +1,88 @@
+module CoreDataConnector
+  module ImportAnalyze
+    class Helper
+
+      PREFIX_USER_DEFINED = 'udf_'
+
+      PRELOADS = [
+        :project_model,
+        relationships: [:related_record, project_model_relationship: :user_defined_fields],
+        related_relationships: [:primary_record, project_model_relationship: :user_defined_fields],
+      ]
+
+      def self.column_name_to_uuid(column_name)
+        column_name.gsub(PREFIX_USER_DEFINED, '').gsub('_', '-')
+      end
+
+      def self.is_user_defined_column?(column_name)
+        column_name.starts_with?(PREFIX_USER_DEFINED)
+      end
+
+      def self.user_defined_columns(filepath)
+        CSV.foreach(filepath).first.select{ |h| is_user_defined_column?(h) }
+      end
+
+      def self.uuid_to_column_name(uuid)
+        "#{PREFIX_USER_DEFINED}#{uuid.gsub('-', '_')}"
+      end
+
+      def analyze(zip, user)
+        # Create a temporary directory
+        directory = FileSystem.create_directory
+
+        # Extract the CSV files
+        FileSystem.extract_zip(zip, directory)
+
+        # Analyze the import files
+        service = Import.new
+        data = service.analyze(directory)
+
+        # Check that the user is authorized to import all of the records in the file
+        policy = Policy.new(user, data)
+        raise Pundit::NotAuthorizedError, I18n.t('errors.import.authorize') unless policy.has_analyze_access?
+
+        # Remove the temporary directory
+        FileSystem.remove_directory(directory)
+
+        data
+      end
+
+      def import(files, user, project_id)
+        # Check that the user is authorized to import all of the records in the file
+        policy = Policy.new(user, files)
+        raise Pundit::NotAuthorizedError, I18n.t('errors.import.authorize') unless policy.has_import_access?
+
+        # Generate the CSV files and compress them in a ZIP
+        service = Import.new
+        zip_filepath = service.create_zip(files)
+
+        # Create the background job
+        filenames = files
+                      .keys
+                      .filter_map { |filename| filename if files[filename][:remove_duplicates].to_s.to_bool }
+                      .compact
+
+        extra = { filenames: }
+
+        file = {
+          io: File.open(zip_filepath),
+          filename: File.basename(zip_filepath)
+        }
+
+        job = Job.create(
+          extra:,
+          file:,
+          job_type: Job::JOB_TYPE_IMPORT,
+          project_id:,
+          user:
+        )
+
+        # Remove the ZIP file directory
+        directory = File.dirname(zip_filepath)
+        FileSystem.remove_directory(directory)
+
+        job.errors
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/import.rb
+++ b/app/services/core_data_connector/import_analyze/import.rb
@@ -1,0 +1,363 @@
+require 'csv'
+
+module CoreDataConnector
+  module ImportAnalyze
+    class Import
+
+      FILE_RELATIONSHIPS = 'relationships.csv'
+      FILE_WEB_IDENTIFIERS = 'web_identifiers.csv'
+
+      def analyze(directory)
+        data = {}
+
+        pattern = File.join(directory, '*.csv')
+
+        Dir.glob(pattern).each do |filepath|
+          filename = File.basename(filepath)
+
+          # Analyzing web identifiers is currently not supported
+          next if filename == FILE_WEB_IDENTIFIERS
+
+          klass = find_class(filename)
+
+          user_defined_columns = Helper.user_defined_columns(filepath)
+          user_defined_fields_uuids = user_defined_columns.map { |c| Helper.column_name_to_uuid(c) }
+
+          user_defined_fields = UserDefinedFields::UserDefinedField
+                                  .where(uuid: user_defined_fields_uuids)
+
+          attributes = build_attributes(klass, user_defined_fields)
+          uuids = find_record_uuids(filepath)
+
+          records_by_uuid = find_records_by_uuid(klass, uuids)
+          merges_by_uuid = find_merges_by_uuid(klass, uuids)
+
+          CSV.foreach(filepath, headers: true, converters: [:numeric]) do |row|
+            data[filename] ||= { attributes: attributes, data: [] }
+
+            row_hash = row_to_csv(row, user_defined_fields)
+            record = records_by_uuid[row_hash[:uuid]]
+
+            if record.present?
+              db = record_to_csv(record, user_defined_fields)
+              merged = record.record_merges.map { |rm| rm.merged_uuid } if record.is_a?(Mergeable)
+            end
+
+            data[filename][:data] << {
+              import: row_hash,
+              db: db,
+              merged: merged,
+              result: db || row_hash
+            }
+
+            # If the current record has been merged and removed, add a row for the record existing in the database. The
+            # merged row will be picked up below and flagged as a merged record.
+            merge_record = merges_by_uuid[row_hash[:uuid]]
+
+            if merge_record.present?
+              # If multiple records in the current import have been merged into an existing record, only add one
+              # record to the file. Other duplicates will be listed in the "merged" attribute.
+              existing = data[filename][:data].select { |r| r[:merged]&.include?(row_hash[:uuid]) }
+
+              if !existing.present?
+                merge_row_hash = record_to_csv(merge_record, user_defined_fields)
+
+                data[filename][:data] << {
+                  import: merge_row_hash,
+                  db: merge_row_hash,
+                  merged: merge_record.record_merges.map { |rm| rm.merged_uuid },
+                  result: merge_row_hash
+                }
+              end
+            end
+          end
+        end
+
+        # Iterate over the data set and remove any already merged rows, adding them to the "merged" attribute
+        # for the row of the primary record.
+        relationship_data = data.dig(FILE_RELATIONSHIPS, :data)
+
+        data.keys.each do |filename|
+          rows = data[filename][:data]
+
+          rows.each do |row|
+            next unless row[:merged].present?
+
+            # Find the rows containing the duplicates and add them to the current row
+            duplicates = []
+
+            row[:merged].each do |uuid|
+              # Find all of the records in the current file that have been merged into the current row
+              duplicate = rows.select { |r| r[:import][:uuid] == uuid }&.first
+              duplicates << duplicate if duplicate.present?
+
+              # Move to the next record if no relationship data is present
+              next unless relationship_data.present?
+
+              # Update relationships where the "primary_record_uuid" matches the merged row
+              update_relationships(relationship_data, :primary_record_uuid, uuid, row[:import][:uuid])
+
+              # Update relationships where the "related_record_uuid" matches the merged row
+              update_relationships(relationship_data, :related_record_uuid, uuid, row[:import][:uuid])
+            end
+
+            row[:duplicates] = duplicates.map { |d| d[:import] }
+
+            # Delete the duplicate rows
+            duplicates.each { |d| rows.delete(d) }
+          end
+
+        end
+
+        # De-duplicate relationships
+        relationship_data&.each&.with_index do |row, i|
+          next if row[:keep].present?
+
+          # Find relationship rows where all fields match the current row except the index
+          relationship = row[:import].except(:uuid)
+          duplicates = relationship_data.select.with_index { |r, j|  i != j && r[:import].except(:uuid) == relationship }
+
+          # Keep row with an existing record in the database, or the first. Mark all other for delete.
+          all = [row, *duplicates]
+          keep = all.select{ |r| r[:db].present? }&.first
+          keep = all.first unless keep.present?
+
+          keep[:keep] = true
+          (all - [keep]).each{ |r| r[:keep] = false }
+        end
+
+        # Remove any rows not marked with "keep"
+        relationship_data.delete_if { |r| r[:keep] != true } if relationship_data.present?
+
+        data
+      end
+
+      def create_zip(files)
+        return nil unless files.present?
+
+        # Create the temporary directory
+        directory = FileSystem.create_directory
+
+        # Generate the CSV files from the passed files hash
+        files.keys.each do |filename|
+          CSV.open("#{directory}/#{filename}", 'w') do |csv|
+            records = files[filename][:data]
+            csv << records.first.keys
+
+            records.each do |record|
+              csv << record.values
+            end
+          end
+        end
+
+        # Zip the generated CSV files
+        zipfile_name = "#{directory}/archive.zip"
+        pattern = File.join(directory, '*.csv')
+
+        Zip::File.open(zipfile_name, create: true) do |zipfile|
+          Dir.glob(pattern).each do |filepath|
+            zipfile.add(File.basename(filepath), filepath)
+          end
+        end
+
+        # Return the file path to the created zip file
+        zipfile_name
+      end
+
+      def remove_duplicates(project_id, filenames)
+        return unless project_id.present? && filenames.present?
+
+        service = Merge::Merger.new
+
+        filenames.each do |filename|
+          klass = find_class(filename)
+          grouped_duplicates = klass.find_duplicates(project_id)
+
+          next if grouped_duplicates.empty?
+
+          grouped_duplicates.each do |group|
+            primary = klass.preload(ImportAnalyze::Helper::PRELOADS).find(group.primary_id)
+            duplicates = klass.preload(ImportAnalyze::Helper::PRELOADS).where(id: group.duplicate_ids)
+
+            service.merge(primary, duplicates)
+          end
+        end
+      end
+
+      private
+
+      def apply_preloads(klass, records)
+        if klass.ancestors.include?(Mergeable)
+          Preloader.new(
+            records: records,
+            associations: [:record_merges]
+          ).call
+        end
+
+        # Preload any associations from the concrete class
+        if klass.respond_to?(:export_preloads) && klass.export_preloads.present?
+          Preloader.new(
+            records: records,
+            associations: klass.export_preloads
+          ).call
+        end
+      end
+
+      def build_attributes(klass, user_defined_fields)
+        attributes = []
+
+        klass.export_attributes.each do |attribute|
+          attributes << {
+            name: attribute[:name],
+            label: translate(klass, attribute)
+          }
+        end
+
+        serializer = UserDefinedFields::UserDefinedFieldsSerializer.new
+
+        user_defined_fields.each do |user_defined_field|
+          attributes << {
+            name: Helper.uuid_to_column_name(user_defined_field.uuid),
+            label: user_defined_field.column_name,
+            field: serializer.render_show(user_defined_field)
+          }
+        end
+
+        attributes
+      end
+
+      def find_class(filename)
+        "CoreDataConnector::#{File.basename(filename, '.csv').singularize.capitalize}".classify.constantize
+      end
+
+      def find_record_uuids(filepath)
+        uuids = []
+
+        CSV.foreach(filepath, headers: true, converters: [:numeric]) do |row|
+          uuids << row.to_h.symbolize_keys[:uuid]
+        end
+
+        uuids
+      end
+
+      def find_merges_by_uuid(klass, uuids)
+        return {} unless klass.ancestors.include?(Mergeable)
+
+        merges_by_uuid = {}
+
+        query = klass.all
+        query = query.merge(klass.export_query) if klass.respond_to?(:export_query)
+
+        query = query.where(
+          RecordMerge
+            .where(RecordMerge.arel_table[:mergeable_id].eq(klass.arel_table[:id]))
+            .where(mergeable_type: klass.to_s)
+            .where(merged_uuid: uuids)
+            .arel
+            .exists
+        )
+
+        query.find_in_batches(batch_size: 1000) do |records|
+          apply_preloads klass, records
+
+          records.each do |record|
+            record.record_merges.each do |record_merge|
+              merges_by_uuid[record_merge.merged_uuid] = record
+            end
+          end
+        end
+
+        merges_by_uuid
+      end
+
+      def find_records_by_uuid(klass, uuids)
+        records_by_uuid = {}
+
+        query = klass.all
+        query = query.merge(klass.export_query) if klass.respond_to?(:export_query)
+        query = query.where(uuid: uuids)
+
+        query.find_in_batches(batch_size: 1000) do |records|
+          apply_preloads klass, records
+
+          records.each do |record|
+            records_by_uuid[record.uuid] = record
+          end
+        end
+
+        records_by_uuid
+      end
+
+      def record_to_csv(record, user_defined_fields)
+        csv = record.to_export_csv(user_defined_fields)
+
+        user_defined_fields.each do |user_defined_field|
+          key = Helper.uuid_to_column_name(user_defined_field.uuid)
+
+          # If the value exists in the hash, extract it. Otherwise add the key to the hash with a nil value.
+          if csv.key?(key)
+            value = csv[key]
+          else
+            csv[key] = nil
+          end
+
+          next unless value.present?
+
+          # Since the "to_export_csv" method will serialize JSON to strings, we'll convert it back to JSON
+          # here in order to do proper comparison on the client.
+          if (user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:select] &&
+            user_defined_field.allow_multiple?) ||
+            user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:fuzzy_date]
+            csv[key] = JSON.parse(value)
+          end
+        end
+
+        csv
+      end
+
+      def row_to_csv(row, user_defined_fields)
+        csv = row.to_h
+
+        user_defined_fields.each do |user_defined_field|
+          key = Helper.uuid_to_column_name(user_defined_field.uuid)
+          next unless csv[key].present?
+
+          if user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:boolean] ||
+            user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:number] ||
+            user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:string]
+            csv[key] = csv[key].to_s
+          elsif user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:select] &&
+            user_defined_field.allow_multiple?
+            csv[key] = JSON.parse(csv[key])
+          elsif user_defined_field.data_type == UserDefinedFields::UserDefinedField::DATA_TYPES[:fuzzy_date]
+            csv[key] = JSON.parse(csv[key])
+          end
+        end
+
+        csv.symbolize_keys
+      end
+
+      def translate(klass, attribute)
+        model_path = "services.import_analyze.#{klass.model_name.route_key}.#{attribute[:name]}"
+        common_path = "services.import_analyze.common.#{attribute[:name]}"
+
+        I18n.t(model_path, default: nil) || I18n.t(common_path, default: nil) || attribute[:name]
+      end
+
+      def update_relationships(relationship_data, attribute, find_uuid, new_uuid)
+        relationships = relationship_data.select{ |r| r[:import][attribute] == find_uuid }
+
+        relationships.each do |relationship|
+          # Create the new relationships row
+          new_relationship = relationship[:import].merge({ attribute => new_uuid })
+
+          # Add the new row to the relationships data set
+          relationship_data << { import: new_relationship }
+
+          # Delete the existing relationship
+          relationship_data.delete(relationship)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/instance.rb
+++ b/app/services/core_data_connector/import_analyze/instance.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Instance
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [CoreDataConnector::SourceName.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/item.rb
+++ b/app/services/core_data_connector/import_analyze/item.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Item
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [CoreDataConnector::SourceName.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/media_content.rb
+++ b/app/services/core_data_connector/import_analyze/media_content.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module MediaContent
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def group_by_columns
+          [CoreDataConnector::MediaContent.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/organization.rb
+++ b/app/services/core_data_connector/import_analyze/organization.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Organization
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [CoreDataConnector::OrganizationName.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/person.rb
+++ b/app/services/core_data_connector/import_analyze/person.rb
@@ -1,0 +1,23 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Person
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [
+            CoreDataConnector::PersonName.arel_table[:last_name],
+            CoreDataConnector::PersonName.arel_table[:first_name]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/place.rb
+++ b/app/services/core_data_connector/import_analyze/place.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Place
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [CoreDataConnector::PlaceName.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/policy.rb
+++ b/app/services/core_data_connector/import_analyze/policy.rb
@@ -1,0 +1,98 @@
+module CoreDataConnector
+  module ImportAnalyze
+    class Policy
+
+      attr_reader :current_user, :files
+
+      def initialize(current_user, files)
+        @current_user = current_user
+        @files = files
+      end
+
+      # A user can analyze the set of files if they are an admin or have access to the project(s) containing all of the
+      # models and relationships they are attempting to import.
+      def has_analyze_access?
+        return true if current_user.admin?
+
+        project_model_ids = files
+                              &.except(Import::FILE_RELATIONSHIPS)
+                              &.values
+                              &.map{ |v| v[:data]&.map{ |d| d[:import][:project_model_id] } }
+                              &.flatten
+                              &.uniq
+
+        project_model_relationship_ids = (files.dig(Import::FILE_RELATIONSHIPS, :data) || [])
+                                           &.map{ |v| v[:import][:project_model_relationship_id] }
+                                           &.flatten
+                                           &.uniq
+
+        has_access?(project_model_ids, project_model_relationship_ids)
+      end
+
+      # A user can import the set of files if they are an admin or have access to the project(s) containing all of the
+      # models and relationships they are attempting to import.
+      def has_import_access?
+        return true if current_user.admin?
+
+        project_model_ids = files
+                              &.except(Import::FILE_RELATIONSHIPS)
+                              &.values
+                              &.map{ |v| v['data']&.map{ |d| d['project_model_id'] } }
+                              &.flatten
+                              &.uniq
+
+        project_model_relationship_ids = (files.dig(Import::FILE_RELATIONSHIPS, :data) || [])
+                                           &.map{ |v| v['project_model_relationship_id'] }
+                                           &.uniq
+
+        has_access?(project_model_ids, project_model_relationship_ids)
+      end
+
+      private
+
+      def has_access?(project_model_ids, project_model_relationship_ids)
+        # Return false if the data being imported belongs to a model for which the user does not have access
+        allowed_project_model_ids = project_models_query.pluck(:id)
+        return false unless project_model_ids.all? { |id| allowed_project_model_ids.include?(id) }
+
+        # Return true if we're not importing any relationships
+        return true if project_model_relationship_ids.nil? || project_model_relationship_ids.empty?
+
+        # Return false if the relationship data being imported belongs to a model for which the user does not have access
+        allowed_project_model_relationship_ids = project_model_relationships_query.pluck(:id)
+        return false unless project_model_relationship_ids.all?{ |id| allowed_project_model_relationship_ids.include?(id) }
+
+        # Return true
+        true
+      end
+
+      def project_models_query
+        ProjectModel
+          .where(
+            Project
+              .joins(:user_projects)
+              .where(Project.arel_table[:id].eq(ProjectModel.arel_table[:project_id]))
+              .where(user_projects: { user_id: current_user.id })
+              .where.not(archived: true)
+              .arel
+              .exists
+          )
+      end
+
+      def project_model_relationships_query
+        ProjectModelRelationship
+          .where(
+            ProjectModel
+              .joins(project: :user_projects)
+              .where(
+                ProjectModel.arel_table[:id].eq(ProjectModelRelationship.arel_table[:primary_model_id])
+                            .or(ProjectModel.arel_table[:id].eq(ProjectModelRelationship.arel_table[:related_model_id])))
+              .where(user_projects: { user_id: current_user.id })
+              .where.not(project: { archived: true })
+              .arel
+              .exists
+          )
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/taxonomy.rb
+++ b/app/services/core_data_connector/import_analyze/taxonomy.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def group_by_columns
+          [CoreDataConnector::Taxonomy.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import_analyze/work.rb
+++ b/app/services/core_data_connector/import_analyze/work.rb
@@ -1,0 +1,20 @@
+module CoreDataConnector
+  module ImportAnalyze
+    module Work
+      extend ActiveSupport::Concern
+
+      # Includes
+      include Base
+
+      class_methods do
+        def base_query
+          joins(:primary_name)
+        end
+
+        def group_by_columns
+          [CoreDataConnector::SourceName.arel_table[:name]]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/map_library.rb
+++ b/app/services/core_data_connector/map_library.rb
@@ -1,0 +1,16 @@
+module CoreDataConnector
+  class MapLibrary
+    include Http::Requestable
+
+    def initialize(map_library_url)
+      @map_library_url = map_library_url
+    end
+
+    def fetch_library
+      params = {}
+      send_request(@map_library_url, method: :get, params: params) do |body|
+        JSON.parse(body)
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/merge/merger.rb
+++ b/app/services/core_data_connector/merge/merger.rb
@@ -1,0 +1,109 @@
+module CoreDataConnector
+  module Merge
+    class Merger
+      MANIFEST_ATTRIBUTES = [
+        :project_model_relationship_id
+      ]
+
+      MERGE_ATTRIBUTES = [
+        :merged_uuid
+      ]
+
+      RELATIONSHIP_ATTRIBUTES = [
+        :project_model_relationship_id,
+        :primary_record_type,
+        :related_record_id,
+        :related_record_type,
+        :user_defined
+      ]
+
+      RELATED_RELATIONSHIP_ATTRIBUTES = [
+        :project_model_relationship_id,
+        :primary_record_id,
+        :primary_record_type,
+        :related_record_type,
+        :user_defined
+      ]
+
+      WEB_IDENTIFIER_ATTRIBUTES = [
+        :web_authority_id,
+        :identifier,
+        :extra
+      ]
+
+      def merge(new_record, merged_records)
+        manifests = []
+        record_merges = []
+        relationships = []
+        related_relationships = []
+        web_identifiers = []
+
+        merged_records.each do |record|
+          # Append the manifests from the merged record(s) to the new record
+          record.manifests.each { |manifest| add_item(manifests, manifest, MANIFEST_ATTRIBUTES) }
+
+          # Append the merges from the merged record(s) to the new record
+          record.record_merges.each { |record_merge| add_item(record_merges, record_merge, MERGE_ATTRIBUTES) }
+
+          # Create a record_merge for the merged record(s)
+          unless record.uuid == new_record.uuid
+            record_merges << RecordMerge.new(
+              merged_uuid: record.uuid,
+              merged_name: record.display_name
+            )
+          end
+
+          # Append the relationships from the merged record(s) to the new record
+          record.relationships.each { |relationship| add_item(relationships, relationship, RELATIONSHIP_ATTRIBUTES) }
+          record.related_relationships.each { |relationship| add_item(related_relationships, relationship, RELATED_RELATIONSHIP_ATTRIBUTES) }
+
+          # Append the web identifiers from the merged record(s) to the new record
+          record.web_identifiers.each { |web_identifier| add_item(web_identifiers, web_identifier, WEB_IDENTIFIER_ATTRIBUTES) }
+        end
+
+        # Add the manifests to the new record
+        manifests.each { |manifest| manifest.manifestable = new_record }
+        new_record.manifests.build(manifests.map(&:as_json))
+
+        # Add the merges to the new record
+        record_merges.each { |record_merge| record_merge.mergeable = new_record }
+        new_record.record_merges.build(record_merges.map(&:as_json))
+
+        # Add the relationships to the new record
+        relationships.each { |relationship| relationship.primary_record = new_record }
+        new_record.relationships.build(relationships.map(&:as_json))
+
+        related_relationships.each { |relationship| relationship.related_record = new_record }
+        new_record.related_relationships.build(related_relationships.map(&:as_json))
+
+        # Add web identifiers to the new record
+        web_identifiers.each { |web_identifier| web_identifier.identifiable = new_record }
+        new_record.web_identifiers.build(web_identifiers.map(&:as_json))
+
+        # Save the new record
+        success = new_record.save
+
+        if success
+          # Re-generate manifests
+          service = Iiif::Manifest.new
+          service.reset_manifests_by_type(new_record.class, { id: new_record.id })
+
+          # Destroy the merged records
+          merged_records.destroy_all
+        end
+      end
+
+      private
+
+      def add_item(array, item, attrs)
+        included = false
+
+        array.each do |i|
+          included = true and break if attrs.all? { |attr| i[attr] == item[attr] }
+        end
+
+        array << item.dup unless included
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/queries.rb
+++ b/app/services/core_data_connector/queries.rb
@@ -1,0 +1,43 @@
+module CoreDataConnector
+  class Queries
+
+    def self.all_fields_by_project(project_id)
+      project_models_query(project_id)
+        .or(project_model_relationships_query(project_id))
+    end
+
+    private
+
+    def self.project_models_query(project_id)
+      subquery = ProjectModel
+                   .where(ProjectModel.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                   .where(project_id: project_id)
+                   .arel
+                   .exists
+
+      UserDefinedFields::UserDefinedField
+        .where(defineable_type: ProjectModel.to_s)
+        .where(subquery)
+    end
+
+    def self.project_model_relationships_query(project_id)
+      subquery = ProjectModelRelationship
+                   .where(ProjectModelRelationship.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                   .joins(:primary_model, :related_model)
+                   .where(primary_model: { project_id: project_id })
+                   .or(
+                     ProjectModelRelationship
+                       .where(ProjectModelRelationship.arel_table[:id].eq(UserDefinedFields::UserDefinedField.arel_table[:defineable_id]))
+                       .joins(:primary_model, :related_model)
+                       .where(related_model: { project_id: project_id })
+                   )
+                   .arel
+                   .exists
+
+      UserDefinedFields::UserDefinedField
+        .where(defineable_type: ProjectModelRelationship.to_s)
+        .where(subquery)
+    end
+
+  end
+end

--- a/app/services/core_data_connector/reconcile/base.rb
+++ b/app/services/core_data_connector/reconcile/base.rb
@@ -1,0 +1,82 @@
+module CoreDataConnector
+  module Reconcile
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+
+        def apply_reconcile_preloads(records)
+          # Preload any associations from the concrete class
+          if self.respond_to?(:preloads) && preloads.present?
+            Preloader.new(
+              records: records,
+              associations: preloads
+            ).call
+          end
+        end
+
+        def for_reconcile(project_id, &block)
+          # Base query
+          query = all_records_by_project(project_id)
+
+          # Concrete class query
+          query = search_query(query) if self.respond_to?(:search_query)
+
+          query.find_in_batches(batch_size: 1000) do |records|
+            # Apply the preloads for the current batch
+            apply_reconcile_preloads records
+
+            # Call the block for the current batch
+            block.call(records)
+          end
+        end
+
+        def reconcile_attribute(*attrs, &block)
+          name, options = attrs
+
+          @reconcile_attrs ||= []
+          @reconcile_attrs << { name: name, block: block}.merge(options || {})
+        end
+
+        def reconcile_attributes
+          @reconcile_attrs
+        end
+
+      end
+
+      included do
+        # Include the ID attributes as a string by default
+        reconcile_attribute(:id) { uuid }
+        reconcile_attribute(:record_id) { id.to_s }
+        reconcile_attribute(:project_model_id) { project_model_id.to_s }
+        reconcile_attribute :uuid
+        reconcile_attribute(:type) { self.class.to_s }
+
+        def to_reconcile_json
+          hash = {}
+
+          # Add attributes defined by the concrete-class
+          self.class.reconcile_attributes.each do |attr|
+            name = attr[:name]
+
+            # Extract the value for the attribute
+            if attr[:block].present?
+              value = instance_exec &attr[:block]
+            else
+              value = self.send(attr[:name])
+            end
+
+            # Skip the property of the value is empty
+            next if value.nil?
+
+            # Add the name/value pair to the JSON
+            hash[name] = value
+          end
+
+          hash
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/event.rb
+++ b/app/services/core_data_connector/reconcile/event.rb
@@ -1,0 +1,53 @@
+module CoreDataConnector
+  module Reconcile
+    module Event
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:start_date, :end_date]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+        reconcile_attribute :description
+
+        reconcile_attribute(:start_date) do
+          resolve_date start_date
+        end
+
+        reconcile_attribute(:end_date) do
+          resolve_date end_date
+        end
+
+        reconcile_attribute(:start_year) do
+          resolve_year start_date
+        end
+
+        reconcile_attribute(:end_year) do
+          resolve_year end_date
+        end
+
+        private
+
+        def resolve_date(date)
+          return [] unless date.present?
+
+          [date.start_date&.to_time&.to_i, date.end_date&.to_time&.to_i]
+        end
+
+        def resolve_year(date)
+          return [] unless date.present?
+
+          [date.start_date&.strftime('%Y')&.to_i, date.end_date&.strftime('%Y')&.to_i]
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/instance.rb
+++ b/app/services/core_data_connector/reconcile/instance.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Reconcile
+    module Instance
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:name) do
+          primary_name.name
+        end
+
+        reconcile_attribute(:names) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/item.rb
+++ b/app/services/core_data_connector/reconcile/item.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Reconcile
+    module Item
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:names) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/manager.rb
+++ b/app/services/core_data_connector/reconcile/manager.rb
@@ -1,0 +1,113 @@
+module CoreDataConnector
+  module Reconcile
+    class Manager
+
+      def send_request(queries, credentials)
+        client = Typesense.create_client(**credentials.except(:collection_name))
+
+        common_params = {
+          query_by: 'name'
+        }
+
+        params = build_params(queries, credentials[:collection_name])
+        response = client.multi_search.perform(params, common_params)
+
+        transform response, queries.keys
+      end
+
+      private
+
+      def build_params(queries, collection)
+        searches = []
+
+        queries.keys.each do |key|
+          query = queries[key]
+
+          # Append "collection" and "query" parameters
+          search = { collection:, q: query[:query] }
+
+          # Append "filter_by" parameter, if present
+          if query[:type].present?
+            types = Array.wrap(query[:type])
+
+            # filter by project model ID and/or model_class
+            project_model_ids = []
+            class_names = []
+            types.each do |t|
+              if t.start_with?('model:')
+                project_model_ids << t.split(':', 2).last
+              elsif t.start_with?('type:')
+                class_names << t.split(':', 2).last
+              else
+                class_names << t
+              end
+            end
+
+            # collect into typesense filters
+            filters = []
+            filters << "type:[#{class_names.join(',')}]" if class_names.any?
+            filters << "project_model_id:[#{project_model_ids.join(',')}]" if project_model_ids.any?
+
+            # join by typesense OR
+            search[:filter_by] = filters.join(' || ') if filters.any?
+          end
+
+          # Append "limit" parameter, if present
+          search[:limit] = query[:limit] if query[:limit].present?
+
+          searches << search
+        end
+
+        { searches: }
+      end
+
+      def transform(response, keys)
+        json = {}
+
+        response['results'].each_with_index do |result, index|
+          json[keys[index]] = transform_results(result['hits'])
+        end
+
+        json
+      end
+
+      def transform_result(result)
+        klass = result['document']['type'].constantize
+        project_model_id = result['document']['project_model_id']
+
+        attributes = {
+          score: result['text_match'],
+          match: false,
+          type: [
+            {
+              id: "type:#{klass.to_s}",
+              name: klass.name.demodulize
+            },
+            {
+              id: "model:#{project_model_id}",
+              name: "#{klass.name.demodulize} model #{project_model_id}"
+            },
+            # retain bare model_class string for backwards compatibility
+            {
+              id: klass.to_s,
+              name: klass.name.demodulize
+            }
+          ]
+        }
+
+        all_attributes = result['document'].merge(attributes).symbolize_keys
+        transformed = ActiveSupport::InheritableOptions.new(all_attributes)
+
+        # For some reason, adding "present" to the constructor does not work
+        transformed.present = true
+
+        transformed
+      end
+
+      def transform_results(results)
+        results.map { |result| transform_result(result) }
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/organization.rb
+++ b/app/services/core_data_connector/reconcile/organization.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Reconcile
+    module Organization
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :organization_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+        reconcile_attribute :description
+
+        reconcile_attribute(:names) do
+          organization_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/person.rb
+++ b/app/services/core_data_connector/reconcile/person.rb
@@ -1,0 +1,36 @@
+module CoreDataConnector
+  module Reconcile
+    module Person
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :person_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute(:description) do
+          biography
+        end
+
+        reconcile_attribute(:name) do
+          create_name primary_name
+        end
+
+        reconcile_attribute(:names, facet: true) do
+          person_names.map { |n| create_name(n) }
+        end
+
+        def create_name(person_name)
+          [person_name.first_name, person_name.middle_name, person_name.last_name].compact.join(' ')
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/place.rb
+++ b/app/services/core_data_connector/reconcile/place.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Reconcile
+    module Place
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :place_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:names) do
+          place_names.map(&:name)
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/taxonomy.rb
+++ b/app/services/core_data_connector/reconcile/taxonomy.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Reconcile
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/reconcile/work.rb
+++ b/app/services/core_data_connector/reconcile/work.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Reconcile
+    module Work
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        reconcile_attribute :name
+
+        reconcile_attribute(:names) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -1,0 +1,545 @@
+module CoreDataConnector
+  module Search
+    module Base
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def apply_preloads(records, project_model_ids)
+          # Preload project_model
+          Preloader.new(
+            records: records,
+            associations: [
+              project_model: [:project, :user_defined_fields]
+            ]
+          ).call
+
+          # Preload any associations from the concrete class
+          if self.respond_to?(:preloads) && preloads.present?
+            Preloader.new(
+              records: records,
+              associations: preloads
+            ).call
+          end
+
+          # Preload primary relationships
+          Preloader.new(
+            records: records,
+            associations: [
+              event_relationships: [
+                related_record: [
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              instance_relationships: [
+                related_record: [
+                  :primary_name,
+                  :source_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              item_relationships: [
+                related_record: [
+                  :primary_name,
+                  :source_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              media_content_relationships: [
+                related_record: [
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              organization_relationships: [
+                related_record: [
+                  :primary_name,
+                  :organization_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              person_relationships: [
+                related_record: [
+                  :primary_name,
+                  :person_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              place_relationships: [
+                related_place_with_search_geometry: [
+                  :place_geometry,
+                  :primary_name,
+                  :place_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              taxonomy_relationships: [
+                related_record: [
+                  :name,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ],
+              work_relationships: [
+                related_record: [
+                  :primary_name,
+                  :source_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, primary_model: :project]
+              ]
+            ],
+            scope: (
+              Relationship
+                .joins(:project_model_relationship)
+                .where(core_data_connector_project_model_relationships: { primary_model_id: project_model_ids })
+            )
+          ).call
+
+          # Preload related relationships
+          Preloader.new(
+            records: records,
+            associations: [
+              event_related_relationships: [
+                primary_record: [
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              instance_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :source_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              item_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :source_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              media_content_related_relationships: [
+                primary_record: [
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              organization_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :organization_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              person_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :person_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              place_related_relationships: [
+                inverse_related_place_with_search_geometry: [
+                  :place_geometry,
+                  :primary_name,
+                  :place_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              taxonomy_related_relationships: [
+                primary_record: [
+                  :name,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+              work_related_relationships: [
+                primary_record: [
+                  :primary_name,
+                  :source_names,
+                  project_model: :user_defined_fields
+                ],
+                project_model_relationship: [:user_defined_fields, related_model: :project]
+              ],
+            ],
+            scope: (
+              Relationship
+                .joins(:project_model_relationship)
+                .where(core_data_connector_project_model_relationships: { related_model_id: project_model_ids })
+            )
+          ).call
+        end
+
+        def for_search(project_model_ids, &block)
+          # Base query
+          query = all_records_by_project_model(project_model_ids)
+
+          # Concrete class query
+          query = search_query(query) if self.respond_to?(:search_query)
+
+          query.find_in_batches(batch_size: 1000) do |records|
+            # Apply the preloads for the current batch
+            apply_preloads records, project_model_ids
+
+            # Call the block for the current batch
+            block.call(records)
+          end
+        end
+
+        def search_attribute(*attrs, &block)
+          name, options = attrs
+
+          @attrs ||= []
+          @attrs << { name: name, block: block}.merge(options || {})
+        end
+
+        def search_attributes
+          @attrs
+        end
+      end
+
+      included do
+        # Includes
+        include UserDefinedFields::Converter
+
+        # Primary relationships
+        has_many :event_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Event.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :instance_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Instance.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :item_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Item.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :media_content_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::MediaContent.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :organization_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Organization.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :person_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Person.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :place_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Place.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :taxonomy_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Taxonomy.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        has_many :work_relationships, -> {
+          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Work.to_s })
+        }, as: :primary_record, class_name: Relationship.to_s
+
+        # Related relationships
+        has_many :event_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Event.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :instance_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Instance.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :item_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Item.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :media_content_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::MediaContent.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :organization_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Organization.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :person_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Person.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :place_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Place.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :taxonomy_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Taxonomy.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        has_many :work_related_relationships, -> {
+          joins(:project_model_relationship)
+            .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Work.to_s })
+            .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+        }, as: :related_record, class_name: Relationship.to_s
+
+        # Include the ID attributes as a string by default
+        search_attribute(:id) { uuid }
+        search_attribute(:record_id) { id.to_s }
+        search_attribute :uuid
+
+        # Uses the specified attributes to create a JSON object. We'll skip relationships by default as to
+        # not create an infinite loop while serializing related records.
+        def to_search_json(options = { include_relationships: false })
+          hash = {}
+
+          # Add attributes defined by the concrete-class
+          self.class.search_attributes.each do |attr|
+            name = attr[:name]
+
+            # Extract the value for the attribute
+            if attr[:block].present?
+              value = instance_exec(options, &attr[:block])
+            else
+              value = self.send(attr[:name])
+            end
+
+            # Skip the property of the value is empty
+            next if value.nil?
+
+            # Add the name/value pair to the JSON
+            hash[name] = value
+
+            # If the attribute should be included as a facet, include the "_facet" attribute
+            hash["#{name}_facet".to_sym] = value if attr[:facet]
+          end
+
+          # Add user-defined fields
+          user_defined_fields = build_user_defined(self, project_model.user_defined_fields)
+          hash.merge!(user_defined_fields)
+
+          projects = []
+
+          # Add a thumbnail URL if one is available
+          set_thumbnail_url(hash)
+
+          # Include related records
+          if options[:include_relationships]
+            build_relationships(hash, projects, options.merge(include_relationships: false))
+
+            # Only include project information for the base record
+            # Add the owning project to the list of all projects
+            add_project(projects, project_model.project)
+
+            # Add the projects to the hash
+            hash['all_projects'] = projects
+
+            # Add the owner project attribute to the hash
+            owner_project = {
+              id: project_model.project.id,
+              name: project_model.project.name,
+              name_facet: project_model.project.name
+            }
+
+            hash['owner_project'] = owner_project
+          end
+
+          # Add the year range for related events
+          build_event_range hash
+
+          hash
+        end
+
+        private
+
+        def add_project(projects, project)
+          return if projects.any?{ |p| p[:id] == project.id }
+
+          projects << { id: project.id, name: project.name, name_facet: project.name }
+        end
+
+        def build_event_range(hash)
+          min_range = nil
+          max_range = nil
+
+          events = [
+            *event_relationships.map{ |r| r.related_record },
+            *event_related_relationships.map{ |r| r.primary_record }
+          ]
+
+          events.each do |event|
+            if min_range.nil? || (event.start_date&.start_date.present? && event.start_date.start_date.year < min_range)
+              min_range = event.start_date&.start_date&.year
+            end
+
+            if min_range.nil? || (event.end_date&.start_date.present? && event.end_date.start_date.year < min_range)
+              min_range = event.end_date&.start_date&.year
+            end
+
+            if max_range.nil? || (event.end_date&.end_date.present? && event.end_date.end_date.year > max_range)
+              max_range = event.end_date&.end_date&.year
+            end
+
+            if max_range.nil? || (event.start_date&.end_date.present? && event.start_date.end_date.year > max_range)
+              max_range = event.start_date&.end_date&.year
+            end
+          end
+
+          hash['event_range_facet'] = [min_range, max_range] unless min_range.nil? || max_range.nil?
+        end
+
+        def build_inverse_place_relationship(relationship, hash, projects, options)
+          project_model_relationship = relationship.project_model_relationship
+          key = project_model_relationship.uuid
+
+          # Add the related model project to the list of projects
+          add_project(projects, project_model_relationship.related_model.project)
+
+          user_defined = build_user_defined(relationship, project_model_relationship.user_defined_fields)
+
+          hash[key] ||= []
+
+          hash[key] << relationship
+                         .inverse_related_place_with_search_geometry
+                         .to_search_json(options)
+                         .merge(user_defined)
+                         .merge({ inverse: true })
+        end
+
+        def build_inverse_relationship(relationship, hash, projects, options)
+          project_model_relationship = relationship.project_model_relationship
+          key = project_model_relationship.uuid
+
+          # Add the related model project to the list of projects
+          add_project(projects, project_model_relationship.related_model.project)
+
+          user_defined = build_user_defined(relationship, project_model_relationship.user_defined_fields)
+
+          hash[key] ||= []
+
+          hash[key] << relationship
+                         .primary_record
+                         .to_search_json(options)
+                         .merge(user_defined)
+                         .merge({ inverse: true })
+        end
+
+        def build_place_relationship(relationship, hash, projects, options)
+          project_model_relationship = relationship.project_model_relationship
+          key = project_model_relationship.uuid
+
+          # Add the primary model project to the list of projects
+          add_project(projects, project_model_relationship.primary_model.project)
+
+          user_defined = build_user_defined(relationship, project_model_relationship.user_defined_fields)
+
+          hash[key] ||= []
+
+          hash[key] << relationship
+                         .related_place_with_search_geometry
+                         .to_search_json(options)
+                         .merge(user_defined)
+                         .merge({ inverse: false })
+        end
+
+        def build_relationship(relationship, hash, projects, options)
+          project_model_relationship = relationship.project_model_relationship
+          key = project_model_relationship.uuid
+
+          # Add the primary model project to the list of projects
+          add_project(projects, project_model_relationship.primary_model.project)
+
+          user_defined = build_user_defined(relationship, project_model_relationship.user_defined_fields)
+
+          hash[key] ||= []
+
+          hash[key] << relationship
+                         .related_record
+                         .to_search_json(options)
+                         .merge(user_defined)
+                         .merge({ inverse: false })
+        end
+
+        def build_relationships(hash, projects, options)
+          event_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          instance_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          item_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          media_content_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          organization_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          person_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          place_relationships.each { |r| build_place_relationship(r, hash, projects, options) }
+          taxonomy_relationships.each { |r| build_relationship(r, hash, projects, options) }
+          work_relationships.each { |r| build_relationship(r, hash, projects, options) }
+
+          event_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+          instance_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+          item_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+          media_content_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+          organization_related_relationships.each { |r| build_inverse_relationship(r,hash, projects, options) }
+          person_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+          place_related_relationships.each { |r| build_inverse_place_relationship(r, hash, projects, options) }
+          taxonomy_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+          work_related_relationships.each { |r| build_inverse_relationship(r, hash, projects, options) }
+        end
+
+        def set_thumbnail_url(hash)
+          media_content_relationships.each do |rel|
+            if rel.related_record.content_thumbnail_url.present?
+              hash['thumbnail'] = rel.related_record.content_thumbnail_url
+              return
+            end
+          end
+
+          media_content_related_relationships.each do |rel|
+            if rel.primary_record.content_thumbnail_url.present?
+              hash['thumbnail'] = rel.primary_record.content_thumbnail_url
+              return
+            end
+          end
+        end
+
+        def build_user_defined(record, user_defined_fields)
+          hash = {}
+
+          user_defined_fields.each do |field|
+            next unless record.user_defined
+
+            value = convert_value(field, record.user_defined[field.uuid])
+            next unless value.present?
+
+            key = field.uuid
+            hash[key] = value
+
+            facet = %(Date Number Select Boolean).include?(field.data_type)
+            hash["#{key}_facet"] = value if facet
+          end
+
+          hash
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/event.rb
+++ b/app/services/core_data_connector/search/event.rb
@@ -1,0 +1,53 @@
+module CoreDataConnector
+  module Search
+    module Event
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:start_date, :end_date]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+        search_attribute :description
+
+        search_attribute(:start_date) do
+          resolve_date start_date
+        end
+
+        search_attribute(:end_date) do
+          resolve_date end_date
+        end
+
+        search_attribute(:start_year, facet: true) do
+          resolve_year start_date
+        end
+
+        search_attribute(:end_year, facet: true) do
+          resolve_year end_date
+        end
+
+        private
+
+        def resolve_date(date)
+          return [] unless date.present?
+
+          [date.start_date&.to_time&.to_i, date.end_date&.to_time&.to_i]
+        end
+
+        def resolve_year(date)
+          return [] unless date.present?
+
+          [date.start_date&.strftime('%Y')&.to_i, date.end_date&.strftime('%Y')&.to_i]
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/instance.rb
+++ b/app/services/core_data_connector/search/instance.rb
@@ -1,0 +1,30 @@
+module CoreDataConnector
+  module Search
+    module Instance
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+
+        search_attribute(:name) do
+          primary_name.name
+        end
+
+        search_attribute(:names, facet: true) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/item.rb
+++ b/app/services/core_data_connector/search/item.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Search
+    module Item
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+        search_attribute :faircopy_cloud_id
+
+        search_attribute(:names, facet: true) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/media_content.rb
+++ b/app/services/core_data_connector/search/media_content.rb
@@ -1,0 +1,21 @@
+module CoreDataConnector
+  module Search
+    module MediaContent
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name
+        search_attribute :content_warning
+
+        search_attribute(:thumbnail) do
+          content_thumbnail_url
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/organization.rb
+++ b/app/services/core_data_connector/search/organization.rb
@@ -1,0 +1,27 @@
+module CoreDataConnector
+  module Search
+    module Organization
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :organization_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+        search_attribute :description
+
+        search_attribute(:names, facet: true) do
+          organization_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/search/person.rb
+++ b/app/services/core_data_connector/search/person.rb
@@ -1,0 +1,34 @@
+module CoreDataConnector
+  module Search
+    module Person
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :person_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :biography
+
+        search_attribute(:name, facet: true) do
+          create_name primary_name
+        end
+
+        search_attribute(:names, facet: true) do
+          person_names.map { |n| create_name(n) }
+        end
+
+        def create_name(person_name)
+          [person_name.first_name, person_name.middle_name, person_name.last_name].compact.join(' ')
+        end
+
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/place.rb
+++ b/app/services/core_data_connector/search/place.rb
@@ -1,0 +1,48 @@
+module CoreDataConnector
+  module Search
+    module Place
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :place_names, :place_geometry]
+        end
+
+        def search_query(query)
+          query.merge(self.with_search_geometry)
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+
+        search_attribute(:names, facet: true) do
+          place_names.map(&:name)
+        end
+
+        search_attribute(:geometry) do |options|
+          if options[:polygons] && self.respond_to?(:simplified_geometry) && simplified_geometry.present?
+            Geometry.to_geojson(self.simplified_geometry)
+          elsif self.respond_to?(:geometry_center) && geometry_center.present?
+            Geometry.to_geojson(geometry_center)
+          end
+        end
+
+        search_attribute(:properties) do
+          place_geometry&.properties
+        end
+
+        search_attribute(:coordinates) do
+          # Return if the "geometry_center" attribute is not defined
+          next unless self.respond_to?(:geometry_center) && geometry_center.present?
+
+          [geometry_center.y, geometry_center.x]
+        end
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/taxonomy.rb
+++ b/app/services/core_data_connector/search/taxonomy.rb
@@ -1,0 +1,15 @@
+module CoreDataConnector
+  module Search
+    module Taxonomy
+      extend ActiveSupport::Concern
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/search/work.rb
+++ b/app/services/core_data_connector/search/work.rb
@@ -1,0 +1,26 @@
+module CoreDataConnector
+  module Search
+    module Work
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def preloads
+          [:primary_name, :source_names]
+        end
+      end
+
+      included do
+        # Includes
+        include Base
+
+        # Search attributes
+        search_attribute :name, facet: true
+
+        search_attribute(:names, facet: true) do
+          source_names.map(&:name)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/core_data_connector/typesense.rb
+++ b/app/services/core_data_connector/typesense.rb
@@ -1,0 +1,20 @@
+require 'typesense'
+
+module CoreDataConnector
+  class Typesense
+
+    def self.create_client(host:, port:, protocol:, api_key:)
+      ::Typesense::Client.new(
+        nodes: [{ host:, port:, protocol: }],
+        api_key:,
+        num_retries: 10,
+        healthcheck_interval_seconds: 1,
+        retry_interval_seconds: 0.01,
+        connection_timeout_seconds: 30,
+        logger: Logger.new($stdout),
+        log_level: Logger::INFO
+      )
+    end
+
+  end
+end

--- a/app/services/core_data_connector/users/clerk_migration.rb
+++ b/app/services/core_data_connector/users/clerk_migration.rb
@@ -1,0 +1,143 @@
+if ENV['VITE_AUTH_PROVIDER'] == 'clerk'
+  require 'clerk'
+end
+
+module CoreDataConnector
+  module Users
+    class ClerkMigration
+      def run
+        clerk = Clerk::SDK.new(secret_key: ENV.fetch('CLERK_SECRET_KEY'))
+
+        organization_list_request = Clerk::Models::Operations::ListOrganizationsRequest.new(limit: 200)
+        organization_list = clerk.organizations.list(request: organization_list_request)
+        sleep 1
+        organizations = organization_list.organizations.data
+
+        org_domains = Hash.new
+
+        organizations.each do |org|
+          puts "Fetching metadata for organization: #{org.name} (#{org.id})"
+          domain_request = Clerk::Models::Operations::ListOrganizationDomainsRequest.new(organization_id: org.id)
+          domains = clerk.organization_domains.list(request: domain_request).organization_domains.data
+          sleep 1
+          next if domains.empty?
+
+          name = domains.first.name
+          org_domains[name] = org.id
+        end
+
+        User.where(sso_id: nil).find_each do |user|
+          begin
+            puts "----------------------------------------"
+            list_request = Clerk::Models::Operations::GetUserListRequest.new(email_address: [user.email])
+            clerk_users = clerk.users.list(request: list_request)
+            sleep 1
+            clerk_user = clerk_users.user_list.first
+
+            is_new_user = false
+
+            email_domain = user.email.split('@').last
+
+            if clerk_user.nil?
+              is_new_user = true
+              first_name, last_name = user.split_name
+
+              is_global_admin = email_domain == ENV['CLERK_MIGRATION_GLOBAL_ADMIN_DOMAIN']
+
+              private_metadata = {
+                migrated_from: 'FairData'
+              }
+
+              if is_global_admin
+                private_metadata[:is_global_admin] = true
+              end
+
+              create_request = Clerk::Models::Operations::CreateUserRequest.new(
+                email_address: [user.email],
+                first_name: first_name,
+                last_name: last_name,
+                skip_password_requirement: true,
+                private_metadata: private_metadata
+              )
+
+              response = clerk.users.create(request: create_request)
+              sleep 1
+              clerk_user = response.user
+              puts "#{user.email} created in Clerk"
+            end
+
+            org_id = org_domains[email_domain]
+
+            if is_new_user
+              needs_membership = true
+            else
+              membership_request = Clerk::Models::Operations::ListOrganizationMembershipsRequest.new(organization_id: org_id)
+              memberships = clerk.organization_memberships.list(request: membership_request)
+              sleep 1
+              needs_membership = !memberships.organization_memberships.data.any? { |m| m.organization.id == org_id }
+            end
+
+            if needs_membership
+              if org_id
+                org_member_request_body = {
+                  user_id: clerk_user.id,
+                  role: 'org:member'
+                }
+                clerk.organization_memberships.create(body: org_member_request_body, organization_id: org_id)
+                sleep 1
+                puts "#{user.email} automatically added to organization based on email domain: #{org_id}"
+              else
+                puts "#{user.email} needs to be added to an organization. Please select one:"
+                organizations.each_with_index do |org, idx|
+                  puts "#{idx + 1}. #{org.name} (#{org.id})"
+                end
+
+                idx = $stdin.gets.chomp.to_i - 1
+
+                org_member_request_body = {
+                  user_id: clerk_user.id,
+                  role: 'org:member'
+                }
+                clerk.organization_memberships.create(body: org_member_request_body, organization_id: organizations[idx].id)
+                sleep 1
+
+                puts "#{user.email} added to #{organizations[idx].name}"
+              end
+            end
+
+            user.update!(sso_id: clerk_user.id)
+          rescue Clerk::Models::Errors::ClerkErrors => e
+            puts "Clerk API error while migrating #{user.email}: #{e.message}"
+            puts e.errors.map { |error| "#{error.code}: #{error.message}" }.join("\n")
+          rescue StandardError => e
+            puts "Error migrating user #{user.email}: #{e.message}"
+          end
+        end
+
+        puts "Migration complete! Make sure to set admin permissions to the relevant users on each organization in Clerk."
+      end
+
+      def reset
+        # This task exists to make development of the run method easier.
+        # It will wipe all users from the Clerk instance and remove their SSO ID.
+
+        clerk = Clerk::SDK.new(secret_key: ENV.fetch('CLERK_SECRET_KEY'))
+
+        request = Clerk::Models::Operations::GetUserListRequest.new(
+          limit: 200
+        )
+
+        users = clerk.users.list(request: request)
+
+        users.user_list.each do |user|
+          sleep 2
+          clerk.users.delete(user_id: user.id)
+          puts "Deleted user #{user.id} with email #{user.email_addresses.first.email_address}"
+        end
+
+        User.update_all(sso_id: nil)
+        puts "Cleared sso_id for all users"
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/users/invitations.rb
+++ b/app/services/core_data_connector/users/invitations.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module Users
+    class Invitations
+      def send_invitation(recipient)
+        user = recipient.is_a?(UserProject) ? recipient.user : recipient
+        project = recipient.is_a?(UserProject) ? recipient.project : nil
+
+        # Generate a new password
+        password = Passwords.generate_user_password
+
+        # Update the user's password
+        user.update!(
+          last_invited_at: Time.now.utc,
+          password: password,
+          password_confirmation: password,
+          password_temporary: true,
+          require_password_change: true
+        )
+
+        # Email the user the new password
+        InvitationMailer.invite_user(user: user, password: password, project: project).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/users/passwords.rb
+++ b/app/services/core_data_connector/users/passwords.rb
@@ -1,0 +1,41 @@
+module CoreDataConnector
+  module Users
+    class Passwords
+
+      # default lengths of generated passwords
+      USER_PASSWORD_LENGTH = 16
+
+      # Password format; must match frontend validation regex
+      PASSWORD_FORMAT = /\A
+        (?=.{8,})            # Must contain 8 or more characters
+        (?=.*\d)             # Must contain a digit
+        (?=.*[a-z])          # Must contain a lower case character
+        (?=.*[A-Z])          # Must contain an upper case character
+        (?=.*[^a-zA-Z0-9\s]) # Must contain a symbol
+      /x
+
+      def self.generate_user_password
+        generate_password USER_PASSWORD_LENGTH
+      end
+
+      private
+
+      def self.generate_password(length)
+        # generate a password that is guaranteed to match regex
+        lower = ('a'..'z').to_a
+        upper = ('A'..'Z').to_a
+        numbers = ('0'..'9').to_a
+        symbols = %w[@ $ ! % * ? &]
+        all_allowed = lower + upper + numbers + symbols
+
+        # random mix of allowed characters (ensure at least one of each required type)
+        required = [lower.sample, upper.sample, numbers.sample, symbols.sample]
+        rest = Array.new(length - 4) { all_allowed.sample }
+        password_chars = required + rest
+  
+        # shuffle so that first 4 aren't always "lower upper number symbol"
+        password_chars.shuffle.join
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,10 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require 'rgeo/active_record'
+
 require_relative '../lib/canonical_domain_redirect'
+require_relative '../lib/core_data_connector'
 
 module RailsReactTemplate
   class Application < Rails::Application
@@ -28,6 +31,17 @@ module RailsReactTemplate
 
     # Redirect requests for non-canonical domains before any other processing.
     config.middleware.insert_before 0, CanonicalDomainRedirect
+
+    # Allow cross-origin reads of the public and reconciliation APIs. Inserted
+    # after CanonicalDomainRedirect to preserve the ordering these had while
+    # Rack::Cors was contributed by the core_data_connector engine.
+    config.middleware.insert_after CanonicalDomainRedirect, Rack::Cors do
+      allow do
+        origins '*'
+        resource '/core_data/public/*', methods: :get
+        resource '/core_data/reconcile/*', methods: [:get, :post]
+      end
+    end
 
     # Configure Postmark for transactional emails
     config.action_mailer.delivery_method = :postmark

--- a/config/initializers/core_data_connector.rb
+++ b/config/initializers/core_data_connector.rb
@@ -1,0 +1,16 @@
+JwtAuth.configure do |config|
+  config.model_class = 'CoreDataConnector::User'
+  config.login_attribute = 'email'
+  config.user_serializer = 'CoreDataConnector::UsersSerializer'
+end
+
+TripleEyeEffable.configure do |config|
+  config.api_key = ENV['IIIF_CLOUD_API_KEY']
+  config.url = ENV['IIIF_CLOUD_URL']
+  config.project_id = ENV['IIIF_CLOUD_PROJECT_ID']
+  config.base_controller = 'CoreDataConnector::DirectUploadsController'
+end
+
+Rails.application.config.to_prepare do
+  JwtAuth::AuthenticationController.prepend(CoreDataConnector::AuthenticationControllerOverride)
+end

--- a/config/locales/core_data_connector.en.yml
+++ b/config/locales/core_data_connector.en.yml
@@ -1,0 +1,176 @@
+en:
+  app:
+    name: "Core Data Cloud"
+    company_name: "Performant Software Solutions"
+    company_address: "Charlottesville, VA and Boston, MA"
+
+  authorization:
+    core_data_connector/event_policy:
+      create?: "You do not have permission to create an event."
+      delete?: "You do not have permission to delete this event."
+      import?: "You do not have permission to import data into this event."
+      show?: "You do not have permission to view this event."
+      update?: "You do not have permission to update this event."
+
+    core_data_connector/instance_policy:
+      create?: "You do not have permission to create an instance."
+      delete?: "You do not have permission to delete this instance."
+      import?: "You do not have permission to import data into this instance."
+      show?: "You do not have permission to view this instance."
+      update?: "You do not have permission to update this instance."
+
+    core_data_connector/item_policy:
+      create?: "You do not have permission to create an item."
+      delete?: "You do not have permission to delete this item."
+      import?: "You do not have permission to import data into this item."
+      show?: "You do not have permission to view this item."
+      update?: "You do not have permission to update this item."
+
+    core_data_connector/media_content_policy:
+      create?: "You do not have permission to create a media_content."
+      delete?: "You do not have permission to delete this media_content."
+      import?: "You do not have permission to import data into this media_content."
+      show?: "You do not have permission to view this media_content."
+      update?: "You do not have permission to update this media_content."
+
+    core_data_connector/organization_policy:
+      create?: "You do not have permission to create an organization."
+      delete?: "You do not have permission to delete this organization."
+      import?: "You do not have permission to import data into this organization."
+      show?: "You do not have permission to view this organization."
+      update?: "You do not have permission to update this organization."
+
+    core_data_connector/person_policy:
+      create?: "You do not have permission to create a person."
+      delete?: "You do not have permission to delete this person."
+      import?: "You do not have permission to import data into this person."
+      show?: "You do not have permission to view this person."
+      update?: "You do not have permission to update this person."
+
+    core_data_connector/place_policy:
+      create?: "You do not have permission to create a place."
+      delete?: "You do not have permission to delete this place."
+      import?: "You do not have permission to import data into this place."
+      show?: "You do not have permission to view this place."
+      update?: "You do not have permission to update this place."
+
+    core_data_connector/project_policy:
+      create?: "You do not have permission to create a project."
+      delete?: "You do not have permission to delete this project."
+      import?: "You do not have permission to import data into this project."
+      show?: "You do not have permission to view this project."
+      update?: "You do not have permission to update this project."
+
+    core_data_connector/record_merge_policy:
+      create?: "You do not have permission to create a record merge."
+      delete?: "You do not have permission to delete this record merge."
+      import?: "You do not have permission to import data into this record merge."
+      show?: "You do not have permission to view this record merge."
+      update?: "You do not have permission to update this record merge."
+
+    core_data_connector/relationship_policy:
+      create?: "You do not have permission to create a relationship."
+      delete?: "You do not have permission to delete this relationship."
+      import?: "You do not have permission to import data into this relationship."
+      show?: "You do not have permission to view this relationship."
+      update?: "You do not have permission to update this relationship."
+
+    core_data_connector/taxonomy_policy:
+      create?: "You do not have permission to create a taxonomy."
+      delete?: "You do not have permission to delete this taxonomy."
+      import?: "You do not have permission to import data into this taxonomy."
+      show?: "You do not have permission to view this taxonomy."
+      update?: "You do not have permission to update this taxonomy."
+
+    core_data_connector/user_project_policy:
+      create?: "You do not have permission to create an add users to this project."
+      delete?: "You do not have permission to delete users from this project."
+      invite?: "You do not have permission to invite this user to this project."
+      show?: "You do not have permission to view users in this project."
+      update?: "You do not have permission to update users in this project."
+
+    core_data_connector/work_policy:
+      create?: "You do not have permission to create a work."
+      delete?: "You do not have permission to delete this work."
+      import?: "You do not have permission to import data into this work."
+      show?: "You do not have permission to view this work."
+      update?: "You do not have permission to update this work."
+
+    core_data_connector/public/v1/public_policy:
+      create?: "You do not have permission to create a record."
+      delete?: "You do not have permission to delete this record."
+      show?: "You do not have permission to view this record."
+      update?: "You do not have permission to update this record."
+
+  errors:
+    general:
+      not_found: "This record cannot be found"
+    http:
+      general: "An error occurred when making your request"
+      no_response: "No response from the server"
+      timeout: "Your request has timed out"
+    import:
+      authorize: "You do not have permission to import these records. Please contact your system administrator."
+    items_controller:
+      authorize: "You do not have permission to import these records. Please contact your system administrator."
+    manifest:
+      unique: "Only a single manifest can exist per relationship"
+    mergeable:
+      ids: "IDs are required"
+    nameable:
+      primary_name: "This record must have a primary name"
+    projects:
+      authorize: "You do not have permission to import these records. Please contact your system administrator."
+      import_configuration: "Configuration file required"
+      import_data: "Importable contents required"
+    user_projects:
+      role_owner: "Projects must have an owner."
+      roles: "Invalid role"
+      unique: "This user cannot be added to the same project multiple times."
+    users:
+      not_found: "User not found"
+      unauthorized: "Unauthorized"
+      password:
+        sso: "Cannot reset passwords for SSO users"
+      roles: "Invalid role"
+    web_authorities_controller:
+      find:
+        identifier: "An identifier is required"
+      search:
+        query: "A search query is required"
+    web_authority:
+      source_type_unique: "Only one authority per type is allowed per project"
+
+  serialization:
+    linked_open_data:
+      annotation_page_label: "Related %{klass}: %{target}"
+
+  services:
+    iiif:
+      manifest:
+        label: "%{name}: %{relationship}"
+        content_warning: "Content Warning"
+    import_analyze:
+      common:
+        name: "Name"
+        uuid: "Identifier"
+      events:
+        description: "Description"
+        end_date: "End date"
+        end_date_description: "End date description"
+        start_date: "Start date"
+        start_date_description: "Start date description"
+      media_contents:
+        import_url: "Import URL"
+      organizations:
+        description: "Description"
+      people:
+        biography: "Biography"
+        first_name: "First name"
+        last_name: "Last name"
+        middle_name: "Middle name"
+      places:
+        latitude: "Latitude"
+        longitude: "Longitude"
+    reconcile:
+      name: "Core Data Cloud Reconciliation API"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,22 @@ Sidekiq::Web.use Rack::Auth::Basic do |email, password|
 end
 
 Rails.application.routes.draw do
-  mount CoreDataConnector::Engine, at: '/core_data'
+  # Preserve `/core_data/**` API routes from the old connector gem
+  scope path: 'core_data', module: 'core_data_connector' do
+    # JWT authentication
+    mount JwtAuth::Engine, at: '/auth'
+
+    # Admin API endpoints
+    draw(:admin)
+
+    # Public API endpoints
+    draw(:v0)
+    draw(:v1)
+
+    # Reconciliation API endpoints
+    draw(:reconcile)
+  end
+
   mount Sidekiq::Web, at: '/sidekiq'
   mount TripleEyeEffable::Engine, at: '/triple_eye_effable'
   mount UserDefinedFields::Engine, at: '/user_defined_fields'

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -1,0 +1,79 @@
+# Admin CMS routes
+
+concern :manifestable do
+  post :create_manifests, on: :member
+end
+
+concern :mergeable do
+  post :merge, on: :collection
+end
+
+concern :versionable do
+  resources :versions, only: [:index]
+end
+
+resources :events, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :instances, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :items, concerns: [:manifestable, :mergeable, :versionable] do
+  get :analyze_import, on: :member
+  post :import, on: :member
+end
+
+resources :jobs, only: [:destroy, :index]
+
+resources :media_contents, concerns: [:manifestable, :mergeable, :versionable] do
+  post :upload, on: :collection
+end
+
+resources :organizations, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :people, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :places, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :project_models do
+  get :model_classes, on: :collection
+end
+
+resources :project_model_accesses, only: :index
+
+resources :projects, concerns: [:versionable] do
+  post :analyze_import, on: :member
+  post :clear, on: :member
+  get :export_configuration, on: :member
+  get :export_data, on: :member
+  get :export_variables, on: :member
+  post :import_analyze, on: :member
+  post :import_configuration, on: :member
+  post :import_data, on: :member
+  get :map_library, on: :member
+end
+
+resources :record_merges, only: [:index, :destroy]
+
+resources :relationships do
+  post :upload, on: :collection
+end
+
+resources :taxonomies, concerns: [:manifestable, :mergeable, :versionable]
+
+resources :user_projects do
+  post :invite, on: :member
+end
+
+resources :users do
+  post :invite, on: :member
+  get :me, on: :collection
+end
+
+resources :web_authorities do
+  get :find, on: :member
+  get :search, on: :member
+end
+
+resources :web_identifiers
+
+resources :works, concerns: [:manifestable, :mergeable, :versionable]
+

--- a/config/routes/reconcile.rb
+++ b/config/routes/reconcile.rb
@@ -1,0 +1,7 @@
+# Reconciliation API routes
+
+namespace :reconcile do
+  get 'projects/:id', to: 'projects#show'
+  post 'projects/:id', to: 'projects#show'
+  get 'projects/:id/view/:record_id', to: 'projects#view'
+end

--- a/config/routes/v0.rb
+++ b/config/routes/v0.rb
@@ -1,0 +1,55 @@
+# Public V0 routes
+
+namespace :public, only: [:index, :show] do
+  resources :instances, controller: 'v0/instances' do
+    resources :instances, only: :index, controller: 'v0/instances'
+    resources :items, only: :index, controller: 'v0/items'
+    resources :manifests, controller: 'v0/manifests'
+    resources :media_contents, only: :index, controller: 'v0/media_contents'
+    resources :organizations, only: :index, controller: 'v0/organizations'
+    resources :people, only: :index, controller: 'v0/people'
+    resources :places, only: :index, controller: 'v0/places'
+    resources :taxonomies, only: :index, controller: 'v0/taxonomies'
+    resources :works, only: :index, controller: 'v0/works'
+  end
+
+  resources :items, controller: 'v0/items' do
+    resources :instances, only: :index, controller: 'v0/instances'
+    resources :items, only: :index, controller: 'v0/items'
+    resources :manifests, controller: 'v0/manifests'
+    resources :media_contents, only: :index, controller: 'v0/media_contents'
+    resources :organizations, only: :index, controller: 'v0/organizations'
+    resources :people, only: :index, controller: 'v0/people'
+    resources :places, only: :index, controller: 'v0/places'
+    resources :taxonomies, only: :index, controller: 'v0/taxonomies'
+    resources :works, only: :index, controller: 'v0/works'
+  end
+
+  resources :places, controller: 'v0/linked_places/places' do
+    resources :instances, only: :index, controller: 'v0/linked_places/instances'
+    resources :items, only: :index, controller: 'v0/linked_places/items'
+    resources :manifests, controller: 'v0/manifests'
+    resources :media_contents, only: :index, controller: 'v0/linked_places/media_contents'
+    resources :organizations, only: :index, controller: 'v0/linked_places/organizations'
+    resources :people, only: :index, controller: 'v0/linked_places/people'
+    resources :places, only: :index, controller: 'v0/linked_places/places'
+    resources :taxonomies, only: :index, controller: 'v0/linked_places/taxonomies'
+    resources :works, only: :index, controller: 'v0/linked_places/works'
+  end
+
+  resources :projects, only: [] do
+    get :descriptors, on: :member, controller: 'v0/projects'
+  end
+
+  resources :works, controller: 'v0/works' do
+    resources :instances, only: :index, controller: 'v0/instances'
+    resources :items, only: :index, controller: 'v0/items'
+    resources :manifests, controller: 'v0/manifests'
+    resources :media_contents, only: :index, controller: 'v0/media_contents'
+    resources :organizations, only: :index, controller: 'v0/organizations'
+    resources :people, only: :index, controller: 'v0/people'
+    resources :places, only: :index, controller: 'v0/places'
+    resources :taxonomies, only: :index, controller: 'v0/taxonomies'
+    resources :works, only: :index, controller: 'v0/works'
+  end
+end

--- a/config/routes/v1.rb
+++ b/config/routes/v1.rb
@@ -1,0 +1,102 @@
+# Public V1 routes
+
+namespace :public, only: [:index, :show] do
+  namespace :v1 do
+    resources :events do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
+    resources :instances do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
+    resources :items do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
+    resources :media_contents, only: :index
+
+    resources :organizations do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
+    resources :people do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
+    resources :places do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+
+    resources :projects, only: [] do
+      get :descriptors, on: :member
+    end
+
+    resources :works do
+      resources :events, only: :index
+      resources :instances, only: :index
+      resources :items, only: :index
+      resources :manifests
+      resources :media_contents, only: :index
+      resources :organizations, only: :index
+      resources :people, only: :index
+      resources :places, only: :index
+      resources :taxonomies, only: :index
+      resources :works, only: :index
+    end
+  end
+end

--- a/lib/core_data_connector.rb
+++ b/lib/core_data_connector.rb
@@ -1,0 +1,9 @@
+module CoreDataConnector
+  def self.table_name_prefix
+    'core_data_connector_'
+  end
+
+  def self.use_relative_model_naming?
+    true
+  end
+end

--- a/lib/tasks/core_data_connector_tasks.rake
+++ b/lib/tasks/core_data_connector_tasks.rake
@@ -1,0 +1,35 @@
+namespace :core_data_connector do
+
+  namespace :data do
+    desc 'Calls the before_create method for each web_identifier record'
+    task :reset_web_identifiers => :environment do
+      CoreDataConnector::WebIdentifier.all.find_each do |web_identifier|
+        service = CoreDataConnector::Authority::Base.create_service(web_identifier.web_authority)
+        service.before_create(web_identifier)
+        web_identifier.save
+      end
+    end
+  end
+
+  namespace :iiif do
+    desc 'Resets IIIF manifests for all records.'
+    task :reset_manifests => :environment do
+      service = CoreDataConnector::Iiif::Manifest.new
+      service.reset_manifests
+    end
+  end
+
+  namespace :users do
+    desc 'Migrates local users to Clerk.'
+    task :migrate_to_clerk => :environment do
+      service = CoreDataConnector::Users::ClerkMigration.new
+      service.run
+    end
+
+    desc 'Reset Clerk data'
+    task :reset => :environment do
+      service = CoreDataConnector::Users::ClerkMigration.new
+      service.reset
+    end
+  end
+end

--- a/lib/tasks/typesense.rake
+++ b/lib/tasks/typesense.rake
@@ -1,0 +1,142 @@
+require_relative '../typesense/options'
+require_relative '../typesense/reconcile'
+require_relative '../typesense/search'
+
+namespace :typesense do
+
+  namespace :reconcile do
+
+    desc 'Creates a new Typesense collection'
+    task create: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      end
+
+      reconcile = Typesense::Reconcile.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      reconcile.create
+    end
+
+    desc 'Deletes the Typesense collection'
+    task delete: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:delete -- --host --port --protocol --api-key --collection-name'
+      end
+
+      reconcile = Typesense::Reconcile.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      begin
+        reconcile.delete
+      rescue
+        # Do nothing, collection doesn't exist yet
+      end
+    end
+
+    desc 'Index documents into Typesense'
+    task index: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts, options|
+        opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-id'
+        opts.on('-j', '--project-id ARG', Integer) { |id| options[:project_id] = id&.to_i }
+      end
+
+      reconcile = Typesense::Reconcile.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      reconcile.index options.slice(:project_id)
+    end
+  end
+
+  namespace :search do
+
+    desc 'Creates a new Typesense collection'
+    task create: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      end
+
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      search.create
+    end
+
+    desc 'Deletes the Typesense collection'
+    task delete: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:delete -- --host --port --protocol --api-key --collection-name'
+      end
+
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      begin
+        search.delete
+      rescue
+        # Do nothing, collection doesn't exist yet
+      end
+    end
+
+    desc 'Index documents into Typesense'
+    task index: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts, options|
+        opts.banner = 'Usage: typesense:index -- --host --port --protocol --api-key --collection-name --project-models --polygons'
+        opts.on('-m', '--project-models ARG', Array) { |ids| options[:project_model_ids] = ids.map(&:to_i) }
+        opts.on('-g', '--polygons ARG', String) { |polygons| options[:polygons] = polygons.to_bool }
+      end
+
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      search.index options.slice(:project_model_ids, :polygons)
+    end
+
+    desc 'Updates the Typesense collection'
+    task update: :environment do
+      options = Typesense::Options.parse(ARGV) do |opts|
+        opts.banner = 'Usage: typesense:create -- --host --port --protocol --api-key --collection-name'
+      end
+
+      search = Typesense::Search.new(
+        host: options[:host],
+        port: options[:port],
+        protocol: options[:protocol],
+        api_key: options[:api_key],
+        collection_name: options[:collection_name]
+      )
+
+      search.update
+    end
+  end
+end

--- a/lib/typesense/base.rb
+++ b/lib/typesense/base.rb
@@ -1,0 +1,34 @@
+require 'typesense'
+
+module Typesense
+  class Base
+    attr_reader :client, :collection_name
+
+    def initialize(host:, port:, protocol:, api_key:, collection_name:)
+      @client = CoreDataConnector::Typesense.create_client(host:, port:, protocol:, api_key:)
+      @collection_name = collection_name
+    end
+
+    def create
+      client.collections.create(schema)
+    end
+
+    def index(options)
+      # Implemented in sub-class
+    end
+
+    def delete
+      client.collections[collection_name].delete
+    end
+
+    def update
+      # Implemented in sub-class
+    end
+
+    protected
+
+    def schema
+      # Implemented in sub-class
+    end
+  end
+end

--- a/lib/typesense/options.rb
+++ b/lib/typesense/options.rb
@@ -1,0 +1,22 @@
+module Typesense
+  class Options
+    def self.parse(args, &block)
+      options = {}
+
+      opts = OptionParser.new
+
+      block.call(opts, options) if block.present?
+
+      opts.on('-h', '--host ARG', String) { |host| options[:host] = host }
+      opts.on('-p', '--port ARG', Integer) { |port| options[:port] = port }
+      opts.on('-r', '--protocol ARG', String) { |protocol| options[:protocol] = protocol }
+      opts.on('-a', '--api-key ARG', String) { |api_key| options[:api_key] = api_key }
+      opts.on('-c', '--collection-name ARG', String) { |collection| options[:collection_name] = collection }
+
+      args = opts.order!(args) {}
+      opts.parse!(args)
+
+      options
+    end
+  end
+end

--- a/lib/typesense/reconcile.rb
+++ b/lib/typesense/reconcile.rb
@@ -1,0 +1,51 @@
+require_relative 'base'
+
+module Typesense
+  class Reconcile < Base
+    attr_reader :client, :collection_name, :project
+
+    def create
+      client.collections.create(schema)
+    end
+
+    def delete
+      client.collections[collection_name].delete
+    end
+
+    def index(options)
+      collection = client.collections[collection_name]
+      project_id = options[:project_id]
+
+      index_model_class CoreDataConnector::Event, project_id, collection
+      index_model_class CoreDataConnector::Instance, project_id, collection
+      index_model_class CoreDataConnector::Item, project_id, collection
+      index_model_class CoreDataConnector::Organization, project_id, collection
+      index_model_class CoreDataConnector::Person, project_id, collection
+      index_model_class CoreDataConnector::Place, project_id, collection
+      index_model_class CoreDataConnector::Taxonomy, project_id, collection
+      index_model_class CoreDataConnector::Work, project_id, collection
+    end
+
+    protected
+
+    def schema
+      {
+        name: collection_name,
+        enable_nested_fields: false,
+        fields: [{
+          name: '.*',
+          type: 'auto'
+        }]
+      }
+    end
+
+    private
+
+    def index_model_class(klass, project_id, collection)
+      klass.for_reconcile(project_id) do |records|
+        documents = records.map(&:to_reconcile_json)
+        collection.documents.import(documents, action: 'emplace')
+      end
+    end
+  end
+end

--- a/lib/typesense/search.rb
+++ b/lib/typesense/search.rb
@@ -1,0 +1,113 @@
+require_relative 'base'
+
+module Typesense
+  class Search < Base
+    attr_reader :client, :collection_name
+
+    def index(options)
+      collection = client.collections[collection_name]
+
+      project_model_ids = options.delete(:project_model_ids)
+      options[:include_relationships] = true
+
+      # Query project_models and build a hash of class names to arrays if project_model IDs
+      model_classes = CoreDataConnector::ProjectModel
+                        .where(id: project_model_ids)
+                        .pluck(:id, :model_class)
+                        .inject({}) do |hash, record|
+                          id, model_class = record
+
+                          hash[model_class] ||= []
+                          hash[model_class] << id
+
+                          hash
+                        end
+
+      # Append a unique import_id to all of the documents indexed in this batch
+      import_id = DateTime.now.to_i
+      import_attributes = { import_id: import_id }
+
+      # Iterate over the keys and query the records belonging to each project model
+      model_classes.keys.each do |model_class|
+        klass = model_class.constantize
+        ids = model_classes[model_class]
+
+        klass.for_search(ids) do |records|
+          documents = records.map { |r| r.to_search_json(options).merge(import_attributes) }
+          collection.documents.import(documents, action: 'emplace')
+        end
+      end
+
+      # Delete any records from the index not included in this batch
+      collection.documents.delete(filter_by: "import_id:!=#{import_id}")
+    end
+
+    def update
+      collection_schema = client.collections[collection_name]
+
+      collection = collection_schema.retrieve
+      fields = collection['fields']
+
+      fields_to_update = []
+
+      # Update any fields where the name ends with "_facet" and are not flagged as facetable.
+      # Update any fields named "coordinates" to type "geopoint"
+      fields.each do |field|
+        name = field['name']
+
+        if name.end_with?('_facet') && !field['facet']
+          fields_to_update.push({ name: name, drop: true }, field.merge({ facet: true }))
+        elsif name.include?('.coordinates') && !name.include?('geometry') && field['type'] != 'geopoint[]'
+          fields_to_update.push({ name: name, drop: true }, field.merge({ type: 'geopoint[]', sort: true }))
+        end
+      end
+
+      collection_schema.update({ fields: fields_to_update })
+    end
+
+    protected
+
+    def schema
+      {
+        name: collection_name,
+        enable_nested_fields: true,
+        fields: [{
+          name: 'geometry',
+          type: 'object',
+          index: false,
+          facet: false,
+          optional: true
+        }, {
+          name: 'properties',
+          type: 'object',
+          index: false,
+          facet: false,
+          optional: true
+        }, {
+          name: 'coordinates',
+          type: 'geopoint',
+          facet: false,
+          optional: true
+        }, {
+          name: 'name',
+          type: 'string',
+          sort: true,
+          optional: true
+        }, {
+          name: 'thumbnail',
+          type: 'string',
+          facet: false,
+          optional: true,
+          index: false
+        }, {
+          name: '.*_facet',
+          type: 'auto',
+          facet: true
+        }, {
+          name: '.*',
+          type: 'auto'
+       }]
+      }
+    end
+  end
+end


### PR DESCRIPTION
# Summary

This PR pulls all the code from https://github.com/performant-software/core-data-connector into this repo, making the gem obsolete.

Obviously there's a ton of stuff to test. I've confirmed that the basic stuff (local and Clerk auth, browsing the site, submitting forms) works but all the special functionality around imports, merges, Typesense, etc. needs to be tested.

## Testing Plan

- [ ] public endpoints work (at least v1 - not sure if we're even using v0 anywhere?)
- [x] merges work
- [ ] reconciliation works
- [x] CSV exports work
- [x] CSVs created prior to this change successfully import
- [x] CSVs created after to this change successfully import
- [ ] Typsense indexing works
  - [ ] polygon geometry is indexed correctly
- [ ] manifests that reference FairData URLs still work (can be confirmed via a FairData Sites site)
- [ ] updating, deleting, and adding GeoJSON to records works