### PR TITLE
Publication controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# core-data-cloud
+# FairData
 
 ## Requirements
 
 - macOS or Linux
 - Ruby version that matches the `.ruby-version` file. ([rbenv](https://github.com/rbenv/rbenv) is recommended for managing Ruby versions)
-- Node 18 ([nvm](https://github.com/nvm-sh/nvm) is likewise recommended)
-- Postgres (this template is confirmed to work with Postgres 18, but any reasonably recent version should work)
+- Node 24 ([mise](https://mise.jdx.dev/lang/node.html#node)) is likewise recommended)
+- Postgres (FairData is confirmed to work with Postgres 18, but any reasonably recent version should work)
 - Heroku CLI (optional, if you want to deploy on Heroku)
 
 ## Setup
@@ -28,10 +28,190 @@ To install Flow types run `yarn flow-typed install`. To run Flow server run `yar
 
 **Note:** Currently, Flow is throwing errors for most files. Instead of updating these all at once, we should fix the Flow errors as other changes are made to the files. Eventually, we should convert this code-base to Typescript.
 
+## Search
+
+Data can be indexed into a Typesense search index using the following commands:
+
+#### Create a new collection
+```bash
+bundle exec rake typesense:search:create -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+#### Delete a collection
+```bash
+bundle exec rake typesense:search:delete -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+#### Index documents into a collection
+```bash
+bundle exec rake typesense:search:index -- -h host -p port -r protocol -a api_key -c collection_name -m model_ids --polygons
+```
+
+**Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.
+
+#### Update a collection
+```bash
+bundle exec rake typesense:search:update -- -h host -p port -r protocol -a api_key -c collection_name
+```
+
+**Note:** This task was added as a workaround for an issue in Typesense indexing nested facetable fields using auto-detection schema. This task should be run _after_ the indexing process to update the "facet" attribute on any fields that should be facetable.
+
+## Reconciliation API
+
+### Indexing Data
+
+Data can be indexed into a Typesense search index using the following commands. The search index is used as the data store for results returned from the Reconciliation API.
+
+#### Create a new collection
+```bash
+bundle exec rake typesense:reconcile:create -- --host=host --port=port --protocol=protocol --api-key=api_key --collection-name=collection_name
+```
+
+#### Delete a collection
+```bash
+bundle exec rake typesense:reconcile:delete -- --host=host --port=port --protocol=protocol --api-key=api_key --collection-name=collection_name
+```
+
+#### Index documents into a collection
+```bash
+bundle exec rake typesense:reconcile:index -- --host=host --port=port --protocol=protocol --api-key=api_key --collection-name=collection_name --project-id=project_id
+```
+
+**Note:** This task expects the entire collection to be indexed. Any records not included in the batch will be removed from the index.
+
+### Update Project
+
+In order to make requests to the Reconciliation API, the project record must be updated with Typesense credentials. This can be configured in the project's "Project Settings" form in the FairData user interface. The Typesense API key needs at least `"collections:get"`, `"documents:search"`, and `"documents:get"` permissions.
+
+### Requests
+
+Requests can be made to the Reconciliation API via the following URLs. Follow the [spec](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#structure-of-a-reconciliation-query) to see how queries and responses should be structured.
+
+```
+GET /core_data/reconcile/projects/:id
+```
+
+```
+POST /core_data/reconcile/projects/:id
+```
+
+The Reconciliation API response for a project includes a `view` property indicating how to structure a view URI. The view URI for an individual record will simply redirect to the CMS edit page for that record:
+```
+GET /core_data/reconcile/projects/:id/view/:record_id
+```
+
+## Public API
+
+In addition to the authenticated API, FairData also provides a public API for the following endpoints:
+
+### Events
+```
+GET /core_data/public/v1/events/:uuid
+GET /core_data/public/v1/events/:uuid/events
+GET /core_data/public/v1/events/:uuid/instances
+GET /core_data/public/v1/events/:uuid/items
+GET /core_data/public/v1/events/:uuid/manifests
+GET /core_data/public/v1/events/:uuid/manifests/:uuid
+GET /core_data/public/v1/events/:uuid/media_contents
+GET /core_data/public/v1/events/:uuid/organizations
+GET /core_data/public/v1/events/:uuid/people
+GET /core_data/public/v1/events/:uuid/places
+GET /core_data/public/v1/events/:uuid/taxonomies
+GET /core_data/public/v1/events/:uuid/works
+```
+
+### Instances
+```
+GET /core_data/public/v1/instances/:uuid
+GET /core_data/public/v1/instances/:uuid/events
+GET /core_data/public/v1/instances/:uuid/instances
+GET /core_data/public/v1/instances/:uuid/items
+GET /core_data/public/v1/instances/:uuid/manifests
+GET /core_data/public/v1/instances/:uuid/manifests/:uuid
+GET /core_data/public/v1/instances/:uuid/media_contents
+GET /core_data/public/v1/instances/:uuid/organizations
+GET /core_data/public/v1/instances/:uuid/people
+GET /core_data/public/v1/instances/:uuid/places
+GET /core_data/public/v1/instances/:uuid/taxonomies
+GET /core_data/public/v1/instances/:uuid/works
+```
+
+### Items
+```
+GET /core_data/public/v1/items/:uuid
+GET /core_data/public/v1/items/:uuid/events
+GET /core_data/public/v1/items/:uuid/instances
+GET /core_data/public/v1/items/:uuid/items
+GET /core_data/public/v1/items/:uuid/manifests
+GET /core_data/public/v1/items/:uuid/manifests/:uuid
+GET /core_data/public/v1/items/:uuid/media_contents
+GET /core_data/public/v1/items/:uuid/organizations
+GET /core_data/public/v1/items/:uuid/people
+GET /core_data/public/v1/items/:uuid/places
+GET /core_data/public/v1/items/:uuid/taxonomies
+GET /core_data/public/v1/items/:uuid/works
+```
+
+### People
+```
+GET /core_data/public/v1/people/:uuid
+GET /core_data/public/v1/people/:uuid/events
+GET /core_data/public/v1/people/:uuid/instances
+GET /core_data/public/v1/people/:uuid/items
+GET /core_data/public/v1/people/:uuid/manifests
+GET /core_data/public/v1/people/:uuid/manifests/:uuid
+GET /core_data/public/v1/people/:uuid/media_contents
+GET /core_data/public/v1/people/:uuid/organizations
+GET /core_data/public/v1/people/:uuid/people
+GET /core_data/public/v1/people/:uuid/places
+GET /core_data/public/v1/people/:uuid/taxonomies
+GET /core_data/public/v1/people/:uuid/works
+```
+
+### Places
+```
+GET /core_data/public/v1/places/:uuid
+GET /core_data/public/v1/places/:uuid/events
+GET /core_data/public/v1/places/:uuid/instances
+GET /core_data/public/v1/places/:uuid/items
+GET /core_data/public/v1/places/:uuid/manifests
+GET /core_data/public/v1/places/:uuid/manifests/:uuid
+GET /core_data/public/v1/places/:uuid/media_contents
+GET /core_data/public/v1/places/:uuid/organizations
+GET /core_data/public/v1/places/:uuid/people
+GET /core_data/public/v1/places/:uuid/places
+GET /core_data/public/v1/places/:uuid/taxonomies
+GET /core_data/public/v1/places/:uuid/works
+```
+
+### Works
+```
+GET /core_data/public/v1/works/:uuid
+GET /core_data/public/v1/works/:uuid/events
+GET /core_data/public/v1/works/:uuid/instances
+GET /core_data/public/v1/works/:uuid/items
+GET /core_data/public/v1/works/:uuid/manifests
+GET /core_data/public/v1/works/:uuid/manifests/:uuid
+GET /core_data/public/v1/works/:uuid/media_contents
+GET /core_data/public/v1/works/:uuid/organizations
+GET /core_data/public/v1/works/:uuid/people
+GET /core_data/public/v1/works/:uuid/places
+GET /core_data/public/v1/works/:uuid/taxonomies
+GET /core_data/public/v1/works/:uuid/works
+```
+
+The following query parameters can be used to further modify the results:
+
+| Parameter   | Description                                      | Required |
+|-------------|--------------------------------------------------|----------|
+| project_ids | An array of project IDs                          | Yes      |
+| search      | Search text used to filter the records           | No       |
+| sort_by     | A database colum name to use for sorting records | No       |
+
 ## Docker
 
 #### Prerequsites
-To run via Docker requires a IIIF Cloud instance as well. This can be run as a separate Docker application, or pointed to a IIIF Cloud application hosted somewhere else. All that's required is the `IIIF_CLOUD_*` environment variables are set properly and a MapTiler account/API key.
+To run via Docker requires a FairImage instance as well. This can be run as a separate Docker application, or pointed to a FairImage application hosted somewhere else. All that's required is the `IIIF_CLOUD_*` environment variables are set properly and a MapTiler account/API key.
 
 #### Running
 To run via a Docker container (for development or production) set your environment variables in `.env`, you can use `.env.example` as a template. If an image has not yet been built, run `docker compose up --build` to build the image and start the container. Subsequent starts of the container can be done with `docker compose up` if no code changes have been made.

--- a/app/controllers/concerns/core_data_connector/public/v0/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v0/nestable_controller.rb
@@ -4,6 +4,8 @@ module CoreDataConnector
       module NestableController
         extend ActiveSupport::Concern
 
+        NESTABLE_PARAMS = %i(event_id instance_id item_id place_id work_id)
+
         included do
           # Member attributes
           attr_reader :current_record
@@ -11,19 +13,23 @@ module CoreDataConnector
           # Actions
           before_action :set_current_record
 
+          def nested_route?
+            NESTABLE_PARAMS.any? { |p| params[p].present? }
+          end
+
           private
 
           def set_current_record
             if params[:event_id].present?
-              @current_record = Event.find_by_uuid(params[:event_id])
+              @current_record = Event.published.find_by_uuid(params[:event_id])
             elsif params[:instance_id].present?
-              @current_record = Instance.find_by_uuid(params[:instance_id])
+              @current_record = Instance.published.find_by_uuid(params[:instance_id])
             elsif params[:item_id].present?
-              @current_record = Item.find_by_uuid(params[:item_id])
+              @current_record = Item.published.find_by_uuid(params[:item_id])
             elsif params[:place_id].present?
-              @current_record = Place.find_by_uuid(params[:place_id])
+              @current_record = Place.published.find_by_uuid(params[:place_id])
             elsif params[:work_id].present?
-              @current_record = Work.find_by_uuid(params[:work_id])
+              @current_record = Work.published.find_by_uuid(params[:work_id])
             end
           end
         end

--- a/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/public/v1/nestable_controller.rb
@@ -19,21 +19,22 @@ module CoreDataConnector
 
           private
 
+          # Unpublished records are not exposed by the public API, so they cannot be used as the parent of a nested route
           def set_current_record
             if params[:event_id].present?
-              @current_record = Event.find_by_uuid(params[:event_id])
+              @current_record = Event.published.find_by_uuid(params[:event_id])
             elsif params[:instance_id].present?
-              @current_record = Instance.find_by_uuid(params[:instance_id])
+              @current_record = Instance.published.find_by_uuid(params[:instance_id])
             elsif params[:item_id].present?
-              @current_record = Item.find_by_uuid(params[:item_id])
+              @current_record = Item.published.find_by_uuid(params[:item_id])
             elsif params[:organization_id].present?
-              @current_record = Organization.find_by_uuid(params[:organization_id])
+              @current_record = Organization.published.find_by_uuid(params[:organization_id])
             elsif params[:person_id].present?
-              @current_record = Person.find_by_uuid(params[:person_id])
+              @current_record = Person.published.find_by_uuid(params[:person_id])
             elsif params[:place_id].present?
-              @current_record = Place.find_by_uuid(params[:place_id])
+              @current_record = Place.published.find_by_uuid(params[:place_id])
             elsif params[:work_id].present?
-              @current_record = Work.find_by_uuid(params[:work_id])
+              @current_record = Work.published.find_by_uuid(params[:work_id])
             end
           end
         end

--- a/app/controllers/concerns/core_data_connector/publishable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/publishable_controller.rb
@@ -1,0 +1,28 @@
+module CoreDataConnector
+  module PublishableController
+    extend ActiveSupport::Concern
+
+    included do
+      def publish
+        item = find_record(item_class)
+        authorize item, :publish?
+
+        if item.update(published: published_param)
+          item = prepare_item(item)
+          preloads(item)
+
+          render json: build_show_response(item), status: :ok
+        else
+          render json: { errors: item.errors }, status: :bad_request
+        end
+      end
+
+      private
+
+      def published_param
+        ActiveModel::Type::Boolean.new.cast(params[:published]) || false
+      end
+
+    end
+  end
+end

--- a/app/controllers/core_data_connector/events_controller.rb
+++ b/app/controllers/core_data_connector/events_controller.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include ManifestableController
     include MergeableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/instances_controller.rb
+++ b/app/controllers/core_data_connector/instances_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/items_controller.rb
+++ b/app/controllers/core_data_connector/items_controller.rb
@@ -6,6 +6,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/media_contents_controller.rb
+++ b/app/controllers/core_data_connector/media_contents_controller.rb
@@ -6,6 +6,7 @@ module CoreDataConnector
     include ManifestableController
     include MergeableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include TripleEyeEffable::ResourceableController
     include UserDefinedFields::Queryable

--- a/app/controllers/core_data_connector/organizations_controller.rb
+++ b/app/controllers/core_data_connector/organizations_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/people_controller.rb
+++ b/app/controllers/core_data_connector/people_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/places_controller.rb
+++ b/app/controllers/core_data_connector/places_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/public/v0/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v0/public_controller.rb
@@ -8,15 +8,18 @@ module CoreDataConnector
         protected
 
         def base_query
-          if nested_resource? && current_record.present?
-            item_class.where(build_base_sql)
-          elsif nested_resource?
-            item_class.none
-          elsif params[:project_ids].present?
-            item_class.all_records_by_project(params[:project_ids])
-          else
-            item_class.none
-          end
+          query = if nested_resource? && current_record.present?
+                    item_class.where(build_base_sql)
+                  elsif nested_route?
+                    # The parent record is missing or unpublished, so it has no records to nest
+                    item_class.none
+                  elsif params[:project_ids].present?
+                    item_class.all_records_by_project(params[:project_ids])
+                  else
+                    item_class.none
+                  end
+
+          query.published
         end
 
         def load_records(item)

--- a/app/controllers/core_data_connector/public/v1/public_controller.rb
+++ b/app/controllers/core_data_connector/public/v1/public_controller.rb
@@ -25,7 +25,7 @@ module CoreDataConnector
             query = item_class.none
           end
 
-          query
+          query.published
         end
 
         def find_record(query)

--- a/app/controllers/core_data_connector/taxonomies_controller.rb
+++ b/app/controllers/core_data_connector/taxonomies_controller.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include ManifestableController
     include MergeableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/controllers/core_data_connector/works_controller.rb
+++ b/app/controllers/core_data_connector/works_controller.rb
@@ -5,6 +5,7 @@ module CoreDataConnector
     include MergeableController
     include NameableController
     include OwnableController
+    include PublishableController
     include RelatedColumnable
     include UserDefinedFields::Queryable
 

--- a/app/models/concerns/core_data_connector/publishable.rb
+++ b/app/models/concerns/core_data_connector/publishable.rb
@@ -6,6 +6,15 @@ module CoreDataConnector
       # Scopes
       scope :published, -> { where(published: true) }
       scope :unpublished, -> { where(published: false) }
+
+      # Callbacks
+      before_validation :set_published, on: :create
+
+      private
+
+      def set_published
+        self[:published] = project.default_to_published
+      end
     end
 
     def publish!

--- a/app/models/concerns/core_data_connector/publishable.rb
+++ b/app/models/concerns/core_data_connector/publishable.rb
@@ -1,0 +1,19 @@
+module CoreDataConnector
+  module Publishable
+    extend ActiveSupport::Concern
+
+    included do
+      # Scopes
+      scope :published, -> { where(published: true) }
+      scope :unpublished, -> { where(published: false) }
+    end
+
+    def publish!
+      update!(published: true)
+    end
+
+    def unpublish!
+      update!(published: false)
+    end
+  end
+end

--- a/app/models/core_data_connector/event.rb
+++ b/app/models/core_data_connector/event.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
     include Manifestable
     include Mergeable
     include Ownable
+    include Publishable
     include Reconcile::Event
     include Relateable
     include Search::Event

--- a/app/models/core_data_connector/instance.rb
+++ b/app/models/core_data_connector/instance.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Publishable
     include Reconcile::Instance
     include Relateable
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/item.rb
+++ b/app/models/core_data_connector/item.rb
@@ -10,6 +10,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Publishable
     include Reconcile::Item
     include Relateable
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/media_content.rb
+++ b/app/models/core_data_connector/media_content.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Manifestable
     include Mergeable
     include Ownable
+    include Publishable
     include Relateable
     include Search::MediaContent
     include Auditable

--- a/app/models/core_data_connector/organization.rb
+++ b/app/models/core_data_connector/organization.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Publishable
     include Reconcile::Organization
     include Relateable
     include Search::Organization

--- a/app/models/core_data_connector/person.rb
+++ b/app/models/core_data_connector/person.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Publishable
     include Reconcile::Person
     include Relateable
     include Search::Person

--- a/app/models/core_data_connector/place.rb
+++ b/app/models/core_data_connector/place.rb
@@ -11,6 +11,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Publishable
     include Reconcile::Place
     include Relateable
     include Search::Place

--- a/app/models/core_data_connector/taxonomy.rb
+++ b/app/models/core_data_connector/taxonomy.rb
@@ -8,6 +8,7 @@ module CoreDataConnector
     include Manifestable
     include Mergeable
     include Ownable
+    include Publishable
     include Reconcile::Taxonomy
     include Relateable
     include UserDefinedFields::Fieldable

--- a/app/models/core_data_connector/work.rb
+++ b/app/models/core_data_connector/work.rb
@@ -9,6 +9,7 @@ module CoreDataConnector
     include Mergeable
     include Nameable
     include Ownable
+    include Publishable
     include Reconcile::Work
     include Relateable
     include UserDefinedFields::Fieldable

--- a/app/policies/concerns/core_data_connector/publishable_policy.rb
+++ b/app/policies/concerns/core_data_connector/publishable_policy.rb
@@ -1,0 +1,25 @@
+module CoreDataConnector
+  module PublishablePolicy
+    extend ActiveSupport::Concern
+
+    included do
+      # A user can publish or unpublish a record if they are an admin or an owner of the project that owns the record.
+      def publish?
+        return true if current_user.admin?
+
+        !project.archived? && project_owner?
+      end
+
+      private
+
+      # Returns true if the current user has an owner `user_projects` record for the project that owns the record.
+      def project_owner?
+        current_user
+          .user_projects
+          .where(project_id: project_id)
+          .where(role: UserProject::ROLE_OWNER)
+          .exists?
+      end
+    end
+  end
+end

--- a/app/policies/core_data_connector/event_policy.rb
+++ b/app/policies/core_data_connector/event_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :event, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/instance_policy.rb
+++ b/app/policies/core_data_connector/instance_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :instance, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/item_policy.rb
+++ b/app/policies/core_data_connector/item_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :item, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/media_content_policy.rb
+++ b/app/policies/core_data_connector/media_content_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :media_content, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/organization_policy.rb
+++ b/app/policies/core_data_connector/organization_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :organization, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/person_policy.rb
+++ b/app/policies/core_data_connector/person_policy.rb
@@ -2,6 +2,7 @@ module CoreDataConnector
   class PersonPolicy < BasePolicy
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :person, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/place_policy.rb
+++ b/app/policies/core_data_connector/place_policy.rb
@@ -4,6 +4,7 @@ module CoreDataConnector
     include ManifestablePolicy
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :place, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/project_policy.rb
+++ b/app/policies/core_data_connector/project_policy.rb
@@ -101,6 +101,7 @@ module CoreDataConnector
       attributes = [
         :name,
         :description,
+        :default_to_published,
         :discoverable,
         :faircopy_cloud_url,
         :faircopy_cloud_project_id,

--- a/app/policies/core_data_connector/taxonomy_policy.rb
+++ b/app/policies/core_data_connector/taxonomy_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :taxonomy, :project_model_id, :project, :project_id
 

--- a/app/policies/core_data_connector/work_policy.rb
+++ b/app/policies/core_data_connector/work_policy.rb
@@ -3,6 +3,7 @@ module CoreDataConnector
     # Includes
     include MergeablePolicy
     include OwnablePolicy
+    include PublishablePolicy
 
     attr_reader :current_user, :work, :project_model_id, :project, :project_id
 

--- a/app/serializers/concerns/core_data_connector/publishable_serializer.rb
+++ b/app/serializers/concerns/core_data_connector/publishable_serializer.rb
@@ -1,0 +1,10 @@
+module CoreDataConnector
+  module PublishableSerializer
+    extend ActiveSupport::Concern
+
+    included do
+      index_attributes :published
+      show_attributes :published
+    end
+  end
+end

--- a/app/serializers/core_data_connector/events_serializer.rb
+++ b/app/serializers/core_data_connector/events_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class EventsSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/instances_serializer.rb
+++ b/app/serializers/core_data_connector/instances_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class InstancesSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/items_serializer.rb
+++ b/app/serializers/core_data_connector/items_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class ItemsSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/media_contents_serializer.rb
+++ b/app/serializers/core_data_connector/media_contents_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class MediaContentsSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include TripleEyeEffable::ResourceableSerializer
     include UserDefinedFields::FieldableSerializer
 

--- a/app/serializers/core_data_connector/organizations_serializer.rb
+++ b/app/serializers/core_data_connector/organizations_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class OrganizationsSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/people_serializer.rb
+++ b/app/serializers/core_data_connector/people_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class PeopleSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/places_serializer.rb
+++ b/app/serializers/core_data_connector/places_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class PlacesSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/projects_serializer.rb
+++ b/app/serializers/core_data_connector/projects_serializer.rb
@@ -1,10 +1,10 @@
 module CoreDataConnector
   class ProjectsSerializer < BaseSerializer
     index_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_id, :map_library_url,
-                     :faircopy_cloud_project_model_id, :archived
+                     :faircopy_cloud_project_model_id, :archived, :default_to_published
 
     show_attributes :id, :name, :description, :discoverable, :faircopy_cloud_url, :faircopy_cloud_project_id, :map_library_url,
                     :faircopy_cloud_project_model_id, :archived, :reconciliation_credentials,
-                    :use_storage_key, :uuid
+                    :use_storage_key, :uuid, :default_to_published
   end
 end

--- a/app/serializers/core_data_connector/taxonomies_serializer.rb
+++ b/app/serializers/core_data_connector/taxonomies_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class TaxonomiesSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/serializers/core_data_connector/works_serializer.rb
+++ b/app/serializers/core_data_connector/works_serializer.rb
@@ -1,6 +1,7 @@
 module CoreDataConnector
   class WorksSerializer < BaseSerializer
     include OwnableSerializer
+    include PublishableSerializer
     include UserDefinedFields::FieldableSerializer
     include RelatedColumnsSerializable
 

--- a/app/services/core_data_connector/iiif/manifest.rb
+++ b/app/services/core_data_connector/iiif/manifest.rb
@@ -103,6 +103,8 @@ module CoreDataConnector
 
               manifest.save
             end
+
+            remove_stale_manifests record, hash, options
           end
         end
       end
@@ -124,6 +126,7 @@ module CoreDataConnector
       def apply_preloads(query, options)
         relationships_scope = Relationship
                                 .joins(:related_media_content)
+                                .where(MediaContent.arel_table[:published].eq(true))
                                 .order(
                                   Relationship.arel_table[:order],
                                   MediaContent.arel_table[:name],
@@ -148,6 +151,7 @@ module CoreDataConnector
                                         .joins(:project_model_relationship)
                                         .joins(:inverse_related_media_content)
                                         .where(project_model_relationship: { allow_inverse: true })
+                                        .where(MediaContent.arel_table[:published].eq(true))
                                         .order(
                                           Relationship.arel_table[:order],
                                           MediaContent.arel_table[:name],
@@ -197,6 +201,24 @@ module CoreDataConnector
 
       def find_manifest(record, project_model_relationship_id)
         record.manifests.select{ |m| m.project_model_relationship_id == project_model_relationship_id }.first
+      end
+
+      # Destroys the manifests for relationships that no longer have any resources to display, so that a manifest is
+      # not left behind for a relationship whose media contents have all been unpublished or deleted. Only the
+      # relationship being reset is considered, if one was passed.
+      def remove_stale_manifests(record, hash, options)
+        project_model_relationship_ids = hash.values.map{ |info| info[:id] }
+
+        manifests = record
+                      .manifests
+                      .reject{ |m| project_model_relationship_ids.include?(m.project_model_relationship_id) }
+
+        if options[:project_model_relationship_id].present?
+          project_model_relationship_id = options[:project_model_relationship_id].to_i
+          manifests = manifests.select{ |m| m.project_model_relationship_id == project_model_relationship_id }
+        end
+
+        manifests.each(&:destroy)
       end
 
     end

--- a/app/services/core_data_connector/import/base.rb
+++ b/app/services/core_data_connector/import/base.rb
@@ -121,6 +121,15 @@ module CoreDataConnector
         )
       end
 
+      def default_to_published(table_alias)
+        <<-SQL.squish
+          COALESCE(( SELECT projects.default_to_published
+                       FROM core_data_connector_project_models project_models
+                       JOIN core_data_connector_projects projects ON projects.id = project_models.project_id
+                      WHERE project_models.id = #{table_alias}.project_model_id ), TRUE)
+        SQL
+      end
+
       def execute(sql)
         @connection.execute sql
       end

--- a/app/services/core_data_connector/import/events.rb
+++ b/app/services/core_data_connector/import/events.rb
@@ -81,6 +81,7 @@ module CoreDataConnector
             description, 
             user_defined,
             import_id,
+            published,
             created_at, 
             updated_at
           )
@@ -91,6 +92,7 @@ module CoreDataConnector
                  z_events.description, 
                  z_events.user_defined,
                  z_events.import_id,
+                 #{default_to_published('z_events')},
                  current_timestamp, 
                  current_timestamp
             FROM #{table_name} z_events

--- a/app/services/core_data_connector/import/instances.rb
+++ b/app/services/core_data_connector/import/instances.rb
@@ -52,6 +52,7 @@ module CoreDataConnector
             z_instance_id,
             user_defined,
             import_id,
+            published,
             created_at,
             updated_at
           )
@@ -60,6 +61,7 @@ module CoreDataConnector
                  z_instances.id,
                  z_instances.user_defined,
                  z_instances.import_id,
+                 #{default_to_published('z_instances')},
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_instances

--- a/app/services/core_data_connector/import/items.rb
+++ b/app/services/core_data_connector/import/items.rb
@@ -52,6 +52,7 @@ module CoreDataConnector
             z_item_id,
             user_defined,
             import_id,
+            published,
             created_at,
             updated_at
           )
@@ -60,6 +61,7 @@ module CoreDataConnector
                  z_items.id,
                  z_items.user_defined,
                  z_items.import_id,
+                 #{default_to_published('z_items')},
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_items

--- a/app/services/core_data_connector/import/media_content.rb
+++ b/app/services/core_data_connector/import/media_content.rb
@@ -55,6 +55,7 @@ module CoreDataConnector
             content_warning,
             user_defined,
             import_id,
+            published,
             created_at, 
             updated_at
           )
@@ -66,6 +67,7 @@ module CoreDataConnector
                  COALESCE(z_media_contents.content_warning, FALSE),
                  z_media_contents.user_defined,
                  z_media_contents.import_id,
+                 #{default_to_published('z_media_contents')},
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_media_contents

--- a/app/services/core_data_connector/import/organizations.rb
+++ b/app/services/core_data_connector/import/organizations.rb
@@ -53,6 +53,7 @@ module CoreDataConnector
             description, 
             user_defined,
             import_id,
+            published,
             created_at, 
             updated_at
           )
@@ -62,6 +63,7 @@ module CoreDataConnector
                  z_organizations.description, 
                  z_organizations.user_defined, 
                  z_organizations.import_id,
+                 #{default_to_published('z_organizations')},
                  current_timestamp, 
                  current_timestamp
             FROM #{table_name} z_organizations

--- a/app/services/core_data_connector/import/people.rb
+++ b/app/services/core_data_connector/import/people.rb
@@ -51,6 +51,7 @@ module CoreDataConnector
             biography, 
             user_defined,
             import_id,
+            published,
             created_at, 
             updated_at
           )
@@ -60,6 +61,7 @@ module CoreDataConnector
                  z_people.biography, 
                  z_people.user_defined,
                  z_people.import_id,
+                 #{default_to_published('z_people')},
                  current_timestamp, 
                  current_timestamp
             FROM #{table_name} z_people

--- a/app/services/core_data_connector/import/places.rb
+++ b/app/services/core_data_connector/import/places.rb
@@ -77,6 +77,7 @@ module CoreDataConnector
             z_place_id, 
             user_defined,
             import_id,
+            published,
             created_at,
             updated_at
           )
@@ -85,6 +86,7 @@ module CoreDataConnector
                  z_places.id,
                  z_places.user_defined,
                  z_places.import_id,
+                 #{default_to_published('z_places')},
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_places

--- a/app/services/core_data_connector/import/taxonomies.rb
+++ b/app/services/core_data_connector/import/taxonomies.rb
@@ -49,6 +49,7 @@ module CoreDataConnector
             name,
             user_defined,
             import_id,
+            published,
             created_at, 
             updated_at
           )
@@ -58,6 +59,7 @@ module CoreDataConnector
                  z_taxonomies.name,
                  z_taxonomies.user_defined,
                  z_taxonomies.import_id,
+                 #{default_to_published('z_taxonomies')},
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_taxonomies

--- a/app/services/core_data_connector/import/works.rb
+++ b/app/services/core_data_connector/import/works.rb
@@ -52,6 +52,7 @@ module CoreDataConnector
             z_work_id,
             user_defined,
             import_id,
+            published,
             created_at,
             updated_at
           )
@@ -60,6 +61,7 @@ module CoreDataConnector
                  z_works.id,
                  z_works.user_defined,
                  z_works.import_id,
+                 #{default_to_published('z_works')},
                  current_timestamp,
                  current_timestamp
             FROM #{table_name} z_works

--- a/app/services/core_data_connector/search/base.rb
+++ b/app/services/core_data_connector/search/base.rb
@@ -186,6 +186,9 @@ module CoreDataConnector
           # Base query
           query = all_records_by_project_model(project_model_ids)
 
+          # Unpublished records are not indexed
+          query = query.published if ancestors.include?(Publishable)
+
           # Concrete class query
           query = search_query(query) if self.respond_to?(:search_query)
 
@@ -216,94 +219,130 @@ module CoreDataConnector
 
         # Primary relationships
         has_many :event_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Event.to_s })
+          joins(:related_event)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Event.to_s })
+            .where(CoreDataConnector::Event.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :instance_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Instance.to_s })
+          joins(:related_instance)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Instance.to_s })
+            .where(CoreDataConnector::Instance.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :item_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Item.to_s })
+          joins(:related_item)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Item.to_s })
+            .where(CoreDataConnector::Item.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :media_content_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::MediaContent.to_s })
+          joins(:related_media_content)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::MediaContent.to_s })
+            .where(CoreDataConnector::MediaContent.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :organization_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Organization.to_s })
+          joins(:related_organization)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Organization.to_s })
+            .where(CoreDataConnector::Organization.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :person_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Person.to_s })
+          joins(:related_person)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Person.to_s })
+            .where(CoreDataConnector::Person.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :place_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Place.to_s })
+          joins(:related_place)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Place.to_s })
+            .where(CoreDataConnector::Place.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :taxonomy_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Taxonomy.to_s })
+          joins(:related_taxonomy)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Taxonomy.to_s })
+            .where(CoreDataConnector::Taxonomy.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         has_many :work_relationships, -> {
-          where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Work.to_s })
+          joins(:related_work)
+            .where(Relationship.arel_table.name => { related_record_type: CoreDataConnector::Work.to_s })
+            .where(CoreDataConnector::Work.arel_table[:published].eq(true))
         }, as: :primary_record, class_name: Relationship.to_s
 
         # Related relationships
         has_many :event_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_event)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Event.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Event.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :instance_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_instance)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Instance.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Instance.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :item_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_item)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Item.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Item.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :media_content_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_media_content)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::MediaContent.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::MediaContent.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :organization_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_organization)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Organization.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Organization.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :person_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_person)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Person.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Person.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :place_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_place)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Place.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Place.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :taxonomy_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_taxonomy)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Taxonomy.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Taxonomy.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         has_many :work_related_relationships, -> {
           joins(:project_model_relationship)
+            .joins(:inverse_related_work)
             .where(Relationship.arel_table.name => { primary_record_type: CoreDataConnector::Work.to_s })
             .where(ProjectModelRelationship.arel_table.name => { allow_inverse: true })
+            .where(CoreDataConnector::Work.arel_table[:published].eq(true))
         }, as: :related_record, class_name: Relationship.to_s
 
         # Include the ID attributes as a string by default

--- a/client/src/components/ItemPage.js
+++ b/client/src/components/ItemPage.js
@@ -25,6 +25,7 @@ import ItemLayoutContext from '../context/ItemLayout';
 import initialize from '../hooks/Item';
 import ProjectContext from '../context/Project';
 import ProjectItemMenu from './ProjectItemMenu';
+import PublishButton from './PublishButton';
 import RelatedIdentifiers from './RelatedIdentifiers';
 import RelatedRecordMerges from './RelatedRecordMerges';
 import Relationships from './Relationships';
@@ -32,6 +33,7 @@ import SaveButton from './SaveButton';
 import Section from './Section';
 import styles from './ItemPage.module.css';
 import useReactRouterEditPage from '../hooks/useReactRouterEditPage';
+import usePermissions from '../hooks/Permissions';
 import Validation from '../utils/Validation';
 import RecordVersions from './RecordVersions';
 
@@ -40,6 +42,7 @@ type Props = {
   loading: boolean,
   onInitialize: (id: number) => Promise<any>,
   onLoadVersions: (id: number, params: any) => Promise<any>,
+  onPublish: (id: number, published: boolean) => Promise<any>,
   onSave: (item: any) => Promise<any>,
   saving?: boolean
 };
@@ -51,16 +54,21 @@ type ComponentProps = {
   loading: boolean,
   onCreateManifests: (item: any) => Promise<any>,
   onLoadVersions: (id: number, params: any) => Promise<any>,
+  onPublish: (id: number, published: boolean) => Promise<any>,
   onSave: (item: any) => Promise<any>,
   onSaved: (item: any) => void,
+  onSetState: (props: any) => void,
   saved?: boolean,
   saving?: boolean
 };
 
 const Component = (props: ComponentProps) => {
+  const [publishError, setPublishError] = useState(null);
   const [saved, setSaved] = useState(false);
+
   const { label, name, url } = initialize(props);
   const { projectModel } = useContext(ProjectContext);
+  const { canPublishRecord } = usePermissions();
   const { t } = useTranslation();
 
   /**
@@ -78,6 +86,24 @@ const Component = (props: ComponentProps) => {
   const itemValue = useMemo(() => ({ uuid: props.item.uuid }), [props.item?.uuid]);
 
   /**
+   * Returns true if the current user can publish and unpublish the current record.
+   *
+   * @type {boolean}
+   */
+  const canPublish = useMemo(() => (
+    canPublishRecord(projectModel, props.item)
+  ), [canPublishRecord, projectModel, props.item]);
+
+  /**
+   * Memo-izes the list of errors to display, including any error encountered publishing the record.
+   *
+   * @type {Array<string>}
+   */
+  const errors = useMemo(() => (
+    _.compact([...(props.errors || []), publishError])
+  ), [props.errors, publishError]);
+
+  /**
    * Loads the versions for the current item.
    *
    * @type {function(*): Promise<any>}
@@ -85,6 +111,21 @@ const Component = (props: ComponentProps) => {
   const onLoadVersions = useCallback((params) => (
     props.onLoadVersions(props.item.id, params)
   ), [props.item?.id, props.onLoadVersions]);
+
+  /**
+   * Sets the published state of the current item.
+   *
+   * @type {function(boolean): Promise<any>}
+   */
+  const onPublish = useCallback((published) => (
+    props
+      .onPublish(props.item.id, published)
+      .then(() => {
+        setPublishError(null);
+        props.onSetState({ published });
+      })
+      .catch(() => setPublishError(t('PublishButton.errors.publish')))
+  ), [props.item?.id, props.onPublish, props.onSetState, t]);
 
   /**
    * Sets the saved prop on the state when the component is mounted.
@@ -120,13 +161,13 @@ const Component = (props: ComponentProps) => {
           <ItemLayout.Toaster
             timeout={0}
             type={Toaster.MessageTypes.negative}
-            visible={!_.isEmpty(props.errors)}
+            visible={!_.isEmpty(errors)}
           >
             <Message.Header
               content={t('Common.errors.header')}
             />
             <Message.List
-              items={props.errors}
+              items={errors}
             />
           </ItemLayout.Toaster>
           <ItemLayout.Header>
@@ -137,6 +178,16 @@ const Component = (props: ComponentProps) => {
               }}
               name={name}
             />
+            { canPublish && (
+              <div
+                className={styles.publishContainer}
+              >
+                <PublishButton
+                  onPublish={onPublish}
+                  published={!!props.item.published}
+                />
+              </div>
+            )}
           </ItemLayout.Header>
           <ItemLayout.Sidebar>
             <ProjectItemMenu />

--- a/client/src/components/ItemPage.js
+++ b/client/src/components/ItemPage.js
@@ -178,16 +178,6 @@ const Component = (props: ComponentProps) => {
               }}
               name={name}
             />
-            { canPublish && (
-              <div
-                className={styles.publishContainer}
-              >
-                <PublishButton
-                  onPublish={onPublish}
-                  published={!!props.item.published}
-                />
-              </div>
-            )}
           </ItemLayout.Header>
           <ItemLayout.Sidebar>
             <ProjectItemMenu />
@@ -202,10 +192,24 @@ const Component = (props: ComponentProps) => {
             <Section
               id='details'
             >
-              <SaveButton
-                onClick={props.onSave}
-                saving={props.saving}
-              />
+              <div
+                className={styles.actions}
+              >
+                <div
+                  className={styles.saveContainer}
+                >
+                  <SaveButton
+                    onClick={props.onSave}
+                    saving={props.saving}
+                  />
+                </div>
+                { canPublish && (
+                  <PublishButton
+                    onPublish={onPublish}
+                    published={!!props.item.published}
+                  />
+                )}
+              </div>
               <Header
                 className={cx(styles.ui, styles.header)}
                 content={t('ItemPage.labels.details')}

--- a/client/src/components/ItemPage.module.css
+++ b/client/src/components/ItemPage.module.css
@@ -2,8 +2,12 @@
   padding-bottom: 1em;
 }
 
-.itemPage .publishContainer {
+.itemPage .actions {
+  align-items: center;
   display: flex;
-  justify-content: flex-end;
-  padding-bottom: 1em;
+  gap: 1em;
+}
+
+.itemPage .actions > .saveContainer {
+  flex: 1;
 }

--- a/client/src/components/ItemPage.module.css
+++ b/client/src/components/ItemPage.module.css
@@ -1,3 +1,9 @@
 .itemPage .ui.header {
   padding-bottom: 1em;
 }
+
+.itemPage .publishContainer {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 1em;
+}

--- a/client/src/components/PublishButton.js
+++ b/client/src/components/PublishButton.js
@@ -1,0 +1,51 @@
+// @flow
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from 'semantic-ui-react';
+
+type Props = {
+  onPublish: (published: boolean) => Promise<any>,
+  published: boolean
+};
+
+const COLOR_GREEN = 'green';
+const COLOR_GREY = 'grey';
+
+const ICON_PRIVATE = 'eye slash';
+const ICON_PUBLIC = 'eye';
+
+const PublishButton = (props: Props) => {
+  const [publishing, setPublishing] = useState(false);
+
+  const { t } = useTranslation();
+
+  const color = useMemo(() => (props.published ? COLOR_GREEN : COLOR_GREY), [props.published]);
+
+  const content = useMemo(() => (
+    props.published ? t('PublishButton.buttons.public') : t('PublishButton.buttons.private')
+  ), [props.published]);
+
+  const icon = useMemo(() => (props.published ? ICON_PUBLIC : ICON_PRIVATE), [props.published]);
+
+  const onClick = useCallback(() => {
+    setPublishing(true);
+
+    props
+      .onPublish(!props.published)
+      .finally(() => setPublishing(false));
+  }, [props.onPublish, props.published]);
+
+  return (
+    <Button
+      color={color}
+      content={content}
+      disabled={publishing}
+      icon={icon}
+      loading={publishing}
+      onClick={onClick}
+    />
+  );
+};
+
+export default PublishButton;

--- a/client/src/hooks/Permissions.js
+++ b/client/src/hooks/Permissions.js
@@ -265,6 +265,30 @@ const usePermissions = () => {
   };
 
   /**
+   * An admin user or a project owner can publish or unpublish a record, as long as the project is not archived and
+   * the record is owned by the passed project model.
+   *
+   * @param projectModel
+   * @param record
+   *
+   * @returns {boolean}
+   */
+  const canPublishRecord = (projectModel: ProjectModelType, record: OwnableType): boolean => {
+    if (!(projectModel && record?.id)) {
+      return false;
+    }
+
+    /**
+     * If the current record is shared by another model, it can only be published by the project that owns it.
+     */
+    if (projectModel.id !== record.project_model_id) {
+      return false;
+    }
+
+    return isAdmin() || (isOwner(projectModel.project_id) && !isArchived(projectModel.project_id));
+  };
+
+  /**
    * Whether the configured authentication provider is local.
    * @returns {boolean}
    */
@@ -290,6 +314,7 @@ const usePermissions = () => {
     canExportData,
     canImportData,
     canInviteUserProject,
+    canPublishRecord,
     canResetPassword,
     getUserProject,
     getUserProjects,

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -684,6 +684,10 @@
         "content": "Do you really want to delete this project? This action cannot be undone.",
         "header": "Are you sure?"
       },
+      "publish": {
+        "content": "Set new records in this project to \"Public\" when they are created. You can always adjust the publication state of an individual record.",
+        "header": "Default Publication State"
+      },
       "share": {
         "content": "Allow other projects to discover this project and share data",
         "header": "Project Discovery"

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -868,6 +868,15 @@
       "updated": "Last modified"
     }
   },
+  "PublishButton": {
+    "buttons": {
+      "private": "Private",
+      "public": "Public"
+    },
+    "errors": {
+      "publish": "An error occurred updating the published state of this record."
+    }
+  },
   "RecordVersionModal": {
     "columns": {
       "field": "Field",

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -118,7 +118,8 @@
       "name": "Name",
       "start_date": "Start date",
       "end_date": "End date",
-      "primary": "Primary"
+      "primary": "Primary",
+      "published": "Published"
     },
     "labels": {
       "all": "All {{name}}",

--- a/client/src/pages/Event.js
+++ b/client/src/pages/Event.js
@@ -21,6 +21,10 @@ const Person = () => (
       EventsService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      EventsService
+        .publish(id, published)
+    )}
     onSave={(event) => (
       EventsService
         .save(event)

--- a/client/src/pages/Instance.js
+++ b/client/src/pages/Instance.js
@@ -21,6 +21,10 @@ const Instance = () => (
       InstancesService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      InstancesService
+        .publish(id, published)
+    )}
     onSave={(instance) => (
       InstancesService
         .save(instance)

--- a/client/src/pages/Item.js
+++ b/client/src/pages/Item.js
@@ -21,6 +21,10 @@ const Item = () => (
       ItemsService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      ItemsService
+        .publish(id, published)
+    )}
     onSave={(item) => (
       ItemsService
         .save(item)

--- a/client/src/pages/MediaContent.js
+++ b/client/src/pages/MediaContent.js
@@ -25,6 +25,10 @@ const MediaContent = () => {
         MediaContentsService
           .getVersions(id, params)
       )}
+      onPublish={(id, published) => (
+        MediaContentsService
+          .publish(id, published)
+      )}
       onSave={(mediaContent) => (
         MediaContentsService
           .uploadOne(mediaContent, project)

--- a/client/src/pages/Organization.js
+++ b/client/src/pages/Organization.js
@@ -21,6 +21,10 @@ const Organization = () => (
       OrganizationService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      OrganizationService
+        .publish(id, published)
+    )}
     onSave={(organization) => (
       OrganizationService
         .save(organization)

--- a/client/src/pages/Person.js
+++ b/client/src/pages/Person.js
@@ -21,6 +21,10 @@ const Person = () => (
       PeopleService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      PeopleService
+        .publish(id, published)
+    )}
     onSave={(person) => (
       PeopleService
         .save(person)

--- a/client/src/pages/Place.js
+++ b/client/src/pages/Place.js
@@ -21,6 +21,10 @@ const Place = () => (
       PlacesService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      PlacesService
+        .publish(id, published)
+    )}
     onSave={(place) => (
       PlacesService
         .save(place)

--- a/client/src/pages/Project.js
+++ b/client/src/pages/Project.js
@@ -3,9 +3,9 @@
 import { AssociatedDropdown, SimpleEditPage, Toaster } from '@performant-software/semantic-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import cx from 'classnames';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IoSearchOutline } from 'react-icons/io5';
+import { IoEyeOutline, IoSearchOutline } from 'react-icons/io5';
 import { useNavigate } from 'react-router';
 import {
   Button,
@@ -66,6 +66,13 @@ const Project = (props: Props) => {
   });
 
   const { item } = editPageProps;
+
+  /**
+   * New records are published by default, so a project that has not set the value renders as checked.
+   *
+   * @type {boolean}
+   */
+  const defaultToPublished = useMemo(() => item.default_to_published !== false, [item.default_to_published]);
 
   /**
    * Clears all of the data from the current project.
@@ -247,6 +254,34 @@ const Project = (props: Props) => {
                   label={t('Project.messages.share.content')}
                   error={editPageProps.isError('discoverable')}
                   onChange={editPageProps.onCheckboxInputChange.bind(this, 'discoverable')}
+                />
+              </Message.Content>
+            </Message>
+          </div>
+          <div
+            className={styles.section}
+          >
+            <Message
+              className={cx(styles.ui, styles.message)}
+              color='green'
+              icon
+            >
+              <Icon>
+                <IoEyeOutline />
+              </Icon>
+              <Message.Content
+                className={styles.content}
+              >
+                <Message.Header
+                  className={styles.header}
+                  content={t('Project.messages.publish.header')}
+                />
+                <Form.Checkbox
+                  checked={defaultToPublished}
+                  className={styles.field}
+                  label={t('Project.messages.publish.content')}
+                  error={editPageProps.isError('default_to_published')}
+                  onChange={editPageProps.onCheckboxInputChange.bind(this, 'default_to_published')}
                 />
               </Message.Content>
             </Message>

--- a/client/src/pages/TaxonomyItem.js
+++ b/client/src/pages/TaxonomyItem.js
@@ -21,6 +21,10 @@ const TaxonomyItem = () => (
       TaxonomiesService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      TaxonomiesService
+        .publish(id, published)
+    )}
     onSave={(taxonomyItem) => (
       TaxonomiesService
         .save(taxonomyItem)

--- a/client/src/pages/Work.js
+++ b/client/src/pages/Work.js
@@ -21,6 +21,10 @@ const Work = () => (
       WorksService
         .getVersions(id, params)
     )}
+    onPublish={(id, published) => (
+      WorksService
+        .publish(id, published)
+    )}
     onSave={(work) => (
       WorksService
         .save(work)

--- a/client/src/services/Base.js
+++ b/client/src/services/Base.js
@@ -50,6 +50,18 @@ class BaseService extends APIBase {
 
     return this.getAxios().post(`${this.getBaseUrl()}/merge`, payload, this.getConfig());
   }
+
+  /**
+   * Calls the /core_data/<model>/<id>/publish API endpoint.
+   *
+   * @param id
+   * @param published
+   *
+   * @returns {*}
+   */
+  publish(id, published) {
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/publish`, { published }, this.getConfig());
+  }
 }
 
 export default BaseService;

--- a/client/src/transforms/Project.js
+++ b/client/src/transforms/Project.js
@@ -26,6 +26,7 @@ class Project extends BaseTransform {
     return [
       'name',
       'description',
+      'default_to_published',
       'discoverable',
       'faircopy_cloud_url',
       'faircopy_cloud_project_id',

--- a/client/src/types/Project.js
+++ b/client/src/types/Project.js
@@ -4,6 +4,7 @@ export type Project = {
   id: number,
   name: string,
   description: string,
+  default_to_published: boolean,
   discoverable: boolean,
   faircopy_cloud_url: string,
   faircopy_cloud_project_id: number,

--- a/config/locales/core_data_connector.en.yml
+++ b/config/locales/core_data_connector.en.yml
@@ -9,6 +9,7 @@ en:
       create?: "You do not have permission to create an event."
       delete?: "You do not have permission to delete this event."
       import?: "You do not have permission to import data into this event."
+      publish?: "You do not have permission to publish this event."
       show?: "You do not have permission to view this event."
       update?: "You do not have permission to update this event."
 
@@ -16,6 +17,7 @@ en:
       create?: "You do not have permission to create an instance."
       delete?: "You do not have permission to delete this instance."
       import?: "You do not have permission to import data into this instance."
+      publish?: "You do not have permission to publish this instance."
       show?: "You do not have permission to view this instance."
       update?: "You do not have permission to update this instance."
 
@@ -23,6 +25,7 @@ en:
       create?: "You do not have permission to create an item."
       delete?: "You do not have permission to delete this item."
       import?: "You do not have permission to import data into this item."
+      publish?: "You do not have permission to publish this item."
       show?: "You do not have permission to view this item."
       update?: "You do not have permission to update this item."
 
@@ -30,6 +33,7 @@ en:
       create?: "You do not have permission to create a media_content."
       delete?: "You do not have permission to delete this media_content."
       import?: "You do not have permission to import data into this media_content."
+      publish?: "You do not have permission to publish this media_content."
       show?: "You do not have permission to view this media_content."
       update?: "You do not have permission to update this media_content."
 
@@ -37,6 +41,7 @@ en:
       create?: "You do not have permission to create an organization."
       delete?: "You do not have permission to delete this organization."
       import?: "You do not have permission to import data into this organization."
+      publish?: "You do not have permission to publish this organization."
       show?: "You do not have permission to view this organization."
       update?: "You do not have permission to update this organization."
 
@@ -44,6 +49,7 @@ en:
       create?: "You do not have permission to create a person."
       delete?: "You do not have permission to delete this person."
       import?: "You do not have permission to import data into this person."
+      publish?: "You do not have permission to publish this person."
       show?: "You do not have permission to view this person."
       update?: "You do not have permission to update this person."
 
@@ -51,6 +57,7 @@ en:
       create?: "You do not have permission to create a place."
       delete?: "You do not have permission to delete this place."
       import?: "You do not have permission to import data into this place."
+      publish?: "You do not have permission to publish this place."
       show?: "You do not have permission to view this place."
       update?: "You do not have permission to update this place."
 
@@ -79,6 +86,7 @@ en:
       create?: "You do not have permission to create a taxonomy."
       delete?: "You do not have permission to delete this taxonomy."
       import?: "You do not have permission to import data into this taxonomy."
+      publish?: "You do not have permission to publish this taxonomy."
       show?: "You do not have permission to view this taxonomy."
       update?: "You do not have permission to update this taxonomy."
 
@@ -93,6 +101,7 @@ en:
       create?: "You do not have permission to create a work."
       delete?: "You do not have permission to delete this work."
       import?: "You do not have permission to import data into this work."
+      publish?: "You do not have permission to publish this work."
       show?: "You do not have permission to view this work."
       update?: "You do not have permission to update this work."
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -8,30 +8,34 @@ concern :mergeable do
   post :merge, on: :collection
 end
 
+concern :publishable do
+  post :publish, on: :member
+end
+
 concern :versionable do
   resources :versions, only: [:index]
 end
 
-resources :events, concerns: [:manifestable, :mergeable, :versionable]
+resources :events, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 
-resources :instances, concerns: [:manifestable, :mergeable, :versionable]
+resources :instances, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 
-resources :items, concerns: [:manifestable, :mergeable, :versionable] do
+resources :items, concerns: [:manifestable, :mergeable, :publishable, :versionable] do
   get :analyze_import, on: :member
   post :import, on: :member
 end
 
 resources :jobs, only: [:destroy, :index]
 
-resources :media_contents, concerns: [:manifestable, :mergeable, :versionable] do
+resources :media_contents, concerns: [:manifestable, :mergeable, :publishable, :versionable] do
   post :upload, on: :collection
 end
 
-resources :organizations, concerns: [:manifestable, :mergeable, :versionable]
+resources :organizations, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 
-resources :people, concerns: [:manifestable, :mergeable, :versionable]
+resources :people, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 
-resources :places, concerns: [:manifestable, :mergeable, :versionable]
+resources :places, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 
 resources :project_models do
   get :model_classes, on: :collection
@@ -57,7 +61,7 @@ resources :relationships do
   post :upload, on: :collection
 end
 
-resources :taxonomies, concerns: [:manifestable, :mergeable, :versionable]
+resources :taxonomies, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 
 resources :user_projects do
   post :invite, on: :member
@@ -75,5 +79,5 @@ end
 
 resources :web_identifiers
 
-resources :works, concerns: [:manifestable, :mergeable, :versionable]
+resources :works, concerns: [:manifestable, :mergeable, :publishable, :versionable]
 

--- a/db/migrate/20260811153532_add_published_to_publishable_records.rb
+++ b/db/migrate/20260811153532_add_published_to_publishable_records.rb
@@ -13,7 +13,7 @@ class AddPublishedToPublishableRecords < ActiveRecord::Migration[8.1]
 
   def change
     TABLES.each do |table|
-      add_column table, :published, :boolean, default: false, null: false
+      add_column table, :published, :boolean, default: true, null: false
     end
   end
 end

--- a/db/migrate/20260811153532_add_published_to_publishable_records.rb
+++ b/db/migrate/20260811153532_add_published_to_publishable_records.rb
@@ -1,0 +1,19 @@
+class AddPublishedToPublishableRecords < ActiveRecord::Migration[8.1]
+  TABLES = [
+    :core_data_connector_events,
+    :core_data_connector_instances,
+    :core_data_connector_items,
+    :core_data_connector_media_contents,
+    :core_data_connector_organizations,
+    :core_data_connector_people,
+    :core_data_connector_places,
+    :core_data_connector_taxonomies,
+    :core_data_connector_works
+  ]
+
+  def change
+    TABLES.each do |table|
+      add_column table, :published, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/migrate/20260812150000_add_default_to_published_to_projects.rb
+++ b/db/migrate/20260812150000_add_default_to_published_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDefaultToPublishedToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :core_data_connector_projects, :default_to_published, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -51,7 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.uuid "import_id"
     t.string "name"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -64,7 +64,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.string "faircopy_cloud_id"
     t.uuid "import_id"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -122,7 +122,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.boolean "import_url_processed", default: false, null: false
     t.string "name"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -145,7 +145,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.text "description"
     t.uuid "import_id"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -159,7 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -212,7 +212,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -272,6 +272,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
   create_table "core_data_connector_projects", force: :cascade do |t|
     t.boolean "archived", default: false, null: false
     t.datetime "created_at", null: false
+    t.boolean "default_to_published", default: true, null: false
     t.string "description"
     t.boolean "discoverable", default: false, null: false
     t.integer "faircopy_cloud_project_id"
@@ -330,7 +331,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.uuid "import_id"
     t.string "name"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -410,7 +411,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
-    t.boolean "published", default: false, null: false
+    t.boolean "published", default: true, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_153532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.uuid "import_id"
     t.string "name"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -63,6 +64,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -76,6 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.string "faircopy_cloud_id"
     t.uuid "import_id"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -119,6 +122,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.boolean "import_url_processed", default: false, null: false
     t.string "name"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -141,6 +145,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.text "description"
     t.uuid "import_id"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -154,6 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -206,6 +212,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -323,6 +330,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.uuid "import_id"
     t.string "name"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
@@ -402,6 +410,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_152829) do
     t.datetime "created_at", null: false
     t.uuid "import_id"
     t.bigint "project_model_id"
+    t.boolean "published", default: false, null: false
     t.datetime "updated_at", null: false
     t.jsonb "user_defined", default: {}
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false

--- a/lib/typesense/search.rb
+++ b/lib/typesense/search.rb
@@ -34,7 +34,8 @@ module Typesense
 
         klass.for_search(ids) do |records|
           documents = records.map { |r| r.to_search_json(options).merge(import_attributes) }
-          collection.documents.import(documents, action: 'emplace')
+
+          collection.documents.import(documents, action: 'upsert')
         end
       end
 


### PR DESCRIPTION
# Summary

This PR adds the ability to mark a record as public or private.

* adds a boolean `published` column to each of the main models
  * defaults to `true` so all existing records are uninterrupted
* adds a new `Publishable` concern to manage published state
* adds a new `default_to_published` boolean on the projects model, describing whether new records should be public or private by default
  * defaults to `true` so existing projects are uninterrupted
* updates public endpoints (both `v0` and `v1`) to only show published records
* updates the Typesense index service to only index published records
* updates the import service to honor the project's `default_to_published` value
* copied over the relevant parts of the `core-data-connector` readme (I realized I needed the Typesense info when testing that part of this PR)

## Notes

- In the Typesense `search.rb`, I replaced `emplace` with `upsert` in order to remove unpublished records from nested relationship fields on reindex. Apparently `emplace` will retain a field from the old version of the record if the field does not exist on the new version of the record, i.e. if a record's only related record gets unpublished, that relationship field will be empty on reindex and the old one will be retained. This change might have unanticipated side effects, either on performance or if we have anything that incidentally relies on the `emplace` behavior.
- `publish` is a separate endpoint, rather than being treated as a regular system field in `POST`/`PUT` requests, because it has different permissions from the standard edit permissions. I think it would be possible to check for admin/owner permissions in an edit payload but it would make the logic a bit complex and would require us to silently ignore the value if the permissions check resolves to false.
- I would prefer to remove the `v0` public endpoints but it seems pretty difficult to prove whether they're being used. The change here was pretty light anyway. Maybe Papertrail would be helpful in determining what, if anything, is connecting to them.

## Screenshots

### Public toggle on record
<img width="1069" height="499" alt="Screenshot 2026-08-12 at 5 09 12 PM" src="https://github.com/user-attachments/assets/8baa534f-f85f-4fa6-acd9-5a1a030f4cf5" />

### Default publication state checkbox on project form
<img width="952" height="105" alt="Screenshot 2026-08-12 at 5 15 27 PM" src="https://github.com/user-attachments/assets/1c969852-b8e3-427a-a2b6-afcd058b6319" />

## Testing notes

- [ ] on a fresh staging deploy, all records should be public and all projects should have the Default publication state box checked in their settings
- [ ] the public/private button should only be visible to global admins and project owners
- [ ] the structure/schema of the response from the `v0` public endpoint should be the same as prod
- [ ] after unpublishing a record, it should stop appearing in the `v0` public endpoints
- [ ] the structure/schema of the response from the `v1` public endpoint should be the same as prod
- [ ] after unpublishing a record, it should stop appearing in the `v1` public endpoints
- [ ] unpublished records should not appear as top-level records in Typesense
- [ ] unpublished records should not appear as *related* records (i.e. nested within a relationship UUID field) in Typesense
- [ ] unpublishing a record and then reindexing should remove it as per the previous two points
- [ ] publishing a private record and reindexing should make it appear in the index
- [ ] imports still work