### PR TITLE
Skip validations when setting published state

### DIFF
--- a/app/controllers/concerns/core_data_connector/publishable_controller.rb
+++ b/app/controllers/concerns/core_data_connector/publishable_controller.rb
@@ -7,7 +7,7 @@ module CoreDataConnector
         item = find_record(item_class)
         authorize item, :publish?
 
-        if item.update(published: published_param)
+        if item.update_published(published_param)
           item = prepare_item(item)
           preloads(item)
 

--- a/app/models/concerns/core_data_connector/publishable.rb
+++ b/app/models/concerns/core_data_connector/publishable.rb
@@ -17,12 +17,9 @@ module CoreDataConnector
       end
     end
 
-    def publish!
-      update!(published: true)
-    end
-
-    def unpublish!
-      update!(published: false)
+    def update_published(value)
+      self[:published] = value
+      save(validate: false)
     end
   end
 end


### PR DESCRIPTION
# Summary

This PR addresses #667, where record validations were erroneously running when the `publish` endpoint was called.