### PR TITLE
Audit logging for imports

### DIFF
--- a/app/jobs/core_data_connector/import_csv_job.rb
+++ b/app/jobs/core_data_connector/import_csv_job.rb
@@ -14,7 +14,7 @@ module CoreDataConnector
       job.file.open do |file|
         begin
           zip_importer = Import::ZipHelper.new
-          success, errors = zip_importer.import_zip(file)
+          success, errors = zip_importer.import_zip(file, job.user_id)
         rescue StandardError => error
           errors = [error]
         end

--- a/app/models/concerns/core_data_connector/auditable.rb
+++ b/app/models/concerns/core_data_connector/auditable.rb
@@ -26,7 +26,9 @@ module CoreDataConnector
             :z_organization_id,
             :z_person_id,
             :z_place_id,
+            :z_relationship_id,
             :z_taxonomy_id,
+            :z_web_identifier_id,
             :z_work_id
           ].concat(options[:ignore] || []),
         )

--- a/app/services/core_data_connector/import/audit.rb
+++ b/app/services/core_data_connector/import/audit.rb
@@ -1,0 +1,389 @@
+module CoreDataConnector
+  module Import
+    # Records PaperTrail versions for the records added and modified by an import.
+    #
+    # The importers write records directly via SQL, so the ActiveRecord callbacks that normally build a version are
+    # never run. Instead, each importer writes a row into a temporary audit table for every record it creates or
+    # updates, and this service converts those rows into version records at the end of the import.
+    #
+    # For an update, the audit row also carries a snapshot of the record's attributes taken before the import modified
+    # it. That snapshot becomes the version's "object" and is diffed against the record's final state to build the
+    # version's "object_changes".
+    class Audit
+      EVENT_CREATE = 'create'
+      EVENT_UPDATE = 'update'
+
+      # Models for which versions are generated
+      MODELS = [
+        CoreDataConnector::Event,
+        CoreDataConnector::Instance,
+        CoreDataConnector::Item,
+        CoreDataConnector::MediaContent,
+        CoreDataConnector::Organization,
+        CoreDataConnector::OrganizationName,
+        CoreDataConnector::Person,
+        CoreDataConnector::PersonName,
+        CoreDataConnector::Place,
+        CoreDataConnector::PlaceGeometry,
+        CoreDataConnector::PlaceName,
+        CoreDataConnector::Relationship,
+        CoreDataConnector::SourceName,
+        CoreDataConnector::Taxonomy,
+        CoreDataConnector::WebIdentifier,
+        CoreDataConnector::Work
+      ]
+
+      # Top-level models that can appear in a version's "roots" attribute
+      ROOT_MODELS = [
+        CoreDataConnector::Event,
+        CoreDataConnector::Instance,
+        CoreDataConnector::Item,
+        CoreDataConnector::MediaContent,
+        CoreDataConnector::Organization,
+        CoreDataConnector::Person,
+        CoreDataConnector::Place,
+        CoreDataConnector::Taxonomy,
+        CoreDataConnector::Work
+      ]
+
+      attr_reader :table_name, :user_id
+
+      def initialize(user_id = nil)
+        @connection = ActiveRecord::Base.connection
+        @user_id = user_id
+        @table_name = "z_audit_records_#{Random.rand(1000..9999)}"
+      end
+
+      def cleanup
+        execute <<-SQL.squish
+          DROP TABLE IF EXISTS #{table_name}
+        SQL
+      end
+
+      # Creates a version record for each row in the audit table
+      def create_versions
+        MODELS.each do |model|
+          create_versions_for model
+          update_versions_for model
+        end
+      end
+
+      # Returns the SQL used to snapshot the records an importer is about to update. The passed "from" clause must
+      # alias the table being updated as "records", so that a snapshot of its attributes can be taken. The "root_type"
+      # and "root_id" values are SQL expressions, defaulting to the record itself.
+      def record_updates_sql(model, from:, root_type: nil, root_id: nil, root_order: 1)
+        <<-SQL.squish
+          INSERT INTO #{table_name} (item_type, item_id, event, object, root_type, root_id, root_order)
+          SELECT #{quote(model.name)},
+                 records.id,
+                 #{quote(EVENT_UPDATE)},
+                 #{object(model)},
+                 #{root_type || quote(model.name)},
+                 #{root_id || 'records.id'},
+                 #{root_order}
+            #{from}
+        SQL
+      end
+
+      def setup
+        execute <<-SQL.squish
+          CREATE TABLE #{table_name} (
+            item_type VARCHAR NOT NULL,
+            item_id INTEGER NOT NULL,
+            event VARCHAR NOT NULL,
+            object JSONB,
+            root_type VARCHAR,
+            root_id INTEGER,
+            root_order INTEGER NOT NULL DEFAULT 1
+          )
+        SQL
+
+        execute <<-SQL.squish
+          CREATE INDEX #{table_name}_item_type_event_idx ON #{table_name} (item_type, event)
+        SQL
+      end
+
+      private
+
+      # Returns the names of the attributes stored in a version's "object_changes" for the passed model. This mirrors
+      # the way PaperTrail resolves the "ignore", "skip", and "only" options.
+      def audited_attributes(model)
+        options = model.paper_trail_options
+
+        ignore = string_option(options[:ignore])
+        skip = string_option(options[:skip])
+        only = string_option(options[:only])
+
+        attributes = model.column_names - ignore - skip
+        attributes = attributes & only if only.present?
+
+        attributes
+      end
+
+      def create_versions_for(model)
+        execute versions_sql(
+          model,
+          event: EVENT_CREATE,
+          object: 'NULL::jsonb',
+          object_changes: create_object_changes(model)
+        )
+      end
+
+      # Returns the SQL expression used to build a "create" version's "object_changes" value. An attribute is included
+      # only if it was actually set by the import, matching the way ActiveRecord excludes unset attributes and column
+      # defaults from the changes of a newly created record.
+      def create_object_changes(model)
+        attributes = audited_attributes(model)
+        return 'NULL::jsonb' if attributes.empty?
+
+        expressions = attributes.map do |attribute|
+          column = model.columns_hash[attribute]
+          name = "records.#{quote_column(attribute)}"
+
+          conditions = ["#{name} IS NOT NULL"]
+          conditions << "#{name} IS DISTINCT FROM CAST(#{quote(column.default)} AS #{column.sql_type})" unless column.default.nil?
+
+          <<-SQL.squish
+            CASE WHEN #{conditions.join(' AND ')}
+                 THEN jsonb_build_object(#{quote(attribute)}, jsonb_build_array(NULL::text, to_jsonb(#{name})))
+                 ELSE '{}'::jsonb
+                  END
+          SQL
+        end
+
+        "NULLIF(#{expressions.join(' || ')}, '{}'::jsonb)"
+      end
+
+      # Returns the SQL expression used to resolve a root record's "display_name"
+      def display_name(model)
+        case model.name
+        when CoreDataConnector::Event.name, CoreDataConnector::MediaContent.name, CoreDataConnector::Taxonomy.name
+          "NULLIF(records.name, '')"
+        when CoreDataConnector::Organization.name
+          <<-SQL.squish
+            ( SELECT NULLIF(names.name, '')
+                FROM core_data_connector_organization_names names
+               WHERE names.organization_id = records.id
+                 AND names."primary"
+               LIMIT 1 )
+          SQL
+        when CoreDataConnector::Person.name
+          <<-SQL.squish
+            ( SELECT CONCAT_WS(' ', names.first_name, names.middle_name, names.last_name)
+                FROM core_data_connector_person_names names
+               WHERE names.person_id = records.id
+                 AND names."primary"
+               LIMIT 1 )
+          SQL
+        when CoreDataConnector::Place.name
+          <<-SQL.squish
+            ( SELECT NULLIF(names.name, '')
+                FROM core_data_connector_place_names names
+               WHERE names.place_id = records.id
+                 AND names."primary"
+               LIMIT 1 )
+          SQL
+        else
+          <<-SQL.squish
+            ( SELECT NULLIF(names.name, '')
+                FROM core_data_connector_source_names names
+               WHERE names.nameable_id = records.id
+                 AND names.nameable_type = #{quote(model.name)}
+                 AND names."primary"
+               LIMIT 1 )
+          SQL
+        end
+      end
+
+      def execute(sql)
+        @connection.execute sql
+      end
+
+      # Returns the SQL expression used to snapshot a record's attributes, which becomes the version's "object" value.
+      # PaperTrail stores every attribute other than those listed in the "skip" option.
+      def object(model)
+        attributes = model.column_names - string_option(model.paper_trail_options[:skip])
+
+        expressions = attributes.map do |attribute|
+          "#{quote(attribute)}, to_jsonb(records.#{quote_column(attribute)})"
+        end
+
+        "jsonb_build_object(#{expressions.join(', ')})"
+      end
+
+      def quote(value)
+        @connection.quote value
+      end
+
+      def quote_column(name)
+        @connection.quote_column_name name
+      end
+
+      # Returns the SQL used to resolve the attributes stored in a version's "roots" value for each type of root record
+      def root_queries
+        ROOT_MODELS.map do |model|
+          <<-SQL.squish
+            SELECT #{quote(model.name)} AS type,
+                   records.id,
+                   records.uuid,
+                   records.project_model_id,
+                   project_models.project_id,
+                   #{display_name(model)} AS display_name
+              FROM audit_root_ids
+              JOIN #{model.table_name} records ON records.id = audit_root_ids.root_id
+              LEFT JOIN core_data_connector_project_models project_models ON project_models.id = records.project_model_id
+             WHERE audit_root_ids.root_type = #{quote(model.name)}
+          SQL
+        end.join(' UNION ALL ')
+      end
+
+      def string_option(option)
+        Array(option).select{ |value| value.is_a?(String) }
+      end
+
+      # Returns the SQL expression used to build an "update" version's "object_changes" value, by comparing the
+      # snapshot taken before the import ran against the record's final state.
+      def update_object_changes(model)
+        attributes = audited_attributes(model)
+        return 'NULL::jsonb' if attributes.empty?
+
+        expressions = attributes.map do |attribute|
+          before = "COALESCE(audit_items.object -> #{quote(attribute)}, 'null'::jsonb)"
+          after = "COALESCE(to_jsonb(records.#{quote_column(attribute)}), 'null'::jsonb)"
+
+          <<-SQL.squish
+            CASE WHEN #{before} <> #{after}
+                 THEN jsonb_build_object(#{quote(attribute)}, jsonb_build_array(#{before}, #{after}))
+                 ELSE '{}'::jsonb
+                  END
+          SQL
+        end
+
+        "NULLIF(#{expressions.join(' || ')}, '{}'::jsonb)"
+      end
+
+      def update_versions_for(model)
+        # A record created by this import already has a "create" version covering its final state, so any subsequent
+        # update to it is not recorded separately.
+        exclude_creates = <<-SQL.squish
+          AND NOT EXISTS ( SELECT 1
+                             FROM #{table_name} creates
+                            WHERE creates.item_type = audit.item_type
+                              AND creates.item_id = audit.item_id
+                              AND creates.event = #{quote(EVENT_CREATE)} )
+        SQL
+
+        # PaperTrail does not record a version when only ignored attributes have changed
+        execute versions_sql(
+          model,
+          event: EVENT_UPDATE,
+          object: 'audit_items.object',
+          object_changes: update_object_changes(model),
+          filter: exclude_creates,
+          where: 'WHERE audit_versions.object_changes IS NOT NULL'
+        )
+      end
+
+      def versions_sql(model, event:, object:, object_changes:, filter: nil, where: nil)
+        <<-SQL.squish
+          WITH
+
+          audit_records AS (
+
+          SELECT audit.item_id, audit.object, audit.root_type, audit.root_id, audit.root_order
+            FROM #{table_name} audit
+           WHERE audit.item_type = #{quote(model.name)}
+             AND audit.event = #{quote(event)}
+             #{filter}
+
+          ),
+
+          audit_root_ids AS (
+
+          SELECT DISTINCT root_type, root_id
+            FROM audit_records
+
+          ),
+
+          audit_roots AS (
+
+          #{root_queries}
+
+          ),
+
+          audit_items AS (
+
+          SELECT DISTINCT ON (item_id) item_id, object
+            FROM audit_records
+           ORDER BY item_id
+
+          ),
+
+          item_roots AS (
+
+          SELECT audit_records.item_id,
+                 jsonb_agg(
+                   jsonb_build_object(
+                     'type', audit_roots.type,
+                     'id', audit_roots.id,
+                     'display_name', audit_roots.display_name,
+                     'uuid', audit_roots.uuid,
+                     'project_model_id', audit_roots.project_model_id
+                   ) ORDER BY audit_records.root_order
+                 ) AS roots,
+                 (array_agg(audit_roots.project_id ORDER BY audit_records.root_order))[1] AS project_id
+            FROM audit_records
+            JOIN audit_roots ON audit_roots.type = audit_records.root_type
+                            AND audit_roots.id = audit_records.root_id
+           GROUP BY audit_records.item_id
+
+          ),
+
+          audit_versions AS (
+
+          SELECT #{quote(model.name)} AS item_type,
+                 records.id AS item_id,
+                 #{quote(event)} AS event,
+                 #{whodunnit} AS whodunnit,
+                 #{object} AS object,
+                 #{object_changes} AS object_changes,
+                 COALESCE(item_roots.roots, '[]'::jsonb) AS roots,
+                 item_roots.project_id AS project_id,
+                 records.updated_at AS created_at
+            FROM audit_items
+            JOIN #{model.table_name} records ON records.id = audit_items.item_id
+            LEFT JOIN item_roots ON item_roots.item_id = audit_items.item_id
+
+          )
+
+          INSERT INTO #{CoreDataConnector::Version.table_name} (
+            item_type,
+            item_id,
+            event,
+            whodunnit,
+            object,
+            object_changes,
+            roots,
+            project_id,
+            created_at
+          )
+          SELECT item_type,
+                 item_id,
+                 event,
+                 whodunnit,
+                 object,
+                 object_changes,
+                 roots,
+                 project_id,
+                 created_at
+            FROM audit_versions
+           #{where}
+        SQL
+      end
+
+      def whodunnit
+        user_id.present? ? quote(user_id.to_s) : 'NULL::varchar'
+      end
+    end
+  end
+end

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -3,11 +3,12 @@ require 'csv'
 module CoreDataConnector
   module Import
     class Base
-      attr_reader :filepath, :import_id, :table_name, :user_defined_columns
+      attr_reader :audit, :filepath, :import_id, :table_name, :user_defined_columns
 
-      def initialize(filepath, import_id)
+      def initialize(filepath, import_id, audit)
         @filepath = filepath
         @import_id = import_id
+        @audit = audit
 
         @connection = ActiveRecord::Base.connection
         @csv_headers = CSV.foreach(filepath).first
@@ -102,6 +103,23 @@ module CoreDataConnector
       end
 
       protected
+
+      # Name of the table used to stage the records created and updated by this import for the audit log
+      def audit_table
+        audit.table_name
+      end
+
+      # Snapshots the records this importer is about to update, so that a version can be created for any of them that
+      # actually change. Must be called before the records are modified. See Audit#record_updates_sql.
+      def audit_updates(model, from:, root_type: nil, root_id: nil, root_order: 1)
+        execute audit.record_updates_sql(
+          model,
+          from: from,
+          root_type: root_type,
+          root_id: root_id,
+          root_order: root_order
+        )
+      end
 
       def execute(sql)
         @connection.execute sql

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -19,6 +19,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the events about to be updated
+        audit_updates(
+          CoreDataConnector::Event,
+          from: <<-SQL.squish
+            FROM #{table_name} z_events
+            JOIN core_data_connector_events records ON records.id = z_events.event_id
+          SQL
+        )
+
         execute <<-SQL.squish
           UPDATE core_data_connector_events events
              SET z_event_id = z_events.id,
@@ -146,12 +155,24 @@ module CoreDataConnector
             FROM insert_events
             JOIN #{table_name} z_events ON z_events.id = insert_events.z_event_id
 
-          )
+          ),
+
+          update_events AS (
 
           UPDATE #{table_name} z_events
              SET event_id = insert_events.event_id
             FROM insert_events
            WHERE insert_events.z_event_id = z_events.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Event',
+                 insert_events.event_id,
+                 'create',
+                 'CoreDataConnector::Event',
+                 insert_events.event_id
+            FROM insert_events
         SQL
       end
 

--- a/app/services/core_data_connector/import/importer.rb
+++ b/app/services/core_data_connector/import/importer.rb
@@ -2,7 +2,7 @@ module CoreDataConnector
   module Import
     class Importer
 
-      attr_reader :importers, :import_id
+      attr_reader :audit, :importers, :import_id
 
       IMPORTERS = [{
         importer_class: Events,
@@ -42,9 +42,10 @@ module CoreDataConnector
         filename: 'web_identifiers.csv'
       }]
 
-      def initialize(directory)
+      def initialize(directory, user_id = nil)
         @importers = []
         @import_id = SecureRandom.uuid
+        @audit = Audit.new(user_id)
 
         IMPORTERS.each do |importer|
           populate_importer(importer, directory)
@@ -60,9 +61,14 @@ module CoreDataConnector
         importers.each do |importer|
           importer.cleanup
         end
+
+        audit.cleanup
       end
 
       def run
+        # Setup the table used to stage the records created for the audit log
+        audit.setup
+
         importers.each do |importer|
           # Setup necessary schema
           importer.setup
@@ -76,6 +82,9 @@ module CoreDataConnector
           # Load the data into the appropriate tables
           importer.load
         end
+
+        # Create the audit log entries for the newly created records
+        audit.create_versions
 
         # Upload any attachments for media_contents
         uploader = Uploader.new(import_id)
@@ -94,7 +103,7 @@ module CoreDataConnector
         filepath = "#{directory}/#{filename}"
 
         if File.exist? filepath
-          @importers << klass.new(filepath, import_id)
+          @importers << klass.new(filepath, import_id, audit)
         end
       end
     end

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -20,6 +20,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the instances about to be updated
+        audit_updates(
+          CoreDataConnector::Instance,
+          from: <<-SQL.squish
+            FROM #{table_name} z_instances
+            JOIN core_data_connector_instances records ON records.id = z_instances.instance_id
+          SQL
+        )
+
         # Update existing instances
         execute <<-SQL.squish
           UPDATE core_data_connector_instances instances
@@ -56,13 +65,25 @@ module CoreDataConnector
             FROM #{table_name} z_instances
            WHERE z_instances.instance_id IS NULL
           RETURNING id AS instance_id, z_instance_id
-  
-          )
-  
+
+          ),
+
+          update_instances AS (
+
           UPDATE #{table_name} z_instances
              SET instance_id = insert_instances.instance_id
             FROM insert_instances
            WHERE insert_instances.z_instance_id = z_instances.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Instance',
+                 insert_instances.instance_id,
+                 'create',
+                 'CoreDataConnector::Instance',
+                 insert_instances.instance_id
+            FROM insert_instances
         SQL
 
         # Insert new source_names
@@ -77,19 +98,21 @@ module CoreDataConnector
           SELECT z_instances.instance_id AS instance_id, unnest(z_instances.additional_names) AS name
             FROM #{table_name} z_instances
           
-          )
-  
+          ),
+
+          insert_instance_names AS (
+
           INSERT INTO core_data_connector_source_names (
-            nameable_id, 
-            nameable_type, 
-            name, 
-            created_at, 
+            nameable_id,
+            nameable_type,
+            name,
+            created_at,
             updated_at
           )
-          SELECT all_instance_names.instance_id, 
-                 'CoreDataConnector::Instance', 
-                 all_instance_names.name, 
-                 current_timestamp, 
+          SELECT all_instance_names.instance_id,
+                 'CoreDataConnector::Instance',
+                 all_instance_names.name,
+                 current_timestamp,
                  current_timestamp
             FROM all_instance_names
            WHERE NOT EXISTS ( SELECT 1
@@ -97,7 +120,30 @@ module CoreDataConnector
                                WHERE source_names.nameable_id = all_instance_names.instance_id
                                  AND source_names.nameable_type = 'CoreDataConnector::Instance'
                                  AND source_names.name = all_instance_names.name )
+          RETURNING id AS source_name_id, nameable_id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::SourceName',
+                 insert_instance_names.source_name_id,
+                 'create',
+                 'CoreDataConnector::Instance',
+                 insert_instance_names.nameable_id
+            FROM insert_instance_names
         SQL
+
+        # Snapshot the source_names about to have their "primary" indicator reset
+        audit_updates(
+          CoreDataConnector::SourceName,
+          root_type: "'CoreDataConnector::Instance'",
+          root_id: 'records.nameable_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_instances
+            JOIN core_data_connector_source_names records ON records.nameable_id = z_instances.instance_id
+                                                         AND records.nameable_type = 'CoreDataConnector::Instance'
+          SQL
+        )
 
         # Reset "primary" indicator for all source_names to FALSE
         execute <<-SQL.squish

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -20,6 +20,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the items about to be updated
+        audit_updates(
+          CoreDataConnector::Item,
+          from: <<-SQL.squish
+            FROM #{table_name} z_items
+            JOIN core_data_connector_items records ON records.id = z_items.item_id
+          SQL
+        )
+
         # Update existing items
         execute <<-SQL.squish
           UPDATE core_data_connector_items items
@@ -56,13 +65,25 @@ module CoreDataConnector
             FROM #{table_name} z_items
            WHERE z_items.item_id IS NULL
           RETURNING id AS item_id, z_item_id
-  
-          )
-  
+
+          ),
+
+          update_items AS (
+
           UPDATE #{table_name} z_items
              SET item_id = insert_items.item_id
             FROM insert_items
            WHERE insert_items.z_item_id = z_items.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Item',
+                 insert_items.item_id,
+                 'create',
+                 'CoreDataConnector::Item',
+                 insert_items.item_id
+            FROM insert_items
         SQL
 
         # Insert new source_names
@@ -77,19 +98,21 @@ module CoreDataConnector
           SELECT z_items.item_id AS item_id, unnest(z_items.additional_names) AS name
             FROM #{table_name} z_items
           
-          )
-  
+          ),
+
+          insert_item_names AS (
+
           INSERT INTO core_data_connector_source_names (
-            nameable_id, 
-            nameable_type, 
-            name, 
-            created_at, 
+            nameable_id,
+            nameable_type,
+            name,
+            created_at,
             updated_at
           )
-          SELECT all_item_names.item_id, 
-                 'CoreDataConnector::Item', 
-                 all_item_names.name, 
-                 current_timestamp, 
+          SELECT all_item_names.item_id,
+                 'CoreDataConnector::Item',
+                 all_item_names.name,
+                 current_timestamp,
                  current_timestamp
             FROM all_item_names
            WHERE NOT EXISTS ( SELECT 1
@@ -97,7 +120,30 @@ module CoreDataConnector
                                WHERE source_names.nameable_id = all_item_names.item_id
                                  AND source_names.nameable_type = 'CoreDataConnector::Item'
                                  AND source_names.name = all_item_names.name )
+          RETURNING id AS source_name_id, nameable_id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::SourceName',
+                 insert_item_names.source_name_id,
+                 'create',
+                 'CoreDataConnector::Item',
+                 insert_item_names.nameable_id
+            FROM insert_item_names
         SQL
+
+        # Snapshot the source_names about to have their "primary" indicator reset
+        audit_updates(
+          CoreDataConnector::SourceName,
+          root_type: "'CoreDataConnector::Item'",
+          root_id: 'records.nameable_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_items
+            JOIN core_data_connector_source_names records ON records.nameable_id = z_items.item_id
+                                                         AND records.nameable_type = 'CoreDataConnector::Item'
+          SQL
+        )
 
         # Reset "primary" indicator for all source_names to FALSE
         execute <<-SQL.squish

--- a/app/services/core_data_connector/import/media_content.rb
+++ b/app/services/core_data_connector/import/media_content.rb
@@ -18,6 +18,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the media_contents about to be updated
+        audit_updates(
+          CoreDataConnector::MediaContent,
+          from: <<-SQL.squish
+            FROM #{table_name} z_media_contents
+            JOIN core_data_connector_media_contents records ON records.id = z_media_contents.media_content_id
+          SQL
+        )
+
         execute <<-SQL.squish
          UPDATE core_data_connector_media_contents media_contents
             SET z_media_content_id = z_media_contents.id,
@@ -63,12 +72,24 @@ module CoreDataConnector
            WHERE z_media_contents.media_content_id IS NULL
           RETURNING id AS media_content_id, z_media_content_id
 
-          )
+          ),
+
+          update_media_contents AS (
 
           UPDATE #{table_name} z_media_contents
              SET media_content_id = insert_media_contents.media_content_id
             FROM insert_media_contents
            WHERE insert_media_contents.z_media_content_id = z_media_contents.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::MediaContent',
+                 insert_media_contents.media_content_id,
+                 'create',
+                 'CoreDataConnector::MediaContent',
+                 insert_media_contents.media_content_id
+            FROM insert_media_contents
         SQL
       end
 

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -20,6 +20,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the organizations about to be updated
+        audit_updates(
+          CoreDataConnector::Organization,
+          from: <<-SQL.squish
+            FROM #{table_name} z_organizations
+            JOIN core_data_connector_organizations records ON records.id = z_organizations.organization_id
+          SQL
+        )
+
         # Update existing organizations
         execute <<-SQL.squish
           UPDATE core_data_connector_organizations organizations
@@ -59,12 +68,24 @@ module CoreDataConnector
            WHERE z_organizations.organization_id IS NULL
           RETURNING id AS organization_id, z_organization_id
 
-          )
+          ),
+
+          update_organizations AS (
 
           UPDATE #{table_name} z_organizations
              SET organization_id = insert_organizations.organization_id
             FROM insert_organizations
            WHERE insert_organizations.z_organization_id = z_organizations.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Organization',
+                 insert_organizations.organization_id,
+                 'create',
+                 'CoreDataConnector::Organization',
+                 insert_organizations.organization_id
+            FROM insert_organizations
         SQL
 
         # Insert new organization_names
@@ -79,24 +100,48 @@ module CoreDataConnector
           SELECT z_organizations.organization_id AS organization_id, unnest(z_organizations.additional_names) AS name
             FROM #{table_name} z_organizations
           
-          )
+          ),
+
+          insert_organization_names AS (
 
           INSERT INTO core_data_connector_organization_names (
-            organization_id, 
-            name, 
-            created_at, 
+            organization_id,
+            name,
+            created_at,
             updated_at
           )
-          SELECT all_organization_names.organization_id, 
-                 all_organization_names.name, 
-                 current_timestamp, 
+          SELECT all_organization_names.organization_id,
+                 all_organization_names.name,
+                 current_timestamp,
                  current_timestamp
             FROM all_organization_names
            WHERE NOT EXISTS ( SELECT 1
                                 FROM core_data_connector_organization_names organization_names
                                WHERE organization_names.organization_id = all_organization_names.organization_id
                                  AND organization_names.name = all_organization_names.name )
+          RETURNING id AS organization_name_id, organization_id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::OrganizationName',
+                 insert_organization_names.organization_name_id,
+                 'create',
+                 'CoreDataConnector::Organization',
+                 insert_organization_names.organization_id
+            FROM insert_organization_names
         SQL
+
+        # Snapshot the organization_names about to have their "primary" indicator reset
+        audit_updates(
+          CoreDataConnector::OrganizationName,
+          root_type: "'CoreDataConnector::Organization'",
+          root_id: 'records.organization_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_organizations
+            JOIN core_data_connector_organization_names records ON records.organization_id = z_organizations.organization_id
+          SQL
+        )
 
         # Reset all organization_names "primary" indicator to FALSE
         execute <<-SQL.squish

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -17,6 +17,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the people about to be updated
+        audit_updates(
+          CoreDataConnector::Person,
+          from: <<-SQL.squish
+            FROM #{table_name} z_people
+            JOIN core_data_connector_people records ON records.id = z_people.person_id
+          SQL
+        )
+
         # Update existing people
         execute <<-SQL.squish
           UPDATE core_data_connector_people people
@@ -57,12 +66,24 @@ module CoreDataConnector
            WHERE z_people.person_id IS NULL
           RETURNING id AS person_id, z_person_id
 
-          )
+          ),
+
+          update_people AS (
 
           UPDATE #{table_name} z_people
              SET person_id = insert_people.person_id
             FROM insert_people
            WHERE insert_people.z_person_id = z_people.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Person',
+                 insert_people.person_id,
+                 'create',
+                 'CoreDataConnector::Person',
+                 insert_people.person_id
+            FROM insert_people
         SQL
 
         # Insert new person_names
@@ -83,21 +104,23 @@ module CoreDataConnector
                  unnest(z_people.additional_middle_names) AS middle_name
             FROM #{table_name} z_people
           
-          )
+          ),
+
+          insert_person_names AS (
 
           INSERT INTO core_data_connector_person_names (
-            person_id, 
+            person_id,
             last_name,
             first_name,
-            middle_name, 
-            created_at, 
+            middle_name,
+            created_at,
             updated_at
           )
-          SELECT all_person_names.person_id, 
+          SELECT all_person_names.person_id,
                  all_person_names.last_name,
                  all_person_names.first_name,
-                 all_person_names.middle_name, 
-                 current_timestamp, 
+                 all_person_names.middle_name,
+                 current_timestamp,
                  current_timestamp
             FROM all_person_names
            WHERE NOT EXISTS ( SELECT 1
@@ -107,9 +130,31 @@ module CoreDataConnector
                                   OR ( person_names.last_name IS NULL AND all_person_names.last_name IS NULL ))
                                  AND ( person_names.first_name = all_person_names.first_name
                                   OR ( person_names.first_name IS NULL AND all_person_names.first_name IS NULL ))
-                                 AND ( person_names.middle_name = all_person_names.middle_name 
+                                 AND ( person_names.middle_name = all_person_names.middle_name
                                   OR ( person_names.middle_name IS NULL AND all_person_names.middle_name IS NULL )))
+          RETURNING id AS person_name_id, person_id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::PersonName',
+                 insert_person_names.person_name_id,
+                 'create',
+                 'CoreDataConnector::Person',
+                 insert_person_names.person_id
+            FROM insert_person_names
         SQL
+
+        # Snapshot the person_names about to have their "primary" indicator reset
+        audit_updates(
+          CoreDataConnector::PersonName,
+          root_type: "'CoreDataConnector::Person'",
+          root_id: 'records.person_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_people
+            JOIN core_data_connector_person_names records ON records.person_id = z_people.person_id
+          SQL
+        )
 
         # Reset all person_names "primary" indicator to FALSE
         execute <<-SQL.squish

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -22,6 +22,25 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the places and geometries about to be updated
+        audit_updates(
+          CoreDataConnector::Place,
+          from: <<-SQL.squish
+            FROM #{table_name} z_places
+            JOIN core_data_connector_places records ON records.id = z_places.place_id
+          SQL
+        )
+
+        audit_updates(
+          CoreDataConnector::PlaceGeometry,
+          root_type: "'CoreDataConnector::Place'",
+          root_id: 'records.place_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_places
+            JOIN core_data_connector_place_geometries records ON records.place_id = z_places.place_id
+          SQL
+        )
+
         # Update existing places
         execute <<-SQL.squish
           WITH
@@ -77,17 +96,41 @@ module CoreDataConnector
           insert_place_geometries AS (
 
           INSERT INTO core_data_connector_place_geometries (place_id, geometry, properties, created_at, updated_at)
-          SELECT insert_places.place_id, st_makepoint(z_places.longitude, z_places.latitude), z_places.properties, current_timestamp, current_timestamp
+          SELECT insert_places.place_id, st_makepoint(z_places.longitude, z_places.latitude), COALESCE(z_places.properties, '{}'::jsonb), current_timestamp, current_timestamp
             FROM insert_places
             JOIN #{table_name} z_places ON z_places.id = insert_places.z_place_id
-          RETURNING id
+          RETURNING id AS place_geometry_id, place_id
 
-          )
+          ),
+
+          update_places AS (
 
           UPDATE #{table_name} z_places
              SET place_id = insert_places.place_id
             FROM insert_places
            WHERE insert_places.z_place_id = z_places.id
+
+          ),
+
+          audit_places AS (
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Place',
+                 insert_places.place_id,
+                 'create',
+                 'CoreDataConnector::Place',
+                 insert_places.place_id
+            FROM insert_places
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::PlaceGeometry',
+                 insert_place_geometries.place_geometry_id,
+                 'create',
+                 'CoreDataConnector::Place',
+                 insert_place_geometries.place_id
+            FROM insert_place_geometries
         SQL
 
         # Insert new place_names
@@ -102,7 +145,9 @@ module CoreDataConnector
           SELECT z_places.place_id AS place_id, unnest(z_places.additional_names) AS name
             FROM #{table_name} z_places
           
-          )
+          ),
+
+          insert_place_names AS (
 
           INSERT INTO core_data_connector_place_names (place_id, name, created_at, updated_at)
           SELECT all_place_names.place_id, all_place_names.name, current_timestamp, current_timestamp
@@ -111,7 +156,29 @@ module CoreDataConnector
                                 FROM core_data_connector_place_names place_names
                                WHERE place_names.place_id = all_place_names.place_id
                                  AND place_names.name = all_place_names.name )
