### PR TITLE
Remove unwanted fields from AtoM identifier modal

### DIFF
--- a/client/src/components/AtomIdentifierForm.js
+++ b/client/src/components/AtomIdentifierForm.js
@@ -78,23 +78,6 @@ const AtomIdentifierForm = (props: Props) => {
           value={props.value}
         />
       </Form.Input>
-      { selectedItem && selectedItem.place_access_points && (
-        <AtomExtraDropdown
-          label={t('AtomIdentifierForm.labels.geographic')}
-          onChange={props.onExtraSelection.bind(this, 'place_access_points')}
-          options={selectedItem.place_access_points}
-          value={props.extra?.place_access_points}
-        />
-      )}
-      { selectedItem && selectedItem.languages_of_material && (
-        <AtomExtraDropdown
-          label={t('AtomIdentifierForm.labels.language')}
-          multiple
-          onChange={props.onExtraSelection.bind(this, 'languages_of_material')}
-          options={selectedItem.languages_of_material}
-          value={props.extra?.languages_of_material}
-        />
-      )}
       { selectedItem && selectedItem.subject_access_points && (
         <AtomExtraDropdown
           label={t('AtomIdentifierForm.labels.subject')}


### PR DESCRIPTION
### In this PR
Removes unnecessary fields from the modal for adding an AtoM identifier to a record. See https://github.com/performant-software/mica-web/issues/151 . (Right now I believe MiCA is the only project using the AtoM identifiers, so I don't see any harm in removing these fields if the MiCA team finds them superfluous; if that's wrong and there are other projects using the identifier, then obviously further thought is needed.)