+          RETURNING id AS place_name_id, place_id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::PlaceName',
+                 insert_place_names.place_name_id,
+                 'create',
+                 'CoreDataConnector::Place',
+                 insert_place_names.place_id
+            FROM insert_place_names
         SQL
+
+        # Snapshot the place_names about to have their "primary" indicator reset
+        audit_updates(
+          CoreDataConnector::PlaceName,
+          root_type: "'CoreDataConnector::Place'",
+          root_id: 'records.place_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_places
+            JOIN core_data_connector_place_names records ON records.place_id = z_places.place_id
+          SQL
+        )
 
         # Reset all place_names "primary" indicator to FALSE
         execute <<-SQL.squish

--- a/app/services/core_data_connector/import/relationships.rb
+++ b/app/services/core_data_connector/import/relationships.rb
@@ -17,6 +17,29 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the relationships about to be updated. A relationship is rooted in both of its records, so an audit
+        # record is captured for each.
+        relationships_from = <<-SQL.squish
+          FROM #{table_name} z_relationships
+          JOIN core_data_connector_relationships records ON records.id = z_relationships.relationship_id
+        SQL
+
+        audit_updates(
+          CoreDataConnector::Relationship,
+          root_type: 'records.primary_record_type',
+          root_id: 'records.primary_record_id',
+          root_order: 1,
+          from: relationships_from
+        )
+
+        audit_updates(
+          CoreDataConnector::Relationship,
+          root_type: 'records.related_record_type',
+          root_id: 'records.related_record_id',
+          root_order: 2,
+          from: relationships_from
+        )
+
         execute <<-SQL.squish
           UPDATE core_data_connector_relationships relationships
              SET z_relationship_id = z_relationships.id,
@@ -62,14 +85,40 @@ module CoreDataConnector
              AND z_relationships.primary_record_type IS NOT NULL
              AND z_relationships.related_record_id IS NOT NULL
              AND z_relationships.related_record_type IS NOT NULL
-          RETURNING id as relationship_id, z_relationship_id
+          RETURNING id as relationship_id,
+                    z_relationship_id,
+                    primary_record_type,
+                    primary_record_id,
+                    related_record_type,
+                    related_record_id
 
-          )
+          ),
+
+          update_relationships AS (
 
           UPDATE #{table_name} z_relationships
              SET relationship_id = insert_relationships.relationship_id
             FROM insert_relationships
            WHERE insert_relationships.z_relationship_id = z_relationships.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id, root_order)
+          SELECT 'CoreDataConnector::Relationship',
+                 insert_relationships.relationship_id,
+                 'create',
+                 insert_relationships.primary_record_type,
+                 insert_relationships.primary_record_id,
+                 1
+            FROM insert_relationships
+           UNION ALL
+          SELECT 'CoreDataConnector::Relationship',
+                 insert_relationships.relationship_id,
+                 'create',
+                 insert_relationships.related_record_type,
+                 insert_relationships.related_record_id,
+                 2
+            FROM insert_relationships
         SQL
       end
 

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -17,6 +17,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the taxonomies about to be updated
+        audit_updates(
+          CoreDataConnector::Taxonomy,
+          from: <<-SQL.squish
+            FROM #{table_name} z_taxonomies
+            JOIN core_data_connector_taxonomies records ON records.id = z_taxonomies.taxonomy_id
+          SQL
+        )
+
         execute <<-SQL.squish
           UPDATE core_data_connector_taxonomies taxonomies
             SET  z_taxonomy_id = z_taxonomies.id,
@@ -55,12 +64,24 @@ module CoreDataConnector
            WHERE z_taxonomies.taxonomy_id IS NULL
           RETURNING id AS taxonomy_id, z_taxonomy_id
 
-          )
+          ),
+
+          update_taxonomies AS (
 
           UPDATE #{table_name} z_taxonomies
               SET taxonomy_id = insert_taxonomies.taxonomy_id
              FROM insert_taxonomies
             WHERE insert_taxonomies.z_taxonomy_id = z_taxonomies.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Taxonomy',
+                 insert_taxonomies.taxonomy_id,
+                 'create',
+                 'CoreDataConnector::Taxonomy',
+                 insert_taxonomies.taxonomy_id
+            FROM insert_taxonomies
         SQL
       end
 

--- a/app/services/core_data_connector/import/web_identifiers.rb
+++ b/app/services/core_data_connector/import/web_identifiers.rb
@@ -17,6 +17,17 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the web_identifiers about to be updated
+        audit_updates(
+          CoreDataConnector::WebIdentifier,
+          root_type: 'records.identifiable_type',
+          root_id: 'records.identifiable_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_web_identifiers
+            JOIN core_data_connector_web_identifiers records ON records.id = z_web_identifiers.web_identifier_id
+          SQL
+        )
+
         execute <<-SQL.squish
           UPDATE core_data_connector_web_identifiers web_identifiers
              SET z_web_identifier_id = z_web_identifiers.id,
@@ -48,14 +59,26 @@ module CoreDataConnector
                  current_timestamp
           FROM   #{table_name} z_web_identifiers
           WHERE  z_web_identifiers.web_identifier_id IS NULL
-          RETURNING id AS web_identifier_id, z_web_identifier_id
+          RETURNING id AS web_identifier_id, z_web_identifier_id, identifiable_type, identifiable_id
 
-          )
+          ),
+
+          update_web_identifiers AS (
 
           UPDATE #{table_name} z_web_identifiers
              SET web_identifier_id = insert_web_identifiers.web_identifier_id
             FROM insert_web_identifiers
            WHERE insert_web_identifiers.z_web_identifier_id = z_web_identifiers.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::WebIdentifier',
+                 insert_web_identifiers.web_identifier_id,
+                 'create',
+                 insert_web_identifiers.identifiable_type,
+                 insert_web_identifiers.identifiable_id
+            FROM insert_web_identifiers
         SQL
       end
 

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -20,6 +20,15 @@ module CoreDataConnector
       def load
         super
 
+        # Snapshot the works about to be updated
+        audit_updates(
+          CoreDataConnector::Work,
+          from: <<-SQL.squish
+            FROM #{table_name} z_works
+            JOIN core_data_connector_works records ON records.id = z_works.work_id
+          SQL
+        )
+
         # Update existing works
         execute <<-SQL.squish
           UPDATE core_data_connector_works works
@@ -56,13 +65,25 @@ module CoreDataConnector
             FROM #{table_name} z_works
            WHERE z_works.work_id IS NULL
           RETURNING id AS work_id, z_work_id
-  
-          )
-  
+
+          ),
+
+          update_works AS (
+
           UPDATE #{table_name} z_works
              SET work_id = insert_works.work_id
             FROM insert_works
            WHERE insert_works.z_work_id = z_works.id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::Work',
+                 insert_works.work_id,
+                 'create',
+                 'CoreDataConnector::Work',
+                 insert_works.work_id
+            FROM insert_works
         SQL
 
         # Insert new source_names
@@ -77,19 +98,21 @@ module CoreDataConnector
           SELECT z_works.work_id AS work_id, unnest(z_works.additional_names) AS name
             FROM #{table_name} z_works
           
-          )
-  
+          ),
+
+          insert_work_names AS (
+
           INSERT INTO core_data_connector_source_names (
-            nameable_id, 
-            nameable_type, 
-            name, 
-            created_at, 
+            nameable_id,
+            nameable_type,
+            name,
+            created_at,
             updated_at
           )
-          SELECT all_work_names.work_id, 
-                 'CoreDataConnector::Work', 
-                 all_work_names.name, 
-                 current_timestamp, 
+          SELECT all_work_names.work_id,
+                 'CoreDataConnector::Work',
+                 all_work_names.name,
+                 current_timestamp,
                  current_timestamp
             FROM all_work_names
            WHERE NOT EXISTS ( SELECT 1
@@ -97,7 +120,30 @@ module CoreDataConnector
                                WHERE source_names.nameable_id = all_work_names.work_id
                                  AND source_names.nameable_type = 'CoreDataConnector::Work'
                                  AND source_names.name = all_work_names.name )
+          RETURNING id AS source_name_id, nameable_id
+
+          )
+
+          INSERT INTO #{audit_table} (item_type, item_id, event, root_type, root_id)
+          SELECT 'CoreDataConnector::SourceName',
+                 insert_work_names.source_name_id,
+                 'create',
+                 'CoreDataConnector::Work',
+                 insert_work_names.nameable_id
+            FROM insert_work_names
         SQL
+
+        # Snapshot the source_names about to have their "primary" indicator reset
+        audit_updates(
+          CoreDataConnector::SourceName,
+          root_type: "'CoreDataConnector::Work'",
+          root_id: 'records.nameable_id',
+          from: <<-SQL.squish
+            FROM #{table_name} z_works
+            JOIN core_data_connector_source_names records ON records.nameable_id = z_works.work_id
+                                                         AND records.nameable_type = 'CoreDataConnector::Work'
+          SQL
+        )
 
         # Reset "primary" indicator for all source_names to FALSE
         execute <<-SQL.squish

--- a/app/services/core_data_connector/import/zip_helper.rb
+++ b/app/services/core_data_connector/import/zip_helper.rb
@@ -5,7 +5,7 @@ IGNORE_PATTERN = /\.DS_Store|__MACOSX|(^|\/)\._/
 module CoreDataConnector
   module Import
     class ZipHelper
-      def import_zip(temp_file)
+      def import_zip(temp_file, user_id = nil)
         begin
           # Create the target directory
           destination = "#{Rails.root}/tmp/#{SecureRandom.urlsafe_base64}"
@@ -28,7 +28,7 @@ module CoreDataConnector
           import_id = nil
 
           # Create a new importer with the temp directory and run it
-          importer = CoreDataConnector::Import::Importer.new(destination)
+          importer = CoreDataConnector::Import::Importer.new(destination, user_id)
 
           ActiveRecord::Base.transaction do
             import_id = importer.run


### PR DESCRIPTION
# Summary

This PR updates the import script to create version records for all imported records.

Closes #658

## Testing notes

- [ ] Imports should work exactly the same as before. You shouldn't see any weird behavior from imports.
- [ ] After importing new records, you should see a row in the project audit log, as well as the record-specific audit log, showing a creation event.
  - [ ] There should be a user attached to the version row, and that user should be you 🫵
- [ ] After *updating* existing records via import, you should see a version row in the audit log that shows the change you made the same as if you'd made it via the form.
- [ ] Imports will take longer than before. But they shouldn't take *drastically* longer.